### PR TITLE
ci: upgrade actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         shell: bash
         run: test -z "$(gofmt -l .)"
 
-  cross-build:
+  build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -64,3 +64,19 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
         run: go build -o /tmp/mihari-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/mihari
+
+  # Fan-in gate: branch protection requires a status named "cross-build", but
+  # GitHub reports each matrix leg under its expanded name (build (linux,
+  # amd64)), so no run ever reports the bare name and the check stays
+  # "Expected - Waiting for status to be reported" forever. This job posts
+  # the exact "cross-build" status and fails when any leg failed.
+  cross-build:
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [build]
+    steps:
+      - name: Verify all matrix builds passed
+        run: |
+          for result in ${{ join(needs.build.result, ' ') }}; do
+            [ "$result" = "success" ] || { echo "build matrix result: $result"; exit 1; }
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-      - uses: golangci/golangci-lint-action@v7
+      - uses: golangci/golangci-lint-action@v9
         with:
           # Pin a v2 release: the v1 line is built with go1.24 and cannot load
           # configs targeting go1.26 (go.mod); action v6 does not support v2.
@@ -22,8 +22,8 @@ jobs:
   test:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - name: Test
@@ -54,8 +54,8 @@ jobs:
           - goos: darwin
             goarch: arm64
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - name: Build

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -15,7 +15,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,9 @@ jobs:
           - { goos: windows, goarch: amd64, ext: '.exe' }
           - { goos: windows, goarch: arm64, ext: '.exe' }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
 
@@ -44,7 +44,7 @@ jobs:
           ls -la dist/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mihari-${{ matrix.goos }}-${{ matrix.goarch }}
           path: dist/*
@@ -53,9 +53,10 @@ jobs:
     name: publish release
     needs: build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    # workflow_dispatch also publishes: RELEASE.md documents manual triggering.
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true
@@ -65,7 +66,7 @@ jobs:
         run: sha256sum * > SHA256SUMS.txt
 
       - name: Publish
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: dist/*
           generate_release_notes: true

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -74,7 +74,7 @@ func LoadOrCreate(path string) (Settings, error) {
 
 // LoadOrCreateResult loads settings or creates them and reports whether this call created the file.
 func LoadOrCreateResult(path string) (Settings, bool, error) {
-	settings, err := Load(path)
+	settings, err := loadSettings(path)
 	if err == nil {
 		return settings, false, nil
 	}
@@ -93,7 +93,7 @@ func LoadOrCreateResult(path string) (Settings, bool, error) {
 		_ = lock.Close()
 		_ = os.Remove(lockPath)
 	}()
-	settings, err = Load(path)
+	settings, err = loadSettings(path)
 	if err == nil {
 		return settings, false, nil
 	}
@@ -110,6 +110,25 @@ func LoadOrCreateResult(path string) (Settings, bool, error) {
 		return Settings{}, false, err
 	}
 	return settings, true, nil
+}
+
+// loadSettings loads settings, retrying while the file exists on disk but is
+// momentarily unopenable. A concurrent writer replaces it via MoveFileEx;
+// during that window Windows reports a sharing violation that is neither
+// os.ErrNotExist nor os.ErrPermission, so existence is the reliable retry
+// signal. Genuine errors (permissions, deletion) surface immediately.
+func loadSettings(path string) (Settings, error) {
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		settings, err := Load(path)
+		if err == nil || errors.Is(err, os.ErrNotExist) {
+			return settings, err
+		}
+		if _, statErr := os.Stat(path); statErr != nil || time.Now().After(deadline) {
+			return Settings{}, err
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 func acquireCreationLock(path string) (*os.File, error) {


### PR DESCRIPTION
## 变更内容

升级三个 workflow 中的 GitHub Actions 至基于 Node 24 的版本,消除 GitHub 2025-09-19 Node 20 弃用警告;修复 release 手动触发只构建不发布的问题;修复 Windows 上并发加载配置的 flaky 测试。

## 类型

- [x] fix: Bug 修复
- [x] chore: 构建/工具

## 检查清单

- [x] `go test -race ./...` 通过(本地 `-count=20` 验证,CI 验证中)
- [x] `go vet ./...` 通过
- [x] `gofmt -l cmd internal` 无输出(无格式化变更)
- [x] 提交包含 `Signed-off-by`(DCO 签名)
- [x] 未修改 `internal/control/protocol` 契约、CLI 输出/退出码

## 相关 Issues

Closes #3

## 变更详情

### 1. Actions 升级(Node 24 运行时)

| action | 旧 | 新 | 理由 |
|---|---|---|---|
| `actions/checkout` | v4 | v7 | Node 24 运行时(ESM 迁移,无配置破坏) |
| `actions/setup-go` | v5 | v7 | Node 24 运行时,缓存 key 更新(顺带解决 tar 缓存恢复失败) |
| `golangci/golangci-lint-action` | v7 | v9 | Node 24 运行时,`version: v2.12.2` 配置兼容 |
| `actions/upload-artifact` | v4 | v7 | Node 24 运行时,与 download-artifact 配套 |
| `actions/download-artifact` | v4 | v8 | Node 24 运行时,支持 v7 上传的 artifact |
| `softprops/action-gh-release` | v2 | v3 | Node 24 运行时,API 兼容 |

### 2. release 手动触发修复

`release.yml` 的 publish job 条件由仅 tag 扩展为 **tag 或 workflow_dispatch**,使手动触发(RELEASE.md 已文档化)也能完整构建并发布,而非只构建不发布。

### 3. Windows 并发加载 flaky 修复

PR 的 CI 在 windows-latest 上暴露 `TestConcurrentLoadOrCreateUsesOneControllerSecret` 偶发失败:`open mihari.yaml: The process cannot access the file because it is being used by another process`。

根因:赢家在 `AtomicWrite` 中通过 `MoveFileEx` 原子替换配置文件时,恰好有 goroutine 打开该文件,Windows 返回共享违规(既不是 `ErrNotExist` 也不是 `ErrPermission`),被 `LoadOrCreateResult` 当成真实错误。

修复:`loadSettings` helper 以"文件存在"为可靠信号短暂重试(与 `acquireCreationLock` 已有的 existence-based 兜底一致),真实错误(权限、删除)立即返回。本地 `-race -count=20` 通过。