### PR TITLE
docs: add CHANGELOG, move release process to docs/

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
     name: publish release
     needs: build
     runs-on: ubuntu-latest
-    # workflow_dispatch also publishes: RELEASE.md documents manual triggering.
+    # workflow_dispatch also publishes: docs/RELEASE.md documents manual triggering.
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/download-artifact@v8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+本文件记录 Mihari 每个版本的变更。版本遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
+
+## [v0.1.1] - 2026-08-06
+
+### Fixed
+
+- 修复 Windows 上并发首次加载配置时,文件原子替换窗口内的共享违规被误报为错误(`loadSettings` 以文件存在为信号重试,与锁文件兜底逻辑一致)
+- 修复 GitHub Actions 的 Node 20 弃用警告:升级 `actions/checkout` v7、`actions/setup-go` v7、`golangci-lint-action` v9、`actions/upload-artifact` v7、`actions/download-artifact` v8、`softprops/action-gh-release` v3
+- 修复分支保护 required check `cross-build` 因矩阵展开命名而永远 "Waiting for status" 的问题:新增 fan-in gate job 精确报告该状态
+- 修复 `release` 工作流手动触发(workflow_dispatch)只构建不发布的问题
+
+### Docs
+
+- 新增 CHANGELOG.md,发布流程移至 docs/RELEASE.md
+- README 标题品牌名统一为大写 Mihari
+
+## [v0.1.0] - 2026-08-06
+
+**初始开源发布**
+
+- 本地守护 daemon：Windows named pipe / Unix domain socket 控制平面，不绑 TCP
+- 系统服务支持（Windows Service / systemd / launchd，kardianos/service），不自动提权
+- mihomo 内核安装 / 更新 / 重启 / 健康检查 / 崩溃退避重启
+- 订阅管理：profile 模型、独立缓存、离线切换、定时刷新、原子配置生成与回滚
+- 交互式 TUI：Setup、Overview、Proxies、Connections（本地 GeoIP）、Rules/Providers、Logs、订阅管理、System、Web GUI
+- 浏览器面板：zashboard / MetaCubeXD 安装、更新、激活、回滚、打开；loopback Web gateway + 独立访问凭证
+- 系统代理管理（Windows 注册表 / GNOME / networksetup）与 TUN 持久化
+- GeoIP 本地解析（MMDB 下载、校验、30 天刷新）
+- CLI 全命令 `--json` 输出与稳定退出码
+- 自更新（GitHub Releases）+ 6 平台无 CGO 预编译发布

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,7 +225,7 @@ git config user.email "you@example.com"
 
 ## 发布流程（仅维护者）
 
-参见 [RELEASE.md](RELEASE.md)。
+参见 [docs/RELEASE.md](docs/RELEASE.md)。
 
 ## 问题反馈
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Build a local binary:
 CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o mihari ./cmd/mihari
 ```
 
-The architecture invariants, package boundaries, and contribution guidance are recorded in [AGENTS.md](AGENTS.md) and [CONTRIBUTING.md](CONTRIBUTING.md). See [RELEASE.md](RELEASE.md) for the release process.
+The architecture invariants, package boundaries, and contribution guidance are recorded in [AGENTS.md](AGENTS.md) and [CONTRIBUTING.md](CONTRIBUTING.md). See [docs/RELEASE.md](docs/RELEASE.md) for the release process.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mihari
+# Mihari
 
 [English](README.md) · [简体中文](README.zh-CN.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -114,7 +114,7 @@ go vet ./...
 CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o mihari ./cmd/mihari
 ```
 
-架构不变量、包边界与贡献指南见 [AGENTS.md](AGENTS.md) 与 [CONTRIBUTING.md](CONTRIBUTING.md),发布流程见 [RELEASE.md](RELEASE.md)。
+架构不变量、包边界与贡献指南见 [AGENTS.md](AGENTS.md) 与 [CONTRIBUTING.md](CONTRIBUTING.md),发布流程见 [docs/RELEASE.md](docs/RELEASE.md)。
 
 ## 许可
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,4 @@
-# mihari
+# Mihari
 
 [English](README.md) · [简体中文](README.zh-CN.md)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -106,6 +106,16 @@ git tag -d v0.1.0
 
 ## 更新日志
 
+### v0.1.1 (2026-08-06)
+
+**Bug 修复**
+
+- 修复 Windows 上并发首次加载配置时,文件原子替换窗口内的共享违规被误报为错误(`loadSettings` 以文件存在为信号重试,与锁文件兜底逻辑一致)
+- 修复 GitHub Actions 的 Node 20 弃用警告:升级 `actions/checkout` v7、`actions/setup-go` v7、`golangci-lint-action` v9、`actions/upload-artifact` v7、`actions/download-artifact` v8、`softprops/action-gh-release` v3
+- 修复分支保护 required check `cross-build` 因矩阵展开命名而永远 "Waiting for status" 的问题:新增 fan-in gate job 精确报告该状态
+- 修复 `release` 工作流手动触发(workflow_dispatch)只构建不发布的问题
+- 文档:README 标题品牌名统一为大写 Mihari
+
 ### v0.1.0 (2026-08-06)
 
 **初始开源发布**

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -104,35 +104,6 @@ git tag -d v0.1.0
 # 删除 GitHub Release（需在网页操作）
 ```
 
-## 更新日志
-
-### v0.1.1 (2026-08-06)
-
-**Bug 修复**
-
-- 修复 Windows 上并发首次加载配置时,文件原子替换窗口内的共享违规被误报为错误(`loadSettings` 以文件存在为信号重试,与锁文件兜底逻辑一致)
-- 修复 GitHub Actions 的 Node 20 弃用警告:升级 `actions/checkout` v7、`actions/setup-go` v7、`golangci-lint-action` v9、`actions/upload-artifact` v7、`actions/download-artifact` v8、`softprops/action-gh-release` v3
-- 修复分支保护 required check `cross-build` 因矩阵展开命名而永远 "Waiting for status" 的问题:新增 fan-in gate job 精确报告该状态
-- 修复 `release` 工作流手动触发(workflow_dispatch)只构建不发布的问题
-- 文档:README 标题品牌名统一为大写 Mihari
-
-### v0.1.0 (2026-08-06)
-
-**初始开源发布**
-
-- 本地守护 daemon：Windows named pipe / Unix domain socket 控制平面，不绑 TCP
-- 系统服务支持（Windows Service / systemd / launchd，kardianos/service），不自动提权
-- mihomo 内核安装 / 更新 / 重启 / 健康检查 / 崩溃退避重启
-- 订阅管理：profile 模型、独立缓存、离线切换、定时刷新、原子配置生成与回滚
-- 交互式 TUI：Setup、Overview、Proxies、Connections（本地 GeoIP）、Rules/Providers、Logs、订阅管理、System、Web GUI
-- 浏览器面板：zashboard / MetaCubeXD 安装、更新、激活、回滚、打开；loopback Web gateway + 独立访问凭证
-- 系统代理管理（Windows 注册表 / GNOME / networksetup）与 TUN 持久化
-- GeoIP 本地解析（MMDB 下载、校验、30 天刷新）
-- CLI 全命令 `--json` 输出与稳定退出码
-- 自更新（GitHub Releases）+ 6 平台无 CGO 预编译发布
-
----
-
 ## CI/CD 检查项
 
 每次发布前确保：
@@ -140,5 +111,5 @@ git tag -d v0.1.0
 - [ ] 所有测试通过 (`go test -race ./...`)
 - [ ] 代码格式正确 (`gofmt -l cmd internal`)
 - [ ] 静态分析通过 (`go vet ./...`)
-- [ ] 变更日志已更新
-- [ ] 标签版本号与变更日志一致
+- [ ] [CHANGELOG.md](../CHANGELOG.md) 已更新
+- [ ] 标签版本号与 CHANGELOG.md 一致


### PR DESCRIPTION
## 变更内容

文档结构重构:

1. **新增 `CHANGELOG.md`**:版本变更日志从 RELEASE.md 移出,独立成文件(含 v0.1.0 / v0.1.1)
2. **`RELEASE.md` 移至 `docs/RELEASE.md`**:只保留发版流程说明,移除更新日志章节;检查项中"变更日志已更新"指向 CHANGELOG.md
3. **README 标题**(中英)品牌名统一为大写 `# Mihari`
4. 更新 `CONTRIBUTING.md`、`README.md`、`README.zh-CN.md` 中指向 `docs/RELEASE.md` 的链接

## 类型

- [x] docs: 文档

## 检查清单

- [x] 无 Go 代码变更(test/vet/gofmt 不受影响)
- [x] 提交包含 `Signed-off-by`(DCO 签名)

## 相关 Issues

无