### PR TITLE
feat: all-in-one distribution + AList 国内分发

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,21 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version, e.g. v0.3.0 (must match ^v[0-9]+\.[0-9]+\.[0-9]+$; enforced by the version gate)'
+        required: true
+        type: string
 
 permissions:
   contents: write
+
+env:
+  # Single source of truth for the version: explicit input on dispatch, else the
+  # pushed tag. workflow_dispatch on a branch would otherwise inject the branch
+  # name via GITHUB_REF_NAME (design §4.2 — fixes the binary-version bug).
+  VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
+  PLATFORMS: linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64
 
 jobs:
   build:
@@ -30,6 +42,14 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Version gate
+        # Layer ② (design §4.2): reject pre-release suffixes / non-semver at every
+        # entry point. The dispatch input is UI-gated upstream; this also covers
+        # tag pushes and any API-direct triggering.
+        run: |
+          echo "${VERSION}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            || { echo "::error::version '${VERSION}' must match ^v[0-9]+\.[0-9]+\.[0-9]+$ (no pre-release suffix)"; exit 1; }
+
       - name: Build
         env:
           CGO_ENABLED: '0'
@@ -40,7 +60,7 @@ jobs:
           # internal/update SelectSelfAsset and the install scripts rely on the
           # fixed prefix, and it keeps the /releases/latest/download/ URL stable.
           OUT="mihari-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}"
-          go build -trimpath -ldflags "-s -w -X github.com/mihari-proxy/mihari/internal/buildinfo.Version=${GITHUB_REF_NAME}" -o "dist/${OUT}" ./cmd/mihari
+          go build -trimpath -ldflags "-s -w -X github.com/mihari-proxy/mihari/internal/buildinfo.Version=${VERSION}" -o "dist/${OUT}" ./cmd/mihari
           ls -la dist/
 
       - name: Upload artifact
@@ -49,24 +69,129 @@ jobs:
           name: mihari-${{ matrix.goos }}-${{ matrix.goarch }}
           path: dist/*
 
+  bundle:
+    name: bundle all-in-one
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - name: Download binary artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Build all-in-one bundles
+        # One mihomo release fetch + shared GeoIP download, then 6 platform packs
+        # (design §4.1). GITHUB_TOKEN raises the unauthenticated API rate ceiling.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          go run ./scripts/build-all-in-one \
+            --mihari-dir dist --out bundles --platforms "${PLATFORMS}"
+          ls -la bundles/
+
+      - name: Upload bundle artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: aio-bundles
+          path: bundles/*
+
   release:
     name: publish release
-    needs: build
-    runs-on: ubuntu-latest
-    # workflow_dispatch also publishes: docs/RELEASE.md documents manual triggering.
+    needs: [build, bundle]
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    env:
+      # Mapped at job scope so the AList steps' `if: env.ALIST_URL != ''` can see
+      # them (step `if` cannot read step-level env, and secrets are unreadable in
+      # `if`). Empty when unconfigured → AList steps skip, never blocking GitHub.
+      ALIST_URL: ${{ secrets.ALIST_URL }}
+      ALIST_USERNAME: ${{ secrets.ALIST_USERNAME }}
+      ALIST_PASSWORD: ${{ secrets.ALIST_PASSWORD }}
+      ALIST_BASE_PATH: ${{ vars.ALIST_BASE_PATH }}
+      MIHARI_KEEP_VERSIONS: ${{ vars.MIHARI_KEEP_VERSIONS }}
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/checkout@v7
+
+      - name: Version gate (final)
+        # Layer ③ (design §4.2): last-chance gate before anything is published.
+        run: |
+          echo "${VERSION}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            || { echo "::error::version '${VERSION}' rejected at final gate"; exit 1; }
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true
 
       - name: Checksums
         working-directory: dist
-        run: sha256sum * > SHA256SUMS.txt
+        run: |
+          # GitHub release: every artifact. AList version dir: aio bundles only
+          # (design §4.5 step 2).
+          sha256sum * > SHA256SUMS.txt
+          sha256sum mihari-all-in-one-* > AIO_SHA256SUMS.txt
 
-      - name: Publish
+      - name: Publish GitHub release
         uses: softprops/action-gh-release@v3
         with:
+          # Explicit tag so workflow_dispatch (on a branch) tags/publishes the
+          # requested version rather than the branch name (design §4.2).
+          tag_name: ${{ env.VERSION }}
           files: dist/*
           generate_release_notes: true
+
+      - name: Publish to AList drive
+        # design §4.5 steps 1-6. Conditional on ALIST_URL so GitHub-only releases
+        # still succeed without the §9 prerequisites. End-to-end verified later.
+        if: ${{ env.ALIST_URL != '' }}
+        run: |
+          # requests ships on the ubuntu runner image; install only if absent to
+          # avoid the externally-managed-environment error on newer images.
+          python -c "import requests" 2>/dev/null || pip install requests
+          python scripts/release-alist.py \
+            --version "${VERSION}" \
+            --dist-dir dist \
+            --repo-root . \
+            --base-path "${ALIST_BASE_PATH:-/mihari}" \
+            --keep-versions "${MIHARI_KEEP_VERSIONS:-5}"
+
+      - name: Append offline install commands to release notes
+        # design §4.5 step 7. Idempotent via a marker (generate_release_notes
+        # regenerates the body each publish, so the appendix is re-added cleanly).
+        if: ${{ env.ALIST_URL != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NOTES="$(gh release view "${VERSION}" --json notes -q .notes)"
+          MARKER='<!-- aio-install -->'
+          printf '%s\n' "$NOTES" | grep -qF "$MARKER" && { echo "install commands already present"; exit 0; }
+          # Quoted heredoc delimiter: backticks and placeholders pass through
+          # verbatim (no shell expansion); the two URLs are injected via sed.
+          cat > /tmp/aio_append.md <<'TEMPLATE'
+
+          <!-- aio-install -->
+          ## 国内离线安装（AList 网盘，免 GitHub 访问）
+
+          Linux / macOS：
+
+          ```bash
+          curl -fsSL __SH_URL__ | bash
+          ```
+
+          Windows (PowerShell)：
+
+          ```powershell
+          & ([scriptblock]::Create((irm __PS1_URL__)))
+          ```
+          TEMPLATE
+          sed -i "s#__SH_URL__#${ALIST_REMOTE_SH_URL}#g; s#__PS1_URL__#${ALIST_REMOTE_PS1_URL}#g" /tmp/aio_append.md
+          gh release edit "${VERSION}" --notes "$(printf '%s\n%s\n' "$NOTES" "$(cat /tmp/aio_append.md)")"

--- a/.github/workflows/retract.yml
+++ b/.github/workflows/retract.yml
@@ -1,0 +1,74 @@
+name: retract
+
+# Withdraw a fatally-broken release from every distribution channel (design §4.6).
+# Manual dispatch only, with a boolean double-confirm. Idempotent: re-running on
+# an already-retracted version removes nothing more and reports so.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to retract, e.g. v0.3.0 (must match ^v[0-9]+\.[0-9]+\.[0-9]+$)'
+        required: true
+        type: string
+      confirm:
+        description: 'Type-check confirmation. The version is permanently deleted from AList and GitHub — check this ONLY after verifying the breakage.'
+        required: true
+        type: boolean
+
+permissions:
+  contents: write
+
+env:
+  VERSION: ${{ inputs.version }}
+  CONFIRM: ${{ inputs.confirm }}
+
+jobs:
+  retract:
+    name: retract ${{ inputs.version }}
+    runs-on: ubuntu-latest
+    env:
+      # Job-scope so the AList step's `if: env.ALIST_URL != ''` can read it
+      # (secrets are unreadable in step `if`; step env isn't either). Empty when
+      # unconfigured → AList step skips; the GitHub release is still deleted.
+      ALIST_URL: ${{ secrets.ALIST_URL }}
+      ALIST_USERNAME: ${{ secrets.ALIST_USERNAME }}
+      ALIST_PASSWORD: ${{ secrets.ALIST_PASSWORD }}
+      ALIST_BASE_PATH: ${{ vars.ALIST_BASE_PATH }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Gate (semver + confirm)
+        # design §4.6 step 1: pure-semver gate (same rule as §4.2) + the boolean
+        # double-confirm must be true before anything destructive runs.
+        run: |
+          echo "${VERSION}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            || { echo "::error::version '${VERSION}' must match ^v[0-9]+\.[0-9]+\.[0-9]+$"; exit 1; }
+          [ "${CONFIRM}" = "true" ] \
+            || { echo "::error::confirm must be true to retract ${VERSION} (this permanently deletes it)"; exit 1; }
+          echo "Retracting ${VERSION} (confirmed)."
+
+      - name: Retract from AList drive
+        # design §4.6 steps 2-4: read index, remove the version dir, rebuild
+        # index.txt to point at the highest remaining complete version (or empty).
+        # Conditional on ALIST_URL so retraction still works GitHub-only.
+        if: ${{ env.ALIST_URL != '' }}
+        run: |
+          python -c "import requests" 2>/dev/null || pip install requests
+          python scripts/retract-alist.py \
+            --version "${VERSION}" \
+            --base-path "${ALIST_BASE_PATH:-/mihari}"
+
+      - name: Delete GitHub release
+        # design §4.6 step 5: release + assets + tag. --cleanup-tag lets the same
+        # version number be re-cut after a fix. Idempotent: a missing release is
+        # reported, not fatal (re-run after a partial retract).
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "${VERSION}" >/dev/null 2>&1; then
+            gh release delete "${VERSION}" --yes --cleanup-tag
+            echo "Deleted GitHub release ${VERSION} (release + assets + tag)."
+          else
+            echo "GitHub release ${VERSION} not found (already retracted?) — nothing to delete."
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ coverage.*
 *.coverprofile
 profile.cov
 
+# Python (release/retract helper scripts under scripts/)
+__pycache__/
+*.pyc
+
 # Dependency directories (remove the comment below to include it)
 # vendor/
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -7,10 +7,11 @@
 | 工作流 | 触发条件 | 运行内容 |
 |--------|----------|----------|
 | **CI** | 推送到 `main` 分支<br>Pull Request | ✅ 代码格式检查 (`gofmt`)<br>✅ 静态分析 (`go vet`)<br>✅ 单元测试 (`go test ./...` + `-race`)<br>✅ 交叉编译验证（6 平台） |
-| **Release** | 推送 `v*` 标签 | ✅ 构建发布产物<br>✅ 注入版本号<br>✅ 生成 SHA256 校验和<br>✅ 创建 GitHub Release |
+| **Release** | 推送 `v*` 标签<br>`workflow_dispatch`（必填 `version` 输入） | ✅ 版本闸门（拒绝 `-` 预发布后缀）<br>✅ 6 平台构建 + 版本号注入<br>✅ 打包 6 个 all-in-one 整合包<br>✅ 生成 SHA256 校验和（全量 + aio 专用）<br>✅ 创建 GitHub Release<br>✅ 上传整合包到 AList 网盘（配置 secrets 后） |
+| **Retract** | `workflow_dispatch`（必填 `version` + `confirm`） | ✅ 彻底撤回致命错误版本（GitHub release + AList 目录 + index 重建） |
 | **DCO** | 推送到任何分支<br>Pull Request | ✅ 校验每个提交的 `Signed-off-by` 签名 |
 
-> **关键点**：推送标签时只触发 **Release** 工作流，不会重复运行 CI 测试。
+> **关键点**：推送标签时只触发 **Release** 工作流，不会重复运行 CI 测试。`Release` 与 `Retract` 仅手动或标签触发。
 
 ## 发版流程
 
@@ -40,10 +41,12 @@ git push origin v0.1.0
 
 推送标签后，GitHub Actions Release 工作流会自动：
 
-1. 交叉编译 linux / darwin / windows（各 amd64 + arm64）
-2. 注入版本号（`-X github.com/mihari-proxy/mihari/internal/buildinfo.Version=<tag>`）
-3. 生成 SHA256 校验和
-4. 创建 GitHub Release 并上传所有产物
+1. 版本闸门校验（build / release 各一层，拒绝 `-` 预发布后缀）；
+2. 交叉编译 linux / darwin / windows（各 amd64 + arm64），注入版本号（`-X .../buildinfo.Version=<version>`）；
+3. 打包 6 个 all-in-one 整合包（mihari + mihomo 核心 + GeoIP）；
+4. 生成 SHA256 校验和（全量 `SHA256SUMS.txt` + aio 专用 `AIO_SHA256SUMS.txt`）；
+5. 创建 GitHub Release 并上传全部产物；
+6. 配置 AList secrets 后，上传整合包到网盘版本目录、更新 `index.txt`、追加离线安装命令到 release notes（未配置则跳过，不阻塞 GitHub 发布）。
 
 ## 版本命名规范
 
@@ -69,10 +72,19 @@ mihari-darwin-amd64
 mihari-darwin-arm64
 mihari-windows-amd64.exe
 mihari-windows-arm64.exe
+mihari-all-in-one-linux-amd64.tar.gz
+mihari-all-in-one-linux-arm64.tar.gz
+mihari-all-in-one-darwin-amd64.tar.gz
+mihari-all-in-one-darwin-arm64.tar.gz
+mihari-all-in-one-windows-amd64.zip
+mihari-all-in-one-windows-arm64.zip
 SHA256SUMS.txt
+AIO_SHA256SUMS.txt
 ```
 
 命名规则：`mihari-<goos>-<goarch>[.exe]`（**不带版本号**）。`internal/update` 的 `SelectSelfAsset` 和 `install.sh` / `install.ps1` 都依赖这个固定命名，同时 GitHub 的 `/releases/latest/download/` 路径也因此可用。
+
+`mihari-all-in-one-*` 是 all-in-one 整合包（mihari 二进制 + mihomo 核心 + GeoIP×2），供墙内用户离线安装，详见 [分发方案](distribution.md)。`SHA256SUMS.txt` 覆盖全部产物，`AIO_SHA256SUMS.txt` 仅覆盖 6 个整合包（AList 版本目录内同名）。
 
 ## 校验下载
 
@@ -88,21 +100,21 @@ Get-FileHash mihari-windows-amd64.exe -Algorithm SHA256
 
 ## 手动触发发布
 
-如需手动触发（不推荐），可在 GitHub 仓库的 Actions 页面手动运行 `release` workflow。
+如需手动触发（不推荐），在 GitHub 仓库的 Actions 页面运行 `release` workflow，**必须填写 `version` 输入**（如 `v0.3.0`，须匹配 `^v[0-9]+\.[0-9]+\.[0-9]+$`，不接受预发布后缀）。
 
-## 回滚发布
+> **为什么必填 version**：`workflow_dispatch` 从分支触发时 `GITHUB_REF_NAME` 是分支名而非版本号。显式输入统一全链路取值（build 注入的版本号、Release 的 `tag_name`、AList 版本目录名），避免二进制版本号被污染。版本闸门在 build / release 两个 job 各校验一次。
 
-如发现问题需要回滚：
+## 回滚发布（致命错误撤回）
 
-```bash
-# 删除远程标签
-git push --delete origin v0.1.0
+发现致命错误需要撤回某版本时，使用 `retract` workflow（**彻底删除**，非改指式回滚）：
 
-# 删除本地标签
-git tag -d v0.1.0
+1. 在 GitHub 仓库 Actions 页面运行 `retract` workflow；
+2. 填写 `version`（如 `v0.3.0`）并勾选 `confirm` 双保险；
+3. workflow 自动：删除 AList 版本目录 → 必要时重建 `index.txt` 指向现存最高完整版本 → 删除 GitHub release + 资产 + tag（`--cleanup-tag`，允许修复后同版本号重发）。
 
-# 删除 GitHub Release（需在网页操作）
-```
+> **仅移除分发渠道，已安装用户不可回收**——靠快速发布修复版（`vN+1 > vN` 自更新覆盖）自愈。详见 [分发方案 · 版本撤回](distribution.md#四版本撤回致命错误)。
+
+> 旧的手动删标签 + 网页删 Release 方式仅删 GitHub 侧、不重建 AList index，已由 `retract` workflow 取代。
 
 ## CI/CD 检查项
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -1,0 +1,159 @@
+# 分发方案
+
+mihari 面向两类用户分发：
+
+- **海外 / 可访问 GitHub 的用户**：在线安装，直接从 GitHub Releases 拉取二进制（脚本1）。
+- **墙内 / 无 GitHub 访问的用户**：离线安装，从自建 AList 网盘拉取 all-in-one 整合包（脚本3 → 脚本2）。
+
+本文档聚焦「运维/用户操作面」。详细的架构论证与设计取舍见 all-in-one 分发设计稿（仓库外规划文档）。
+
+---
+
+## 一、用户安装入口
+
+### 1. 在线安装（脚本1，需 GitHub 访问）
+
+```bash
+# Linux / macOS
+curl -fsSL https://raw.githubusercontent.com/mihari-proxy/mihari/main/install.sh | bash
+
+# Windows (PowerShell)
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/mihari-proxy/mihari/main/install.ps1)))
+```
+
+脚本1 仅安装 mihari 二进制，核心（mihomo）与 GeoIP 在首次运行时联网下载。
+
+### 2. 离线安装（脚本3 下载器，免 GitHub）
+
+一条命令，全程不触碰 GitHub：
+
+```bash
+# Linux / macOS
+curl -fsSL <install-aio-remote.sh 签名直链> | bash
+
+# Windows (PowerShell)
+& ([scriptblock]::Create((irm <install-aio-remote.ps1 签名直链>)))
+```
+
+> **签名直链从哪里来**：每个 GitHub Release 的 release notes 会自动追加「国内离线安装」一节，含上述两条命令的真实签名直链。首次发版后，把这两条命令回填到 README 即可。
+
+脚本3 下载器的执行流程：
+
+1. 下载根目录 `index.txt`（固定签名直链，永久有效），解析出最新版本号与本平台的整合包签名直链 + sha256；
+2. 询问确认（`--yes` / `-y` 可跳过；stdin 非 tty 时读 `/dev/tty`）；
+3. 下载整合包 → `Downloads/mihari-aio/` → sha256 校验；
+4. 解压到 `Downloads/mihari-aio/`；
+5. 调用包内的本地安装器（脚本2），传入 bundle 目录；
+6. 提示重启终端，运行 `mihari`。
+
+### 3. 手动安装某个整合包
+
+无需脚本3，直接下载某版本的整合包解压后运行包内安装器：
+
+```bash
+# 下载 mihari-all-in-one-linux-amd64.tar.gz（从 AList 版本目录）
+tar -xzf mihari-all-in-one-linux-amd64.tar.gz
+sh install-aio.sh        # Windows: powershell -File install-aio.ps1
+```
+
+环境变量可覆盖默认安装位置：
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `MIHARI_BIN` | `/usr/local/bin`（Linux/macOS）<br>`%LOCALAPPDATA%\Programs\mihari`（Windows） | mihari 二进制安装目录 |
+| `MIHARI_DATA` | `$HOME/.mihari`（Linux/macOS）<br>`%USERPROFILE%\.mihari`（Windows） | 数据根目录（核心 + GeoIP 落地处） |
+| `MIHARI_INDEX_URL` | （CI 注入） | index.txt 签名直链（脚本3） |
+| `MIHARI_BUNDLE_URL` | 空 | 显式指定整合包 URL，**跳过 index 与 sha256 校验**（信任自担） |
+
+---
+
+## 二、AList 网盘目录结构
+
+base_path 默认 `/mihari`（通过 GitHub 变量 `ALIST_BASE_PATH` 配置）：
+
+```
+/mihari/
+├── index.txt                       路由表（根目录固定签名直链）
+├── install-aio-remote.sh / .ps1    脚本3 下载器（CI 注入 index 直链，每次发布覆盖）
+├── v0.3.0/                         不可变版本目录
+│   ├── mihari-all-in-one-{linux,darwin,windows}-{amd64,arm64}.tar.gz / .zip
+│   ├── SHA256SUMS.txt              本版本 6 个整合包的 sha256
+│   └── COMPLETE                    完整标记（内部语义）
+├── v0.2.0/
+└── v0.1.0/
+```
+
+### index.txt 格式
+
+```
+latest v0.3.0
+linux-amd64   <签名直链>  <sha256>
+linux-arm64   <签名直链>  <sha256>
+darwin-amd64  <签名直链>  <sha256>
+darwin-arm64  <签名直链>  <sha256>
+windows-amd64 <签名直链>  <sha256>
+windows-arm64 <签名直链>  <sha256>
+```
+
+每行 `<key> <rest...>`：`latest` 行的 key 后是版本号；平台行的 key 是 `<goos>-<goarch>`，后跟签名直链与 sha256。脚本3 按此解析。
+
+### 发布顺序（零失败窗口）
+
+release workflow 的 AList 步骤顺序保证用户永远拿不到半成品：
+
+1. 先把整个版本目录上传完整（6 包 + SHA256SUMS.txt），**最后传 `COMPLETE`**；
+2. 已完整的目录（`COMPLETE` 存在）**整个跳过**——重跑幂等，不覆盖任何文件；
+3. **最后一行才覆盖 `index.txt`**——发布过程中用户读到的是旧 index → 下载旧版本目录，无校验失败窗口。
+
+唯一残留风险是 `index.txt` 单文件覆盖中断 → 用户解析失败，重试即可。
+
+---
+
+## 三、版本保留策略
+
+`MIHARI_KEEP_VERSIONS`（GitHub 变量，默认 `5`）控制保留数量：
+
+- 保留 = **index 当前指向的 1 个**（不计入名额）+ **其余最新的 N-1 个**；
+- 无 `COMPLETE` 的半成品目录（发版中断残留）**优先删除，不占名额**；
+- `index.txt` 读取失败 → 重试 1 次 → 仍失败则本次跳过、不删任何版本、打警告（发布不因此失败）。
+
+---
+
+## 四、版本撤回（致命错误）
+
+独立 workflow `.github/workflows/retract.yml` 手动触发，**彻底删除**坏版本：
+
+1. `workflow_dispatch` 输入 `version`（纯 semver 闸门）+ `confirm`（布尔双保险）；
+2. 读 `index.txt` 判断撤回版本是否为当前 latest；
+3. 删除 AList 版本目录 `/mihari/<version>/`；
+4. **仅当撤回的是 latest** 才重建 `index.txt`：latest 改为现存最高且完整（含 `COMPLETE`）的版本（sha256 从该目录的 `SHA256SUMS.txt` 读取）；无完整版本 → `index.txt` 置空；
+5. `gh release delete <version> --yes --cleanup-tag`（删 release + 资产 + tag，允许修复后同版本号重发）。
+
+幂等：对已撤回的版本重跑不报错。
+
+### 边界（务必知晓）
+
+撤回**只移除分发渠道，已安装用户不可回收**。修复版发布前，已装用户主动 `self-update` 会先降到次高版本，再随修复版回升——最终靠**快速发布修复版**（`vN+1 > vN` 自更新覆盖坏版本）自愈。
+
+---
+
+## 五、CI 配置（前置依赖）
+
+AList 分发步骤在 release workflow 中以 `if: env.ALIST_URL != ''` 包裹——**未配置时跳过，不阻塞 GitHub 发布**。启用国内分发需配置：
+
+**GitHub Secrets：**
+
+| Secret | 用途 |
+|--------|------|
+| `ALIST_URL` | AList 站点地址（如 `https://alist.example.com`） |
+| `ALIST_USERNAME` | 登录用户名 |
+| `ALIST_PASSWORD` | 登录密码 |
+
+**GitHub Variables（可选）：**
+
+| Variable | 默认值 | 用途 |
+|----------|--------|------|
+| `ALIST_BASE_PATH` | `/mihari` | 网盘 base_path |
+| `MIHARI_KEEP_VERSIONS` | `5` | 保留版本数 |
+
+> **签名直链失效**：直链的 sign 依赖 AList 站点 **Token**（后台 settings 的 `token` 项，非登录 JWT）。直接改登录账号密码**不**作废直链；改站点 Token 才让全部旧 sign 失效。恢复 = **重跑 release workflow**（fs/get 现有 index.txt 取新 sign 重建，幂等）。

--- a/install-aio-remote.ps1
+++ b/install-aio-remote.ps1
@@ -1,0 +1,110 @@
+# mihari all-in-one REMOTE downloader for Windows (script 3). Fetches the
+# platform bundle from the AList drive (index.txt -> signed direct link +
+# sha256), verifies it, extracts, and hands off to the local installer
+# (script 2) inside the bundle.
+#   & ([scriptblock]::Create((irm <ALIST>/p/mihari/install-aio-remote.ps1?sign=<fixed>)))
+#   & ([scriptblock]::Create((irm <ALIST>/p/mihari/install-aio-remote.ps1?sign=<fixed>))) -Yes
+#
+# One-time: only the first offline install goes through this downloader; later
+# reinstalls run script 2 (install-aio.ps1) directly from an existing bundle.
+#
+# Environment overrides:
+#   $env:MIHARI_INDEX_URL   index.txt signed direct link (default: CI-injected placeholder)
+#   $env:MIHARI_BUNDLE_URL  explicit bundle URL (skips index + sha256)
+param([switch]$Yes)
+$ErrorActionPreference = 'Stop'
+
+# Placeholder: the release workflow (design 4.5 step 5) injects the root
+# index.txt signed direct link here. Pre-injection this token is not a URL, so
+# the index fetch fails with a clear "not published yet" message.
+$indexUrl = if ($env:MIHARI_INDEX_URL) { $env:MIHARI_INDEX_URL } else { '__MIHARI_INDEX_URL__' }
+$bundleUrl = $env:MIHARI_BUNDLE_URL
+
+function Info($m) { Write-Host "* $m" -ForegroundColor Cyan }
+function Fail($m) { Write-Host "error: $m" -ForegroundColor Red; exit 1 }
+function Confirm($p) {
+  # Read-Host reads the host console (not the stdin pipe), so no /dev/tty
+  # special-casing is needed (design 4.4 step 2).
+  if ($Yes) { return $true }
+  $ans = Read-Host "$p [y/N]"
+  return $ans -match '^[Yy]'
+}
+
+# Detect platform (mirrors install.ps1).
+$arch = switch ($env:PROCESSOR_ARCHITECTURE) {
+  'AMD64' { 'amd64' }
+  'ARM64' { 'arm64' }
+  default { Fail "unsupported architecture: $($env:PROCESSOR_ARCHITECTURE)" }
+}
+$platform = "windows-$arch"
+
+# Resolve bundle URL + expected sha256 + latest version.
+$latest = ''; $wantSum = ''; $resolvedUrl = $bundleUrl
+if (-not $resolvedUrl) {
+  # index.txt line format: "<key> <rest...>". key="latest" -> <version>;
+  # key="<goos>-<goarch>" -> <signed_url> <sha256>.
+  $index = ''
+  try { $index = (Invoke-WebRequest -Uri $indexUrl -UseBasicParsing).Content } catch { $index = '' }
+  if (-not $index) { Fail "尚未发布完成：无法获取 index（请稍后重试，或检查网络/网盘可用性）。" }
+  foreach ($line in ($index -split "`n")) {
+    $line = $line.Trim()
+    if (-not $line -or $line.StartsWith('#') -or $line.StartsWith('//')) { continue }
+    $fields = $line -split '\s+'
+    if ($fields[0] -eq 'latest') { $latest = $fields[1] }
+    elseif ($fields[0] -eq $platform) { $resolvedUrl = $fields[1]; $wantSum = $fields[2] }
+  }
+  if (-not $latest) { Fail "尚未发布完成：index 无 latest 版本（可能正在发布或已撤回）。" }
+  if (-not $resolvedUrl) { Fail "index 未包含本平台 $platform 的包。" }
+}
+
+# Version judgment: PATH mihari only, local (no daemon). Single source of truth
+# vs index.latest; empty -> unknown. (Equality-only compare: == latest ->
+# "reinstall", != latest -> "upgrade" with honest versions shown. Full semver is
+# not needed since judgment only informs the prompt, never gates the install.)
+$haveMihari = $false; $current = ''
+$mihariCmd = Get-Command mihari -ErrorAction SilentlyContinue
+if ($mihariCmd) {
+  $haveMihari = $true
+  try {
+    $vobj = (& mihari self version --json) | Out-String | ConvertFrom-Json
+    $current = $vobj.version
+  } catch { $current = '' }
+}
+
+if (-not $haveMihari) {
+  Info ("未检测到 mihari，安装最新版" + $(if ($latest) { " ($latest)" }) + "…")
+} elseif (-not $current) {
+  Info '检测到 mihari 但版本未知（二进制可能损坏）。'
+  if (-not (Confirm '  重新安装（修复）？')) { Info '已取消。'; exit 0 }
+} elseif ($latest -and $current -eq $latest) {
+  Info "已是最新版本 ($current)。"
+  if (-not (Confirm '  重新安装（用于修复）？')) { Info '已取消。'; exit 0 }
+} else {
+  Info ("当前已安装 $current" + $(if ($latest) { "，最新版本为 $latest" }) + "。")
+  if (-not (Confirm '  安装？')) { Info '已取消。'; exit 0 }
+}
+
+# Download to a temp file (outside the work dir) so the work dir can be fully
+# cleared before extraction — PS 5.1 Expand-Archive does not reliably overwrite
+# existing files (design 4.4 step 4).
+$workdir = Join-Path $env:USERPROFILE 'Downloads\mihari-aio'
+New-Item -ItemType Directory -Force -Path $workdir | Out-Null
+$tmpArchive = Join-Path ([IO.Path]::GetTempPath()) ("mihari-aio-" + ([guid]::NewGuid().ToString('N')) + ".zip")
+Info "下载 $resolvedUrl …"
+Invoke-WebRequest -Uri $resolvedUrl -OutFile $tmpArchive -UseBasicParsing
+if ($wantSum) {
+  $got = (Get-FileHash -Algorithm SHA256 -LiteralPath $tmpArchive).Hash.ToLower()
+  if ($got -ne $wantSum.ToLower()) { Remove-Item -LiteralPath $tmpArchive -Force; Fail "sha256 校验失败：期望 $wantSum，实际 $got。" }
+  Info 'sha256 校验通过。'
+}
+Info "解压到 $workdir …"
+if (Test-Path -LiteralPath $workdir) { Get-ChildItem -LiteralPath $workdir | Remove-Item -Recurse -Force }
+Expand-Archive -LiteralPath $tmpArchive -DestinationPath $workdir -Force
+Remove-Item -LiteralPath $tmpArchive -Force
+
+# Hand off to the local installer inside the bundle (script 2) via a scriptblock
+# that reads the file content as a string — bypassing ExecutionPolicy and Mark of
+# the Web; the bundle dir is injected via -BundleDir (design 4.4 step 5).
+$localInstaller = Join-Path $workdir 'install-aio.ps1'
+if (-not (Test-Path -LiteralPath $localInstaller)) { Fail '包内缺少 install-aio.ps1。' }
+& ([scriptblock]::Create([IO.File]::ReadAllText($localInstaller))) -BundleDir $workdir

--- a/install-aio-remote.sh
+++ b/install-aio-remote.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env sh
+# mihari all-in-one REMOTE downloader (script 3). Fetches the platform bundle
+# from the AList drive (index.txt → signed direct link + sha256), verifies it,
+# extracts, and hands off to the local installer (script 2) inside the bundle.
+#   curl -fsSL <ALIST>/p/mihari/install-aio-remote.sh?sign=<fixed> | bash
+#   sh install-aio-remote.sh [--yes|-y]
+#
+# One-time: only the first offline install goes through this downloader; later
+# reinstalls run script 2 (install-aio.sh) directly from an existing bundle.
+#
+# Environment overrides:
+#   MIHARI_INDEX_URL   index.txt signed direct link (default: CI-injected placeholder)
+#   MIHARI_BUNDLE_URL  explicit bundle URL (skips index + sha256 — trust borne by user)
+set -eu
+
+# Placeholder: the release workflow (design §4.5 step 5) injects the root
+# index.txt signed direct link here. Pre-injection this token is not a URL, so
+# the index fetch fails with a clear "not published yet" message.
+INDEX_URL="${MIHARI_INDEX_URL:-__MIHARI_INDEX_URL__}"
+BUNDLE_URL="${MIHARI_BUNDLE_URL:-}"
+YES=0
+for arg in "$@"; do
+  case "$arg" in
+    --yes|-y) YES=1 ;;
+    *) ;;
+  esac
+done
+
+info() { printf '\033[1;34m•\033[0m %s\n' "$*"; }
+err()  { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# confirm: returns 0 (yes) / 1 (no). --yes bypasses. stdin tty → read; else
+# /dev/tty (when piped from curl, real stdin is occupied but the user's tty is
+# still readable); failure → default no (design §4.4 step 2).
+confirm() {
+  [ "$YES" = "1" ] && return 0
+  printf '%s [y/N] ' "$1"
+  reply=''
+  if [ -t 0 ]; then
+    read reply || return 1
+  else
+    read reply </dev/tty 2>/dev/null || return 1
+  fi
+  case "$reply" in
+    y|Y|yes|YES|Yes) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Detect platform (mirrors install.sh).
+os="$(uname -s)"
+case "$os" in
+  Linux) os="linux" ;;
+  Darwin) os="darwin" ;;
+  *) err "unsupported OS: $os" ;;
+esac
+arch="$(uname -m)"
+case "$arch" in
+  x86_64|amd64) arch="amd64" ;;
+  aarch64|arm64) arch="arm64" ;;
+  *) err "unsupported architecture: $arch" ;;
+esac
+platform="${os}-${arch}"
+
+# Downloader: dl writes to a file, fetch writes to stdout (mirrors install.sh).
+if command -v curl >/dev/null 2>&1; then
+  dl() { curl -fsSL "$1" -o "$2"; }
+  fetch() { curl -fsSL "$1"; }
+elif command -v wget >/dev/null 2>&1; then
+  dl() { wget -qO "$2" "$1"; }
+  fetch() { wget -qO- "$1"; }
+else
+  err "need curl or wget"
+fi
+
+checksum() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | cut -d' ' -f1
+  elif command -v shasum >/dev/null 2>&1; then shasum -a 256 "$1" | cut -d' ' -f1
+  else err "need sha256sum or shasum"
+  fi
+}
+
+# Resolve bundle URL + expected sha256 + latest version.
+latest=""
+bundle_url=""
+want_sum=""
+if [ -n "$BUNDLE_URL" ]; then
+  bundle_url="$BUNDLE_URL"
+else
+  # index.txt line format: "<key> <rest...>". key="latest" → <version>;
+  # key="<goos>-<goarch>" → <signed_url> <sha256>.
+  index="$(fetch "$INDEX_URL" 2>/dev/null || true)"
+  [ -n "$index" ] || err "尚未发布完成：无法获取 index（请稍后重试，或检查网络/网盘可用性）。"
+  # Heredoc (not a pipe) so parsed values survive outside the loop's subshell.
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    case "$line" in '#'*|'//'*) continue ;; esac
+    key="${line%% *}"
+    rest="${line#* }"
+    if [ "$key" = "latest" ]; then
+      latest="${rest%% *}"
+    elif [ "$key" = "$platform" ]; then
+      bundle_url="${rest%% *}"
+      want_sum="${rest#* }"
+    fi
+  done <<EOF
+$index
+EOF
+  [ -n "$latest" ] || err "尚未发布完成：index 无 latest 版本（可能正在发布或已撤回）。"
+  [ -n "$bundle_url" ] || err "index 未包含本平台 $platform 的包。"
+fi
+
+# Version judgment: PATH mihari only, local (no daemon). Single source of truth
+# vs index.latest; empty → unknown. (Comparison is equality-only: == latest →
+# "reinstall", != latest → "upgrade" with honest versions shown. Full semver is
+# not needed since judgment only informs the prompt, never gates the install.)
+have_mihari=0
+current=""
+if command -v mihari >/dev/null 2>&1; then
+  have_mihari=1
+  current="$(mihari self version --json 2>/dev/null | sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' || true)"
+fi
+
+if [ "$have_mihari" = "0" ]; then
+  info "未检测到 mihari，安装最新版${latest:+ ($latest)}…"
+elif [ -z "$current" ]; then
+  info "检测到 mihari 但版本未知（二进制可能损坏）。"
+  confirm "  重新安装（修复）？" || { info "已取消。"; exit 0; }
+elif [ -n "$latest" ] && [ "$current" = "$latest" ]; then
+  info "已是最新版本 ($current)。"
+  confirm "  重新安装（用于修复）？" || { info "已取消。"; exit 0; }
+else
+  info "当前已安装 $current${latest:+，最新版本为 $latest}。"
+  confirm "  安装？" || { info "已取消。"; exit 0; }
+fi
+
+# Download + verify + extract to a fixed, idempotent work dir.
+workdir="${HOME}/Downloads/mihari-aio"
+mkdir -p "$workdir"
+archive="${workdir}/mihari-all-in-one-${platform}.tar.gz"
+info "下载 ${bundle_url} …"
+dl "$bundle_url" "$archive" || err "下载失败: $bundle_url"
+if [ -n "$want_sum" ]; then
+  got="$(checksum "$archive")"
+  [ "$got" = "$want_sum" ] || err "sha256 校验失败：期望 $want_sum，实际 $got。"
+  info "sha256 校验通过。"
+fi
+info "解压到 ${workdir} …"
+tar -xzf "$archive" -C "$workdir" || err "解压失败。"
+rm -f "$archive"
+
+# Hand off to the local installer inside the bundle (script 2), passing the
+# bundle dir so it locates mihari + data/ without relying on the caller's path.
+[ -f "${workdir}/install-aio.sh" ] || err "包内缺少 install-aio.sh。"
+sh "${workdir}/install-aio.sh" "$workdir"

--- a/install-aio.ps1
+++ b/install-aio.ps1
@@ -1,0 +1,105 @@
+# mihari all-in-one LOCAL installer for Windows (script 2). Offline: lays down
+# the mihari binary + bundled mihomo core + GeoIP from <BundleDir> with zero
+# network.
+#   powershell -File install-aio.ps1 [-BundleDir <path>]   (default: script dir)
+#
+# Bundle layout (produced by scripts/build-all-in-one):
+#   mihari.exe          -> $binDir\mihari.exe
+#   data\bin\mihomo.exe -> $MIHARI_DATA\bin\mihomo.exe       (overwrite)
+#   data\geoip\*.mmdb   -> $MIHARI_DATA\geoip\*.mmdb         (overwrite)
+#
+# Never touches: mihari.yaml, subscriptions\, control.token, onboarding.json,
+# logs\, web\ (user-private config and panel state stay intact).
+#
+# Environment overrides:
+#   $env:MIHARI_BIN    mihari binary install dir (default %LOCALAPPDATA%\Programs\mihari)
+#   $env:MIHARI_DATA   data root (default %USERPROFILE%\.mihari)
+param([string]$BundleDir = $PSScriptRoot)
+$ErrorActionPreference = 'Stop'
+
+if (-not $BundleDir) { $BundleDir = if ($PSScriptRoot) { $PSScriptRoot } else { (Get-Location).Path } }
+
+function Info($m) { Write-Host "* $m" -ForegroundColor Cyan }
+function Fail($m) { Write-Host "error: $m" -ForegroundColor Red; exit 1 }
+# Invoke-MihariService runs a `mihari service ...` step, elevating via UAC when
+# the current session is not admin (service control needs elevation on Windows).
+function Invoke-MihariService([string[]]$ServiceArgs) {
+  if ($isAdmin) {
+    & $dest @ServiceArgs
+  } else {
+    Info ("提权执行: mihari " + ($ServiceArgs -join ' '))
+    Start-Process -FilePath $dest -ArgumentList $ServiceArgs -Verb RunAs -Wait
+  }
+}
+
+$mihariSrc = Join-Path $BundleDir 'mihari.exe'
+$mihomoSrc = Join-Path $BundleDir 'data\bin\mihomo.exe'
+if (-not (Test-Path -LiteralPath $mihariSrc)) { Fail "all-in-one bundle not found at $BundleDir (expected mihari.exe)" }
+if (-not (Test-Path -LiteralPath $mihomoSrc)) { Fail "bundled mihomo core missing at $mihomoSrc" }
+if (-not (Test-Path -LiteralPath (Join-Path $BundleDir 'data\geoip\GeoLite2-Country.mmdb'))) { Fail "bundled GeoIP Country missing at $BundleDir\data\geoip" }
+if (-not (Test-Path -LiteralPath (Join-Path $BundleDir 'data\geoip\GeoLite2-ASN.mmdb'))) { Fail "bundled GeoIP ASN missing at $BundleDir\data\geoip" }
+
+$binDir = if ($env:MIHARI_BIN) { $env:MIHARI_BIN } else { Join-Path $env:LOCALAPPDATA 'Programs\mihari' }
+$dataDir = if ($env:MIHARI_DATA) { $env:MIHARI_DATA } else { Join-Path $env:USERPROFILE '.mihari' }
+$dest = Join-Path $binDir 'mihari.exe'
+
+New-Item -ItemType Directory -Force -Path $binDir | Out-Null
+
+$isAdmin = ([Security.Principal.WindowsPrincipal] `
+  [Security.Principal.WindowsIdentity]::GetCurrent()
+  ).IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
+
+# A running service / foreground process holds an open handle on mihari.exe and
+# the MMDBs — stop both before overwriting (mirrors install.ps1's svcRunning
+# branch and adds the foreground-daemon lock the aio overlay introduces).
+$svc = Get-Service -Name 'mihari' -ErrorAction SilentlyContinue
+$svcRunning = $svc -and $svc.Status -eq 'Running'
+$proc = Get-Process -Name 'mihari' -ErrorAction SilentlyContinue
+$stopSteps = @()
+if ($svcRunning) { $stopSteps += 'Stop-Service -Name mihari -Force' }
+if ($proc) { $stopSteps += 'Stop-Process -Name mihari -Force -ErrorAction SilentlyContinue' }
+if ($stopSteps.Count -gt 0) {
+  Info '检测到运行中的 mihari，停止以释放文件锁…'
+  $stopCmd = $stopSteps -join '; '
+  if ($isAdmin) {
+    Invoke-Expression $stopCmd
+  } else {
+    Start-Process powershell -Verb RunAs -Wait -ArgumentList '-NoProfile', '-Command', $stopCmd
+  }
+  Start-Sleep -Seconds 1
+}
+
+# 1. mihari binary -> binDir.
+Info "安装 mihari 到 $dest"
+Copy-Item -LiteralPath $mihariSrc -Destination $dest -Force
+
+# Add install dir to the user PATH if missing (mirrors install.ps1).
+$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+if ($userPath -and $userPath -notlike "*$binDir*") {
+  Info "将 $binDir 加入 PATH"
+  [Environment]::SetEnvironmentVariable('Path', "$userPath;$binDir", 'User')
+  $env:Path = "$env:Path;$binDir"
+}
+
+# 2. Data overlay -> MIHARI_DATA (bundle authoritative for core + GeoIP; user
+#    config / panel state below is never touched).
+New-Item -ItemType Directory -Force -Path (Join-Path $dataDir 'bin') | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $dataDir 'geoip') | Out-Null
+Info "覆盖 mihomo 核心与 GeoIP 到 $dataDir"
+Copy-Item -LiteralPath $mihomoSrc -Destination (Join-Path $dataDir 'bin\mihomo.exe') -Force
+Copy-Item -LiteralPath (Join-Path $BundleDir 'data\geoip\GeoLite2-Country.mmdb') -Destination (Join-Path $dataDir 'geoip\GeoLite2-Country.mmdb') -Force
+Copy-Item -LiteralPath (Join-Path $BundleDir 'data\geoip\GeoLite2-ASN.mmdb') -Destination (Join-Path $dataDir 'geoip\GeoLite2-ASN.mmdb') -Force
+
+# 3. Service: reinstall when registered (re-stages the service copy from the
+#    freshly installed PATH binary, closing the "service vs PATH" version drift),
+#    install when fresh. Service control needs elevation (Invoke-MihariService).
+if ($svc) {
+  Info '已注册服务，执行 service reinstall 同步新版本…'
+  Invoke-MihariService 'service', 'reinstall'
+} else {
+  Info '注册并启动服务…'
+  Invoke-MihariService 'service', 'install'
+  Invoke-MihariService 'service', 'start'
+}
+
+Write-Host "`n✅ aio 版安装完成！请重启终端，然后运行 mihari 开始使用。" -ForegroundColor Green

--- a/install-aio.sh
+++ b/install-aio.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env sh
+# mihari all-in-one LOCAL installer (script 2). Offline: lays down the mihari
+# binary + bundled mihomo core + GeoIP from <bundle_dir> with zero network.
+#   sh install-aio.sh [bundle_dir]      (bundle_dir defaults to this script's dir)
+#
+# Bundle layout (produced by scripts/build-all-in-one):
+#   mihari            -> $BIN_DIR/mihari
+#   data/bin/mihomo   -> $MIHARI_DATA/bin/mihomo      (overwrite)
+#   data/geoip/*.mmdb -> $MIHARI_DATA/geoip/*.mmdb    (overwrite)
+#
+# Never touches: mihari.yaml, subscriptions/, control.token, onboarding.json,
+# logs/, web/ (user-private config and panel state stay intact).
+#
+# Environment overrides:
+#   MIHARI_BIN    mihari binary install dir (default /usr/local/bin)
+#   MIHARI_DATA   data root (default ~/.mihari)
+set -eu
+
+bundle_dir="${1:-$(cd "$(dirname "$0")" && pwd)}"
+
+info() { printf '\033[1;34m•\033[0m %s\n' "$*"; }
+err()  { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+[ -f "$bundle_dir/mihari" ] || err "all-in-one bundle not found at $bundle_dir (expected the mihari binary)"
+[ -f "$bundle_dir/data/bin/mihomo" ] || err "bundled mihomo core missing at $bundle_dir/data/bin/mihomo"
+[ -f "$bundle_dir/data/geoip/GeoLite2-Country.mmdb" ] || err "bundled GeoIP Country missing at $bundle_dir/data/geoip"
+[ -f "$bundle_dir/data/geoip/GeoLite2-ASN.mmdb" ] || err "bundled GeoIP ASN missing at $bundle_dir/data/geoip"
+
+BIN_DIR="${MIHARI_BIN:-/usr/local/bin}"
+DATA_DIR="${MIHARI_DATA:-$HOME/.mihari}"
+mihari_bin="${BIN_DIR}/mihari"
+
+# Elevate for writes to the system binary dir when needed (mirrors install.sh).
+SUDO=""
+if [ ! -w "$BIN_DIR" ] 2>/dev/null; then
+  if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1; then
+    SUDO="sudo"
+  fi
+fi
+
+# Stop anything holding file locks on the binary / MMDBs before overwriting.
+# `service stop` covers the registered-service case (and survives a systemd
+# restart policy); pkill covers a foreground daemon. This symmetric handling is
+# the gap install.sh leaves open (design §4.4).
+if [ -x "$mihari_bin" ]; then
+  $SUDO "$mihari_bin" service stop >/dev/null 2>&1 || true
+fi
+if command -v pgrep >/dev/null 2>&1 && pgrep -x mihari >/dev/null 2>&1; then
+  info "检测到运行中的 mihari，停止以释放文件锁…"
+  pkill -x mihari >/dev/null 2>&1 || true
+  tries=0
+  while [ "$tries" -lt 5 ] && pgrep -x mihari >/dev/null 2>&1; do
+    tries=$((tries + 1))
+    sleep 1
+  done
+fi
+
+# 1. mihari binary -> BIN_DIR.
+$SUDO mkdir -p "$BIN_DIR"
+info "安装 mihari 到 $mihari_bin"
+$SUDO install -m 0755 "$bundle_dir/mihari" "$mihari_bin"
+
+# 2. Data overlay -> MIHARI_DATA (bundle is authoritative for core + GeoIP;
+#    user config / panel state below is never touched).
+mkdir -p "$DATA_DIR/bin" "$DATA_DIR/geoip"
+info "覆盖 mihomo 核心与 GeoIP 到 $DATA_DIR"
+install -m 0755 "$bundle_dir/data/bin/mihomo" "$DATA_DIR/bin/mihomo"
+install -m 0644 "$bundle_dir/data/geoip/GeoLite2-Country.mmdb" "$DATA_DIR/geoip/GeoLite2-Country.mmdb"
+install -m 0644 "$bundle_dir/data/geoip/GeoLite2-ASN.mmdb" "$DATA_DIR/geoip/GeoLite2-ASN.mmdb"
+
+# 3. Service: reinstall when registered (re-stages the service copy from the
+#    freshly installed PATH binary, closing the "service vs PATH" version drift),
+#    install when fresh. Service control needs root; elevate the step (mirrors
+#    install.sh). service status returns "not_installed" for a fresh machine with
+#    no elevation, so the branch is reliable; any ambiguity falls through to the
+#    fresh-install path whose install/start is the safe default.
+status="$($SUDO "$mihari_bin" service status 2>/dev/null || true)"
+case "$status" in
+  running|stopped)
+    info "已注册服务，执行 service reinstall 同步新版本…"
+    $SUDO "$mihari_bin" service reinstall
+    ;;
+  *)
+    info "注册并启动服务…"
+    $SUDO "$mihari_bin" service install
+    $SUDO "$mihari_bin" service start
+    ;;
+esac
+
+printf '\n\033[1;32m✅ aio 版安装完成！请重启终端，然后运行 mihari 开始使用。\033[0m\n'

--- a/internal/control/protocol/runtime.go
+++ b/internal/control/protocol/runtime.go
@@ -108,6 +108,7 @@ type DelayResult struct {
 type MutationRequest struct {
 	OperationID string  `json:"operation_id"`
 	IfRevision  *uint64 `json:"if_revision,omitempty"`
+	Source      string  `json:"source,omitempty"` // request origin; empty defaults to "control" (normalized by handlers)
 }
 
 type ProxySelectionRequest struct {

--- a/internal/control/protocol/runtime_test.go
+++ b/internal/control/protocol/runtime_test.go
@@ -112,3 +112,21 @@ func TestRuleProviderListJSONContract(t *testing.T) {
 		t.Fatalf("json=%s want=%s", raw, want)
 	}
 }
+
+func TestMutationRequestThreadsSource(t *testing.T) {
+	var setup MutationRequest
+	if err := json.Unmarshal([]byte(`{"operation_id":"x","source":"setup"}`), &setup); err != nil {
+		t.Fatal(err)
+	}
+	if setup.Source != "setup" {
+		t.Fatalf("source=%q want setup", setup.Source)
+	}
+
+	var omitted MutationRequest
+	if err := json.Unmarshal([]byte(`{"operation_id":"x"}`), &omitted); err != nil {
+		t.Fatal(err)
+	}
+	if omitted.Source != "" {
+		t.Fatalf("source=%q want empty", omitted.Source)
+	}
+}

--- a/internal/control/server/geoip.go
+++ b/internal/control/server/geoip.go
@@ -85,7 +85,7 @@ func (s *Server) geoIPUpdate(writer http.ResponseWriter, request *http.Request) 
 	if !decodeControlJSON(writer, request, &body) || !requireOperationID(writer, body.OperationID) {
 		return
 	}
-	status, err := s.runtime.UpdateGeoIP(request.Context(), runtimeapi.Operation{ID: body.OperationID, Source: "control", IfRevision: body.IfRevision})
+	status, err := s.runtime.UpdateGeoIP(request.Context(), runtimeapi.Operation{ID: body.OperationID, Source: mutationSource(body.Source), IfRevision: body.IfRevision})
 	if err != nil {
 		writeControlError(writer, err)
 		return

--- a/internal/control/server/geoip_test.go
+++ b/internal/control/server/geoip_test.go
@@ -67,3 +67,28 @@ func TestGeoIPLookupRejectsMalformedDuplicateAndOversizedBatches(t *testing.T) {
 		}
 	}
 }
+
+func TestGeoIPUpdateThreadsRequestSource(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"setup source", `{"operation_id":"geoip-1","source":"setup"}`, "setup"},
+		{"default control source", `{"operation_id":"geoip-2"}`, "control"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fake := &fakeRuntime{geoIPStatus: geoip.Status{Country: geoip.DatabaseStatus{Available: true}, ASN: geoip.DatabaseStatus{Available: true}}}
+			server := New(Options{Token: "token", Store: state.NewStore(state.Snapshot{}), Runtime: fake})
+			recorder := httptest.NewRecorder()
+			server.Handler().ServeHTTP(recorder, authorizedRequest(http.MethodPost, "/v1/geoip/update", bytes.NewBufferString(test.body)))
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+			}
+			if fake.operation.Source != test.want {
+				t.Fatalf("source=%q want %q", fake.operation.Source, test.want)
+			}
+		})
+	}
+}

--- a/internal/control/server/runtime.go
+++ b/internal/control/server/runtime.go
@@ -87,7 +87,7 @@ func (s *Server) installCore(writer http.ResponseWriter, request *http.Request) 
 	if !decodeControlJSON(writer, request, &body) || !requireOperationID(writer, body.OperationID) {
 		return
 	}
-	result, err := s.runtime.Install(request.Context(), runtimeapi.Operation{ID: body.OperationID, Source: "control", IfRevision: body.IfRevision})
+	result, err := s.runtime.Install(request.Context(), runtimeapi.Operation{ID: body.OperationID, Source: mutationSource(body.Source), IfRevision: body.IfRevision})
 	if err != nil {
 		writeControlError(writer, err)
 		return
@@ -435,6 +435,15 @@ func requireOperationID(writer http.ResponseWriter, operationID string) bool {
 	}
 	writeInvalidArgument(writer, "operation_id is required")
 	return false
+}
+
+// mutationSource 归一化请求来源：空值默认 "control"。只有 setup 流程显式传 "setup"
+// 以触发 daemon 侧本地预检短路；其余 mutation 保持 "control" 语义（design §4.3）。
+func mutationSource(raw string) string {
+	if raw == "" {
+		return "control"
+	}
+	return raw
 }
 
 func writeInvalidArgument(writer http.ResponseWriter, message string) {

--- a/internal/control/server/runtime_test.go
+++ b/internal/control/server/runtime_test.go
@@ -470,3 +470,28 @@ func (f *fakeRuntime) DisableTun(_ context.Context, operation runtimeapi.Operati
 	}
 	return f.tunStatus, nil
 }
+
+func TestInstallCoreThreadsRequestSource(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"setup source", `{"operation_id":"install-1","source":"setup"}`, "setup"},
+		{"default control source", `{"operation_id":"install-2"}`, "control"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fake := &fakeRuntime{installResult: core.InstallResult{Version: "v1.19.0"}}
+			server := New(Options{Token: "token", Store: state.NewStore(state.Snapshot{}), Runtime: fake})
+			recorder := httptest.NewRecorder()
+			server.Handler().ServeHTTP(recorder, authorizedRequest(http.MethodPost, "/v1/core/install", bytes.NewBufferString(test.body)))
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+			}
+			if fake.operation.Source != test.want {
+				t.Fatalf("source=%q want %q", fake.operation.Source, test.want)
+			}
+		})
+	}
+}

--- a/internal/core/install.go
+++ b/internal/core/install.go
@@ -113,7 +113,7 @@ func (c *Candidate) Cleanup() {
 
 func (i Installer) Prepare(ctx context.Context, request InstallRequest) (PreparedCore, error) {
 	checkCtx, cancel := context.WithTimeout(ctx, i.checkTimeout())
-	release, err := i.latestRelease(checkCtx)
+	release, err := i.LatestRelease(checkCtx)
 	cancel()
 	if err != nil {
 		return nil, withAIOHint(err)
@@ -148,7 +148,7 @@ func (i Installer) Prepare(ctx context.Context, request InstallRequest) (Prepare
 	archivePath := archive.Name()
 	archive.Close()
 	defer os.Remove(archivePath)
-	if err := i.download(ctx, asset, archivePath); err != nil {
+	if err := i.Download(ctx, asset, archivePath); err != nil {
 		return nil, err
 	}
 
@@ -185,7 +185,10 @@ func (i Installer) Prepare(ctx context.Context, request InstallRequest) (Prepare
 	return &Candidate{path: candidatePath, binaryPath: request.BinaryPath, version: release.TagName, updated: true}, nil
 }
 
-func (i Installer) download(ctx context.Context, asset Asset, destination string) error {
+// Download 取 asset 并落盘到 destination，校验 asset.Digest 的 sha256:<hex>
+// （bundler 复用入口，design §4.1 export 边界；绝不照 self.go 复刻——其无 Digest 校验）。
+// 以 O_WRONLY|O_TRUNC 写入：调用方需先落盘目标文件（与 Prepare 内 CreateTemp 同契约）。
+func (i Installer) Download(ctx context.Context, asset Asset, destination string) error {
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, asset.URL, nil)
 	if err != nil {
 		return protocol.APIError{Code: protocol.CodeInternal, Message: "create core download request"}

--- a/internal/core/install.go
+++ b/internal/core/install.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"io"
 	"net/http"
 	"os"
@@ -24,12 +25,13 @@ const (
 )
 
 type Installer struct {
-	HTTPClient *http.Client
-	APIBase    string
-	Repository string
-	GOOS       string
-	GOARCH     string
-	Runner     CommandRunner
+	HTTPClient   *http.Client
+	APIBase      string
+	Repository   string
+	GOOS         string
+	GOARCH       string
+	Runner       CommandRunner
+	CheckTimeout time.Duration // 包住"检查最新版"请求，默认 8s；下载仍用 httpClient 超时（design §4.3）
 }
 
 type InstallRequest struct {
@@ -110,13 +112,23 @@ func (c *Candidate) Cleanup() {
 }
 
 func (i Installer) Prepare(ctx context.Context, request InstallRequest) (PreparedCore, error) {
-	release, err := i.latestRelease(ctx)
+	checkCtx, cancel := context.WithTimeout(ctx, i.checkTimeout())
+	release, err := i.latestRelease(checkCtx)
+	cancel()
 	if err != nil {
-		return nil, err
+		return nil, withAIOHint(err)
 	}
 	if request.CurrentVersion == release.TagName {
-		if info, err := os.Stat(request.BinaryPath); err == nil && !info.IsDir() {
-			return &Candidate{binaryPath: request.BinaryPath, version: release.TagName, updated: false}, nil
+		if info, statErr := os.Stat(request.BinaryPath); statErr == nil && !info.IsDir() {
+			// 文件存在还要 -v 成功才短路；判据复用 DetectVersion（含 ParseVersion 版本格式校验）
+			// ——design §4.3，与 Manager.Install setup 预检同一判据、DRY。-v 失败 → 走下载修复。
+			runner := i.Runner
+			if runner == nil {
+				runner = OSCommandRunner{}
+			}
+			if version, vErr := DetectVersion(ctx, runner, request.BinaryPath); vErr == nil && version != "" {
+				return &Candidate{binaryPath: request.BinaryPath, version: release.TagName, updated: false}, nil
+			}
 		}
 	}
 	asset, err := SelectAsset(release, i.targetOS(), i.targetArch())
@@ -296,6 +308,24 @@ func (i Installer) httpClient() *http.Client {
 		return i.HTTPClient
 	}
 	return &http.Client{Timeout: 15 * time.Minute}
+}
+
+// checkTimeout 返回"检查最新版"请求的超时（默认 8s）；下载仍用 httpClient 的 15min 超时（design §4.3）。
+func (i Installer) checkTimeout() time.Duration {
+	if i.CheckTimeout > 0 {
+		return i.CheckTimeout
+	}
+	return 8 * time.Second
+}
+
+// withAIOHint 给网络类失败的错误信息追加 aio 离线安装脚本引导（design §6 错误处理）。
+func withAIOHint(err error) error {
+	var apiError protocol.APIError
+	if errors.As(err, &apiError) && apiError.Code == protocol.CodeNetworkFailure {
+		apiError.Message += "；若处于无网/受限网络环境，请使用 all-in-one 安装脚本（install-aio-remote.sh / .ps1）离线安装"
+		return apiError
+	}
+	return err
 }
 
 func (i Installer) apiBase() string {

--- a/internal/core/install.go
+++ b/internal/core/install.go
@@ -54,6 +54,17 @@ func (i Installer) Install(ctx context.Context, request InstallRequest) (Install
 	return candidate.Commit()
 }
 
+// DetectVersion 报告现有核心二进制的版本（运行 mihomo -v）。供 runtime 侧 setup 本地预检
+// 复用，避免在 runtime.Manager 里另持 Runner；判据复用 DetectVersion（含 ParseVersion 版本
+// 格式校验），与 Prepare 的同版本短路同一判据、DRY（design §4.3 实现位置）。
+func (i Installer) DetectVersion(ctx context.Context, binaryPath string) (string, error) {
+	runner := i.Runner
+	if runner == nil {
+		runner = OSCommandRunner{}
+	}
+	return DetectVersion(ctx, runner, binaryPath)
+}
+
 type Candidate struct {
 	path       string
 	binaryPath string

--- a/internal/core/install_test.go
+++ b/internal/core/install_test.go
@@ -5,6 +5,8 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -472,4 +474,57 @@ func slowReleaseServer(t *testing.T, assetName string, archive []byte, delay tim
 		}
 	}))
 	return server
+}
+
+func TestLatestReleaseExport(t *testing.T) {
+	archive := gzipFixture(t, []byte("payload"))
+	server := releaseFixture(t, "mihomo-linux-amd64-compatible-v1.19.0.gz", archive)
+	defer server.Close()
+	installer := Installer{HTTPClient: server.Client(), APIBase: server.URL, Repository: "MetaCubeX/mihomo"}
+	release, err := installer.LatestRelease(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if release.TagName != "v1.19.0" || len(release.Assets) != 1 {
+		t.Fatalf("release=%#v", release)
+	}
+	if release.Assets[0].Name != "mihomo-linux-amd64-compatible-v1.19.0.gz" {
+		t.Fatalf("asset=%#v", release.Assets[0])
+	}
+}
+
+// TestDownloadExportVerifiesSha256Digest 断言导出的 Download 与原 unexported download 行为
+// 一致：落盘字节 + asset.Digest 的 sha256:<hex> 校验。这是 bundler（Task 8）复用、绝不绕过
+// 校验的契约（design §4.1）。Download 以 O_WRONLY|O_TRUNC 写入，调用方需先落盘目标文件——
+// 与 Prepare 内 CreateTemp 同契约；bundler 自管 staging（design §4.1「解压归 bundler 自管」）。
+func TestDownloadExportVerifiesSha256Digest(t *testing.T) {
+	payload := []byte("the-core-binary")
+	sum := sha256.Sum256(payload)
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		_, _ = response.Write(payload)
+	}))
+	defer server.Close()
+	installer := Installer{HTTPClient: server.Client()}
+	dest := filepath.Join(t.TempDir(), "mihomo.gz")
+	if err := os.WriteFile(dest, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	asset := Asset{
+		Name: "mihomo-linux-amd64-v1.19.0.gz", URL: server.URL,
+		Size: int64(len(payload)), Digest: "sha256:" + hex.EncodeToString(sum[:]),
+	}
+	if err := installer.Download(context.Background(), asset, dest); err != nil {
+		t.Fatalf("download err=%v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil || !bytes.Equal(got, payload) {
+		t.Fatalf("dest=%q err=%v", got, err)
+	}
+
+	// 摘要不一致必须失败——证明 export 后 Download 仍带 sha256 校验。
+	tampered := asset
+	tampered.Digest = "sha256:" + strings.Repeat("0", 64)
+	if err := installer.Download(context.Background(), tampered, dest); err == nil {
+		t.Fatal("expected digest mismatch error, got nil")
+	}
 }

--- a/internal/core/install_test.go
+++ b/internal/core/install_test.go
@@ -224,3 +224,24 @@ func zipFixture(t *testing.T, content []byte) []byte {
 	}
 	return archive.Bytes()
 }
+
+func TestInstallerDetectVersionReportsExistingBinary(t *testing.T) {
+	runner := &recordingRunner{output: []byte("Mihomo Meta v1.18.2")}
+	version, err := Installer{Runner: runner}.DetectVersion(context.Background(), "mihomo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version != "v1.18.2" {
+		t.Fatalf("version=%q", version)
+	}
+	if len(runner.args) != 1 || runner.args[0] != "-v" {
+		t.Fatalf("args=%q", runner.args)
+	}
+
+	failing := &recordingRunner{err: errors.New("exec failed")}
+	_, err = Installer{Runner: failing}.DetectVersion(context.Background(), "mihomo")
+	var apiError protocol.APIError
+	if !errors.As(err, &apiError) || apiError.Code != protocol.CodeDataFailure {
+		t.Fatalf("err=%v", err)
+	}
+}

--- a/internal/core/install_test.go
+++ b/internal/core/install_test.go
@@ -11,7 +11,9 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/mihari-proxy/mihari/internal/control/protocol"
 )
@@ -244,4 +246,230 @@ func TestInstallerDetectVersionReportsExistingBinary(t *testing.T) {
 	if !errors.As(err, &apiError) || apiError.Code != protocol.CodeDataFailure {
 		t.Fatalf("err=%v", err)
 	}
+}
+
+func TestPrepare(t *testing.T) {
+	t.Run("API timeout with local binary fails fast with aio hint", func(t *testing.T) {
+		archive := gzipFixture(t, []byte("payload"))
+		server := slowReleaseServer(t, "mihomo-linux-amd64-compatible-v1.19.0.gz", archive, 150*time.Millisecond)
+		defer server.Close()
+		root := t.TempDir()
+		binaryPath := filepath.Join(root, "mihomo")
+		if err := os.WriteFile(binaryPath, []byte("existing"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		installer := Installer{
+			HTTPClient: server.Client(), APIBase: server.URL, Repository: "MetaCubeX/mihomo",
+			GOOS: "linux", GOARCH: "amd64", Runner: &recordingRunner{output: []byte("Mihomo Meta v1.19.0")},
+			CheckTimeout: 40 * time.Millisecond,
+		}
+		start := time.Now()
+		_, err := installer.Prepare(context.Background(), InstallRequest{
+			BinaryPath: binaryPath, CurrentVersion: "v1.19.0",
+			DataDir: root, ConfigPath: filepath.Join(root, "config.yaml"), StagingDir: filepath.Join(root, "staging"),
+		})
+		if elapsed := time.Since(start); elapsed >= time.Second {
+			t.Fatalf("Prepare did not fail fast: elapsed=%v", elapsed)
+		}
+		var apiError protocol.APIError
+		if !errors.As(err, &apiError) || apiError.Code != protocol.CodeNetworkFailure {
+			t.Fatalf("err=%v", err)
+		}
+		if !strings.Contains(apiError.Message, "install-aio-remote") {
+			t.Fatalf("message=%q missing aio hint", apiError.Message)
+		}
+	})
+
+	t.Run("same version with valid local binary short-circuits", func(t *testing.T) {
+		server := releaseFixture(t, "mihomo-linux-amd64-compatible-v1.19.0.gz", gzipFixture(t, []byte("new-binary")))
+		defer server.Close()
+		root := t.TempDir()
+		binaryPath := filepath.Join(root, "mihomo")
+		if err := os.WriteFile(binaryPath, []byte("existing-valid"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		installer := Installer{
+			HTTPClient: server.Client(), APIBase: server.URL, Repository: "MetaCubeX/mihomo",
+			GOOS: "linux", GOARCH: "amd64", Runner: &recordingRunner{output: []byte("Mihomo Meta v1.19.0")},
+		}
+		candidate, err := installer.Prepare(context.Background(), InstallRequest{
+			BinaryPath: binaryPath, CurrentVersion: "v1.19.0",
+			DataDir: root, ConfigPath: filepath.Join(root, "config.yaml"), StagingDir: filepath.Join(root, "staging"),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer candidate.Cleanup()
+		if candidate.Updated() {
+			t.Fatal("expected short-circuit, got updated candidate")
+		}
+		if got, _ := os.ReadFile(binaryPath); string(got) != "existing-valid" {
+			t.Fatalf("binary changed=%q (download should not happen)", got)
+		}
+	})
+
+	t.Run("same version with failing dash-v downloads repair", func(t *testing.T) {
+		server := releaseFixture(t, "mihomo-linux-amd64-compatible-v1.19.0.gz", gzipFixture(t, []byte("fresh-binary")))
+		defer server.Close()
+		root := t.TempDir()
+		binaryPath := filepath.Join(root, "mihomo")
+		if err := os.WriteFile(binaryPath, []byte("corrupt"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		installer := Installer{
+			HTTPClient: server.Client(), APIBase: server.URL, Repository: "MetaCubeX/mihomo",
+			GOOS: "linux", GOARCH: "amd64",
+			Runner: &selectiveRunner{existingPath: binaryPath, output: []byte("Mihomo Meta v1.19.0")},
+		}
+		candidate, err := installer.Prepare(context.Background(), InstallRequest{
+			BinaryPath: binaryPath, CurrentVersion: "v1.19.0",
+			DataDir: root, ConfigPath: filepath.Join(root, "config.yaml"), StagingDir: filepath.Join(root, "staging"),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer candidate.Cleanup()
+		if !candidate.Updated() {
+			t.Fatalf("expected download repair, got unmodified candidate")
+		}
+	})
+
+	t.Run("same version with unparseable dash-v downloads repair", func(t *testing.T) {
+		server := releaseFixture(t, "mihomo-linux-amd64-compatible-v1.19.0.gz", gzipFixture(t, []byte("fresh-binary")))
+		defer server.Close()
+		root := t.TempDir()
+		binaryPath := filepath.Join(root, "mihomo")
+		if err := os.WriteFile(binaryPath, []byte("weird"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		installer := Installer{
+			HTTPClient: server.Client(), APIBase: server.URL, Repository: "MetaCubeX/mihomo",
+			GOOS: "linux", GOARCH: "amd64",
+			Runner: &selectiveRunner{existingPath: binaryPath, existingOut: []byte("not-a-version"), output: []byte("Mihomo Meta v1.19.0")},
+		}
+		candidate, err := installer.Prepare(context.Background(), InstallRequest{
+			BinaryPath: binaryPath, CurrentVersion: "v1.19.0",
+			DataDir: root, ConfigPath: filepath.Join(root, "config.yaml"), StagingDir: filepath.Join(root, "staging"),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer candidate.Cleanup()
+		if !candidate.Updated() {
+			t.Fatalf("expected download repair, got unmodified candidate")
+		}
+	})
+
+	t.Run("new version downloads update", func(t *testing.T) {
+		server := releaseFixture(t, "mihomo-linux-amd64-compatible-v1.19.0.gz", gzipFixture(t, []byte("new-mihomo")))
+		defer server.Close()
+		root := t.TempDir()
+		binaryPath := filepath.Join(root, "mihomo")
+		if err := os.WriteFile(binaryPath, []byte("old"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		installer := Installer{
+			HTTPClient: server.Client(), APIBase: server.URL, Repository: "MetaCubeX/mihomo",
+			GOOS: "linux", GOARCH: "amd64", Runner: &recordingRunner{output: []byte("Mihomo Meta v1.19.0")},
+		}
+		candidate, err := installer.Prepare(context.Background(), InstallRequest{
+			BinaryPath: binaryPath, CurrentVersion: "v1.18.0",
+			DataDir: root, ConfigPath: filepath.Join(root, "config.yaml"), StagingDir: filepath.Join(root, "staging"),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer candidate.Cleanup()
+		if !candidate.Updated() {
+			t.Fatalf("expected update, got unmodified candidate")
+		}
+	})
+
+	t.Run("corrupt local binary and API 500 fails with aio hint", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+			response.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+		root := t.TempDir()
+		binaryPath := filepath.Join(root, "mihomo")
+		if err := os.WriteFile(binaryPath, []byte("corrupt"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		installer := Installer{
+			HTTPClient: server.Client(), APIBase: server.URL, Repository: "MetaCubeX/mihomo",
+			GOOS: "linux", GOARCH: "amd64",
+			Runner: &selectiveRunner{existingPath: binaryPath, output: []byte("Mihomo Meta v1.19.0")},
+		}
+		_, err := installer.Prepare(context.Background(), InstallRequest{
+			BinaryPath: binaryPath, CurrentVersion: "v1.19.0",
+			DataDir: root, ConfigPath: filepath.Join(root, "config.yaml"), StagingDir: filepath.Join(root, "staging"),
+		})
+		var apiError protocol.APIError
+		if !errors.As(err, &apiError) || apiError.Code != protocol.CodeNetworkFailure {
+			t.Fatalf("err=%v", err)
+		}
+		if !strings.Contains(apiError.Message, "install-aio-remote") {
+			t.Fatalf("message=%q missing aio hint", apiError.Message)
+		}
+	})
+
+	t.Run("no local binary and API timeout fails fast", func(t *testing.T) {
+		archive := gzipFixture(t, []byte("payload"))
+		server := slowReleaseServer(t, "mihomo-linux-amd64-compatible-v1.19.0.gz", archive, 150*time.Millisecond)
+		defer server.Close()
+		root := t.TempDir()
+		installer := Installer{
+			HTTPClient: server.Client(), APIBase: server.URL, Repository: "MetaCubeX/mihomo",
+			GOOS: "linux", GOARCH: "amd64", Runner: &recordingRunner{output: []byte("Mihomo Meta v1.19.0")},
+			CheckTimeout: 40 * time.Millisecond,
+		}
+		start := time.Now()
+		_, err := installer.Prepare(context.Background(), InstallRequest{
+			BinaryPath: filepath.Join(root, "missing"), CurrentVersion: "v1.18.0",
+			DataDir: root, ConfigPath: filepath.Join(root, "config.yaml"), StagingDir: filepath.Join(root, "staging"),
+		})
+		if elapsed := time.Since(start); elapsed >= time.Second {
+			t.Fatalf("Prepare did not fail fast: elapsed=%v", elapsed)
+		}
+		var apiError protocol.APIError
+		if !errors.As(err, &apiError) || apiError.Code != protocol.CodeNetworkFailure {
+			t.Fatalf("err=%v", err)
+		}
+	})
+}
+
+// selectiveRunner mimics a broken/odd existing binary (existingPath) while
+// serving a valid candidate response for any other path (downloaded candidate,
+// config validation). existingOut nil → running existingPath errors.
+type selectiveRunner struct {
+	existingPath string
+	existingOut  []byte
+	output       []byte
+}
+
+func (r *selectiveRunner) Run(_ context.Context, name string, _ ...string) ([]byte, error) {
+	if name == r.existingPath {
+		if r.existingOut == nil {
+			return nil, errors.New("existing binary broken")
+		}
+		return r.existingOut, nil
+	}
+	return r.output, nil
+}
+
+func slowReleaseServer(t *testing.T, assetName string, archive []byte, delay time.Duration) *httptest.Server {
+	t.Helper()
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		time.Sleep(delay)
+		switch request.URL.Path {
+		case "/repos/MetaCubeX/mihomo/releases/latest":
+			_ = json.NewEncoder(response).Encode(Release{TagName: "v1.19.0", Assets: []Asset{{Name: assetName, URL: server.URL + "/asset", Size: int64(len(archive))}}})
+		case "/asset":
+			_, _ = response.Write(archive)
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	return server
 }

--- a/internal/core/release.go
+++ b/internal/core/release.go
@@ -24,7 +24,8 @@ type Release struct {
 	Assets  []Asset `json:"assets"`
 }
 
-func (i Installer) latestRelease(ctx context.Context) (Release, error) {
+// LatestRelease 取 mihomo 最新 release（bundler 复用入口，design §4.1 export 边界）。
+func (i Installer) LatestRelease(ctx context.Context) (Release, error) {
 	var release Release
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(i.apiBase(), "/")+"/repos/"+i.repository()+"/releases/latest", nil)
 	if err != nil {

--- a/internal/runtime/geoip.go
+++ b/internal/runtime/geoip.go
@@ -52,6 +52,13 @@ func (m *Manager) LookupGeoIP(_ context.Context, addresses []netip.Addr) ([]geoi
 // UpdateGeoIP prepares outside the mutation gate and commits under revision control.
 func (m *Manager) UpdateGeoIP(ctx context.Context, operation Operation) (geoip.Status, error) {
 	result, err := m.doOperation(ctx, "geoip:"+operation.ID, func() (any, error) {
+		// setup 预检（design §4.3）：aio 脚本已预置 GeoIP 且本地 MMDB 有效时直接返回，不联网下载。
+		if operation.Source == "setup" && m.geoip != nil {
+			if status := m.geoip.Status(); status.Country.Available && status.ASN.Available {
+				return status, nil
+			}
+			// 无效 → 落联网下载。
+		}
 		if m.geoip == nil || m.prepareGeoIP == nil {
 			return nil, protocol.APIError{Code: protocol.CodeInvalidState, Message: "geoip updater is unavailable"}
 		}

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -24,6 +24,7 @@ type PreparedCore = core.PreparedCore
 
 type CoreInstaller interface {
 	Prepare(context.Context, core.InstallRequest) (core.PreparedCore, error)
+	DetectVersion(context.Context, string) (string, error)
 }
 
 type CoreSupervisor interface {

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -368,6 +368,14 @@ func (m *Manager) Install(ctx context.Context, operation Operation) (core.Instal
 		}
 		installRequest := m.installRequest
 		installRequest.CurrentVersion = m.store.Load().Core.Version
+		// setup 预检（design §4.3）：aio 脚本已预置核心时，对现有文件 -v 成功即秒过，不联网。
+		// store.Core.Version 不作判据（DetectVersion 失败时旧值残留，见 runtime.go 启动检测）。
+		if operation.Source == "setup" {
+			if version, detectErr := m.installer.DetectVersion(ctx, installRequest.BinaryPath); detectErr == nil && version != "" {
+				return core.InstallResult{Version: version, Updated: false}, nil
+			}
+			// -v 失败（缺失/损坏）→ 落 Prepare 联网修复（失败由 Prepare 报错并提示 aio 脚本）。
+		}
 		candidate, err := m.installer.Prepare(ctx, installRequest)
 		if err != nil {
 			return nil, err

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -629,3 +629,75 @@ func waitManager(t *testing.T, done <-chan error) error {
 		return nil
 	}
 }
+
+func TestManagerInstallSetupSkipsNetworkWhenLocalCoreValid(t *testing.T) {
+	installer := &fakeInstaller{}
+	installer.detectVersion = func(context.Context, string) (string, error) {
+		return "v1.18.0", nil
+	}
+	installer.prepare = func(context.Context, core.InstallRequest) (PreparedCore, error) {
+		t.Fatal("Prepare must not be called when setup local core is valid")
+		return nil, nil
+	}
+	manager := newTestManager(Options{Installer: installer})
+	manager.installRequest.BinaryPath = "mihomo"
+
+	result, err := manager.Install(context.Background(), Operation{ID: "setup-valid", Source: "setup"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Version != "v1.18.0" || result.Updated {
+		t.Fatalf("result=%#v", result)
+	}
+	if got := installer.calls.Load(); got != 0 {
+		t.Fatalf("prepare calls=%d (setup must skip network)", got)
+	}
+	if got := installer.detectCalls.Load(); got != 1 {
+		t.Fatalf("detect calls=%d", got)
+	}
+}
+
+func TestManagerInstallSetupFallsBackToPrepareWhenLocalCoreInvalid(t *testing.T) {
+	installer := &fakeInstaller{candidate: &fakeCandidate{version: "v1.19.0"}}
+	installer.detectVersion = func(context.Context, string) (string, error) {
+		return "", errors.New("binary missing or corrupt")
+	}
+	prepareCalled := false
+	installer.prepare = func(_ context.Context, _ core.InstallRequest) (PreparedCore, error) {
+		prepareCalled = true
+		return installer.candidate, nil
+	}
+	manager := newTestManager(Options{Installer: installer, Supervisor: &fakeSupervisor{}})
+	manager.installRequest.BinaryPath = "mihomo"
+
+	result, err := manager.Install(context.Background(), Operation{ID: "setup-invalid", Source: "setup"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Version != "v1.19.0" {
+		t.Fatalf("result=%#v", result)
+	}
+	if !prepareCalled {
+		t.Fatal("Prepare must run when local core is invalid")
+	}
+	if got := installer.detectCalls.Load(); got != 1 {
+		t.Fatalf("detect calls=%d (DetectVersion must run before fallback)", got)
+	}
+}
+
+func TestManagerInstallControlDoesNotShortCircuit(t *testing.T) {
+	installer := &fakeInstaller{candidate: &fakeCandidate{version: "v1.19.0", notUpdated: true}}
+	installer.detectVersion = func(context.Context, string) (string, error) { return "v1.18.0", nil }
+	manager := newTestManager(Options{Installer: installer, Supervisor: &fakeSupervisor{}})
+	manager.installRequest.BinaryPath = "mihomo"
+
+	if _, err := manager.Install(context.Background(), Operation{ID: "control-install", Source: "control"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := installer.detectCalls.Load(); got != 0 {
+		t.Fatalf("detect calls=%d (must be 0 for control source)", got)
+	}
+	if got := installer.calls.Load(); got != 1 {
+		t.Fatalf("prepare calls=%d (must be 1 for control source)", got)
+	}
+}

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -189,9 +189,15 @@ func (c *fakeGeoIPCandidate) Valid() bool      { return c.valid }
 func (c *fakeGeoIPCandidate) Commit() error    { c.commits++; return c.commitErr }
 func (c *fakeGeoIPCandidate) Cleanup()         { c.cleanups++ }
 
-type fakeGeoIPService struct{ recordedError bool }
+type fakeGeoIPService struct {
+	statusFunc    func() geoip.Status
+	recordedError bool
+}
 
-func (*fakeGeoIPService) Status() geoip.Status {
+func (s *fakeGeoIPService) Status() geoip.Status {
+	if s.statusFunc != nil {
+		return s.statusFunc()
+	}
 	return geoip.Status{Country: geoip.DatabaseStatus{Available: true}, ASN: geoip.DatabaseStatus{Available: true}}
 }
 func (*fakeGeoIPService) Lookup(netip.Addr) (geoip.Record, error) { return geoip.Record{}, nil }
@@ -699,5 +705,67 @@ func TestManagerInstallControlDoesNotShortCircuit(t *testing.T) {
 	}
 	if got := installer.calls.Load(); got != 1 {
 		t.Fatalf("prepare calls=%d (must be 1 for control source)", got)
+	}
+}
+
+func TestUpdateGeoIPSetupSkipsNetworkWhenMMDBValid(t *testing.T) {
+	service := &fakeGeoIPService{} // default: Country+ASN Available
+	var prepareCalls atomic.Int64
+	manager := newTestManager(Options{
+		GeoIP: service,
+		PrepareGeoIP: func(context.Context) (GeoIPCandidate, error) {
+			prepareCalls.Add(1)
+			return nil, errors.New("prepareGeoIP must not be called when setup MMDB is valid")
+		},
+	})
+	status, err := manager.UpdateGeoIP(context.Background(), Operation{ID: "setup-valid", Source: "setup"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !status.Country.Available || !status.ASN.Available {
+		t.Fatalf("status=%#v", status)
+	}
+	if got := prepareCalls.Load(); got != 0 {
+		t.Fatalf("prepareGeoIP calls=%d (setup must skip network)", got)
+	}
+}
+
+func TestUpdateGeoIPSetupFallsBackToNetworkWhenMMDBInvalid(t *testing.T) {
+	service := &fakeGeoIPService{statusFunc: func() geoip.Status {
+		return geoip.Status{Country: geoip.DatabaseStatus{Available: true}, ASN: geoip.DatabaseStatus{Available: false}}
+	}}
+	prepared := &fakeGeoIPCandidate{valid: true, identity: "fresh-pair"}
+	var prepareCalls atomic.Int64
+	manager := newTestManager(Options{
+		GeoIP: service,
+		PrepareGeoIP: func(context.Context) (GeoIPCandidate, error) {
+			prepareCalls.Add(1)
+			return prepared, nil
+		},
+	})
+	if _, err := manager.UpdateGeoIP(context.Background(), Operation{ID: "setup-invalid", Source: "setup"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := prepareCalls.Load(); got != 1 {
+		t.Fatalf("prepareGeoIP calls=%d (must download when MMDB invalid)", got)
+	}
+}
+
+func TestUpdateGeoIPControlDoesNotShortCircuit(t *testing.T) {
+	service := &fakeGeoIPService{} // both Available — would short-circuit if source were setup
+	prepared := &fakeGeoIPCandidate{valid: true, identity: "control-pair"}
+	var prepareCalls atomic.Int64
+	manager := newTestManager(Options{
+		GeoIP: service,
+		PrepareGeoIP: func(context.Context) (GeoIPCandidate, error) {
+			prepareCalls.Add(1)
+			return prepared, nil
+		},
+	})
+	if _, err := manager.UpdateGeoIP(context.Background(), Operation{ID: "control-geoip", Source: "control"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := prepareCalls.Load(); got != 1 {
+		t.Fatalf("prepareGeoIP calls=%d (control must always download)", got)
 	}
 }

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -460,9 +460,11 @@ func newTestManager(options Options) *Manager {
 }
 
 type fakeInstaller struct {
-	calls     atomic.Int64
-	candidate PreparedCore
-	prepare   func(context.Context, core.InstallRequest) (PreparedCore, error)
+	calls         atomic.Int64
+	detectCalls   atomic.Int64
+	candidate     PreparedCore
+	prepare       func(context.Context, core.InstallRequest) (PreparedCore, error)
+	detectVersion func(context.Context, string) (string, error)
 }
 
 func (i *fakeInstaller) Prepare(ctx context.Context, request core.InstallRequest) (PreparedCore, error) {
@@ -471,6 +473,14 @@ func (i *fakeInstaller) Prepare(ctx context.Context, request core.InstallRequest
 		return i.prepare(ctx, request)
 	}
 	return i.candidate, nil
+}
+
+func (i *fakeInstaller) DetectVersion(ctx context.Context, binaryPath string) (string, error) {
+	i.detectCalls.Add(1)
+	if i.detectVersion != nil {
+		return i.detectVersion(ctx, binaryPath)
+	}
+	return "", nil
 }
 
 type fakeCandidate struct {

--- a/internal/tui/pages/setup/model.go
+++ b/internal/tui/pages/setup/model.go
@@ -416,7 +416,7 @@ func (m *Model) endpointsChanged() bool {
 func (m *Model) installCore() tea.Cmd {
 	revision, operationID := m.status.Revision, m.newOperationID()
 	return func() tea.Msg {
-		result, err := m.client.InstallCore(m.ctx, protocol.MutationRequest{OperationID: operationID, IfRevision: &revision})
+		result, err := m.client.InstallCore(m.ctx, protocol.MutationRequest{OperationID: operationID, IfRevision: &revision, Source: "setup"})
 		return actionResultMsg{next: stepSubscription, revision: result.Revision, err: err}
 	}
 }
@@ -432,7 +432,7 @@ func (m *Model) addSubscription(name, url string) tea.Cmd {
 func (m *Model) updateGeoIP() tea.Cmd {
 	revision, operationID := m.status.Revision, m.newOperationID()
 	return func() tea.Msg {
-		result, err := m.client.UpdateGeoIP(m.ctx, protocol.MutationRequest{OperationID: operationID, IfRevision: &revision})
+		result, err := m.client.UpdateGeoIP(m.ctx, protocol.MutationRequest{OperationID: operationID, IfRevision: &revision, Source: "setup"})
 		return actionResultMsg{next: stepReview, revision: result.Revision, err: err}
 	}
 }

--- a/internal/tui/pages/setup/model_test.go
+++ b/internal/tui/pages/setup/model_test.go
@@ -14,8 +14,10 @@ import (
 type fakeClient struct {
 	status          protocol.OnboardingStatus
 	installCalls    int
+	installRequest  protocol.MutationRequest
 	addCalls        int
 	geoIPCalls      int
+	geoIPRequest    protocol.MutationRequest
 	updateCalls     int
 	update          protocol.OnboardingUpdateRequest
 	onboardingCalls int
@@ -26,8 +28,9 @@ func (f *fakeClient) Onboarding(context.Context) (protocol.OnboardingStatus, err
 	f.onboardingCalls++
 	return f.status, nil
 }
-func (f *fakeClient) InstallCore(ctx context.Context, _ protocol.MutationRequest) (protocol.CoreInstallResult, error) {
+func (f *fakeClient) InstallCore(ctx context.Context, request protocol.MutationRequest) (protocol.CoreInstallResult, error) {
 	f.installCalls++
+	f.installRequest = request
 	if f.installErr != nil {
 		return protocol.CoreInstallResult{}, f.installErr
 	}
@@ -40,8 +43,9 @@ func (f *fakeClient) AddSubscription(context.Context, protocol.SubscriptionAddRe
 	f.addCalls++
 	return protocol.SubscriptionResult{Schema: "mihari/v1", Revision: f.status.Revision + 1}, nil
 }
-func (f *fakeClient) UpdateGeoIP(context.Context, protocol.MutationRequest) (protocol.GeoIPUpdateResult, error) {
+func (f *fakeClient) UpdateGeoIP(_ context.Context, request protocol.MutationRequest) (protocol.GeoIPUpdateResult, error) {
 	f.geoIPCalls++
+	f.geoIPRequest = request
 	return protocol.GeoIPUpdateResult{Schema: "mihari/v1", Revision: f.status.Revision + 1}, nil
 }
 func (f *fakeClient) UpdateOnboarding(_ context.Context, request protocol.OnboardingUpdateRequest) (protocol.OnboardingStatus, error) {
@@ -305,4 +309,19 @@ func runKeyCommand(t *testing.T, model *Model, key tea.KeyPressMsg) *Model {
 	}
 	updated, _ = model.Update(command())
 	return updated.(*Model)
+}
+
+func TestSetupCoreAndGeoIPRequestsCarrySetupSource(t *testing.T) {
+	client := &fakeClient{status: defaultStatus(false)}
+	model := loadedModel(client)
+
+	_ = model.installCore()()
+	if client.installRequest.Source != "setup" {
+		t.Fatalf("install source=%q want setup", client.installRequest.Source)
+	}
+
+	_ = model.updateGeoIP()()
+	if client.geoIPRequest.Source != "setup" {
+		t.Fatalf("geoip source=%q want setup", client.geoIPRequest.Source)
+	}
 }

--- a/scripts/alist_client.py
+++ b/scripts/alist_client.py
@@ -1,0 +1,150 @@
+"""Shared AList v3 client + helpers for the release/retract workflows.
+
+Both scripts/release-alist.py (publish) and scripts/retract-alist.py
+(withdraw) talk to the same self-hosted AList drive via the v3 REST API
+(login / fs/get / fs/list / fs/put / fs/remove / fs/mkdir) and share the
+same notion of a version directory, bundle names, and semver ordering.
+Centralizing the client keeps the two flows consistent and avoids drifting
+two copies of the API surface.
+"""
+import hashlib
+import os
+import re
+import sys
+from pathlib import Path
+from urllib.parse import quote
+
+import requests
+
+DEFAULT_BASE_PATH = "/mihari"
+DEFAULT_KEEP_VERSIONS = 5
+PLATFORMS = [
+    "linux/amd64", "linux/arm64",
+    "darwin/amd64", "darwin/arm64",
+    "windows/amd64", "windows/arm64",
+]
+SEMVER_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+INDEX_PLACEHOLDER = "__MIHARI_INDEX_URL__"
+
+
+def fail(message):
+    print(f"::error::{message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def info(message):
+    print(f"::notice::{message}")
+
+
+def semver_key(name):
+    match = SEMVER_RE.match(name)
+    return tuple(int(x) for x in match.groups()) if match else None
+
+
+def sha256_file(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def bundle_name(goos, goarch):
+    ext = ".zip" if goos == "windows" else ".tar.gz"
+    return f"mihari-all-in-one-{goos}-{goarch}{ext}"
+
+
+class AList:
+    """Thin client over the AList v3 REST API."""
+
+    def __init__(self, base_url, username, password):
+        self.base = base_url.rstrip("/")
+        self.session = requests.Session()
+        token = self._login(username, password)
+        self.session.headers["Authorization"] = token
+
+    def _post(self, path, **kwargs):
+        response = self.session.post(self.base + path, timeout=120, **kwargs)
+        response.raise_for_status()
+        return response.json()
+
+    def _login(self, username, password):
+        data = self._post("/api/auth/login", json={"username": username, "password": password})
+        if data.get("code") != 200:
+            fail(f"alist login failed: {data.get('message')}")
+        return data["data"]["token"]
+
+    def get(self, path):
+        return self._post("/api/fs/get", json={"path": path, "password": ""})
+
+    def exists(self, path):
+        return self.get(path).get("code") == 200
+
+    def sign_of(self, path):
+        data = self.get(path)
+        if data.get("code") != 200:
+            return None
+        return data["data"].get("sign", "")
+
+    def list_dir(self, path):
+        data = self._post("/api/fs/list", json={"path": path, "password": "", "page": 1, "per_page": 0, "refresh": False})
+        return data.get("data", {}).get("content") or []
+
+    def mkdir(self, path):
+        self._post("/api/fs/mkdir", json={"path": path})
+
+    def upload(self, local, remote_path):
+        with open(local, "rb") as handle:
+            response = self.session.put(
+                self.base + "/api/fs/put",
+                headers={
+                    "File-Path": quote(remote_path, safe=""),
+                    "As-Task": "false",
+                    "Content-Type": "application/octet-stream",
+                },
+                data=handle,
+                timeout=900,
+            )
+        response.raise_for_status()
+
+    def upload_text(self, text, remote_path):
+        response = self.session.put(
+            self.base + "/api/fs/put",
+            headers={
+                "File-Path": quote(remote_path, safe=""),
+                "As-Task": "false",
+                "Content-Type": "text/plain",
+            },
+            data=text.encode("utf-8"),
+            timeout=120,
+        )
+        response.raise_for_status()
+
+    def remove(self, dir_path, names):
+        self._post("/api/fs/remove", json={"dir": dir_path, "names": list(names)})
+
+    def content(self, path):
+        """Read a remote text file via its signed proxy route. Returns None when
+        the file does not exist (sign_of is None). Used by retract to read the
+        root index.txt and a version dir's SHA256SUMS.txt."""
+        sign = self.sign_of(path)
+        if sign is None:
+            return None
+        response = self.session.get(self.signed_url(path, sign), timeout=120)
+        response.raise_for_status()
+        return response.text
+
+    def signed_url(self, path, sign):
+        # /p<path>?sign=... is AList's proxy/stream route (design §4.4 URL form).
+        return f"{self.base}/p{path}?sign={sign}"
+
+
+def connect():
+    """Build an AList client from the standard ALIST_* environment variables,
+    failing loudly if any required one is missing."""
+    base_url = os.environ.get("ALIST_URL")
+    username = os.environ.get("ALIST_USERNAME")
+    password = os.environ.get("ALIST_PASSWORD")
+    if not base_url or not username or not password:
+        fail("ALIST_URL / ALIST_USERNAME / ALIST_PASSWORD are required")
+    return AList(base_url, username, password)

--- a/scripts/build-all-in-one/main.go
+++ b/scripts/build-all-in-one/main.go
@@ -402,16 +402,24 @@ func packStage(stage, out, goos, goarch string) error {
 	return tarStage(stage, filepath.Join(out, name+".tar.gz"))
 }
 
-func tarStage(stage, dest string) error {
+func tarStage(stage, dest string) (err error) {
 	out, err := os.Create(dest)
 	if err != nil {
 		return err
 	}
 	defer out.Close()
 	gzipWriter := gzip.NewWriter(out)
-	defer gzipWriter.Close()
+	defer func() {
+		if cerr := gzipWriter.Close(); err == nil {
+			err = cerr
+		}
+	}()
 	tarWriter := tar.NewWriter(gzipWriter)
-	defer tarWriter.Close()
+	defer func() {
+		if cerr := tarWriter.Close(); err == nil {
+			err = cerr
+		}
+	}()
 	return filepath.Walk(stage, func(path string, info os.FileInfo, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
@@ -437,14 +445,18 @@ func tarStage(stage, dest string) error {
 	})
 }
 
-func zipStage(stage, dest string) error {
+func zipStage(stage, dest string) (err error) {
 	out, err := os.Create(dest)
 	if err != nil {
 		return err
 	}
 	defer out.Close()
 	zipWriter := zip.NewWriter(out)
-	defer zipWriter.Close()
+	defer func() {
+		if cerr := zipWriter.Close(); err == nil {
+			err = cerr
+		}
+	}()
 	return filepath.Walk(stage, func(path string, info os.FileInfo, walkErr error) error {
 		if walkErr != nil {
 			return walkErr

--- a/scripts/build-all-in-one/main.go
+++ b/scripts/build-all-in-one/main.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -339,11 +340,14 @@ func writeAll(dest string, reader io.Reader, maxBytes int64) error {
 	return nil
 }
 
-// smokeMihomo runs `-v` for linux/amd64 (the only target the build host can
-// execute) and verifies the executable magic number for the other five
-// platforms — design §4.1 step 2.
+// smokeMihomo runs `-v` for the target matching the build host (the only target
+// the host can actually execute) and verifies the executable magic number for
+// the other platforms — design §4.1 step 2. Matching on runtime.GOOS/GOARCH
+// keeps the bundler runnable on any host (CI is linux/amd64, but local dev on
+// Windows/macOS now smokes its own platform instead of failing to exec a
+// foreign binary).
 func smokeMihomo(ctx context.Context, goos, goarch, path string, runner core.CommandRunner) error {
-	if goos == "linux" && goarch == "amd64" {
+	if goos == runtime.GOOS && goarch == runtime.GOARCH {
 		runner := runner
 		if runner == nil {
 			runner = core.OSCommandRunner{}

--- a/scripts/build-all-in-one/main.go
+++ b/scripts/build-all-in-one/main.go
@@ -1,0 +1,555 @@
+// Command build-all-in-one packs mihari + mihomo core + GeoIP×2 + the local
+// install-aio installer into per-platform all-in-one bundles for offline
+// distribution. It reuses the runtime core.LatestRelease/Download/SelectAsset
+// (mihomo) and geoip.Downloader (GeoIP, same checksum mechanism as the daemon);
+// extraction and smoke checks are bundler-local per design §4.1.
+package main
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/mihari-proxy/mihari/internal/core"
+	"github.com/mihari-proxy/mihari/internal/geoip"
+)
+
+var defaultPlatforms = []string{
+	"linux/amd64", "linux/arm64",
+	"darwin/amd64", "darwin/arm64",
+	"windows/amd64", "windows/arm64",
+}
+
+const maxMihomoBinary int64 = 256 << 20
+
+type options struct {
+	MihariDir   string // dist/ — CI cross-build artifacts (mihari-<os>-<arch>[.exe])
+	Out         string // bundles/
+	ScriptsDir  string // directory holding install-aio.sh / install-aio.ps1 (repo root in CI)
+	Platforms   []string
+	GitHubToken string // optional; adds Authorization: Bearer when set
+
+	// Test seams (zero-valued in production).
+	HTTPClient    *http.Client
+	APIBase       string // override GitHub API base
+	Repository    string // override "MetaCubeX/mihomo"
+	GeoIPBase     string // override GeoIP root (empty → geoip.Default*URL)
+	GeoIPValidate func(string) error
+	Runner        core.CommandRunner // linux/amd64 `-v` smoke; defaults to OSCommandRunner
+}
+
+func main() {
+	mihariDir := flag.String("mihari-dir", "dist", "directory with mihari-<os>-<arch>[.exe] build artifacts")
+	out := flag.String("out", "bundles", "output directory for all-in-one bundles")
+	platforms := flag.String("platforms", strings.Join(defaultPlatforms, ","), "comma-separated goos/goarch targets")
+	scriptsDir := flag.String("scripts-dir", ".", "directory holding install-aio.sh / install-aio.ps1")
+	token := flag.String("github-token", os.Getenv("GITHUB_TOKEN"), "GitHub API token (default $GITHUB_TOKEN)")
+	flag.Parse()
+
+	if err := run(options{
+		MihariDir: *mihariDir, Out: *out, ScriptsDir: *scriptsDir,
+		Platforms: splitPlatforms(*platforms), GitHubToken: *token,
+	}); err != nil {
+		fmt.Fprintln(os.Stderr, "build-all-in-one:", err)
+		os.Exit(1)
+	}
+}
+
+func run(o options) error {
+	if o.MihariDir == "" {
+		return errors.New("--mihari-dir is required")
+	}
+	if o.Out == "" {
+		return errors.New("--out is required")
+	}
+	if len(o.Platforms) == 0 {
+		o.Platforms = defaultPlatforms
+	}
+	if o.ScriptsDir == "" {
+		o.ScriptsDir = "."
+	}
+	if err := os.MkdirAll(o.Out, 0o755); err != nil {
+		return fmt.Errorf("create bundles directory: %w", err)
+	}
+	client := o.HTTPClient
+	if client == nil {
+		client = newClient(o.GitHubToken)
+	}
+	installer := core.Installer{HTTPClient: client, APIBase: o.APIBase, Repository: o.Repository, Runner: o.Runner}
+	ctx := context.Background()
+
+	// Exactly one mihomo API request returns every platform asset.
+	release, err := installer.LatestRelease(ctx)
+	if err != nil {
+		return fmt.Errorf("fetch mihomo release: %w", err)
+	}
+
+	// GeoIP×2 is shared across all platforms — download once.
+	geoipDir, err := os.MkdirTemp("", "aio-geoip-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(geoipDir)
+	countryPath, asnPath, err := downloadGeoIP(ctx, client, geoipDir, o)
+	if err != nil {
+		return fmt.Errorf("download geoip: %w", err)
+	}
+
+	for _, platform := range o.Platforms {
+		goos, goarch, err := splitPlatform(platform)
+		if err != nil {
+			return fmt.Errorf("platform %q: %w", platform, err)
+		}
+		if err := buildPlatform(ctx, installer, release, goos, goarch, o, countryPath, asnPath); err != nil {
+			return fmt.Errorf("build %s: %w", platform, err)
+		}
+	}
+	return nil
+}
+
+func buildPlatform(ctx context.Context, installer core.Installer, release core.Release, goos, goarch string, o options, countryPath, asnPath string) error {
+	stage, err := os.MkdirTemp("", "aio-stage-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(stage)
+
+	asset, err := core.SelectAsset(release, goos, goarch)
+	if err != nil {
+		return err
+	}
+	// core.Download opens the destination with O_WRONLY|O_TRUNC (no O_CREATE);
+	// create it first, mirroring Prepare's CreateTemp contract (Task 7).
+	archivePath := filepath.Join(stage, ".mihomo-archive")
+	stagedArchive, err := os.Create(archivePath)
+	if err != nil {
+		return err
+	}
+	if err := stagedArchive.Close(); err != nil {
+		return err
+	}
+	if err := installer.Download(ctx, asset, archivePath); err != nil {
+		return err
+	}
+	mihomoName := "mihomo"
+	if goos == "windows" {
+		mihomoName = "mihomo.exe"
+	}
+	mihomoDest := filepath.Join(stage, "data", "bin", mihomoName)
+	if err := extractMihomo(archivePath, asset.Name, mihomoDest); err != nil {
+		return err
+	}
+	if err := os.Remove(archivePath); err != nil {
+		return err
+	}
+	if err := smokeMihomo(ctx, goos, goarch, mihomoDest, o.Runner); err != nil {
+		return err
+	}
+
+	geoipDest := filepath.Join(stage, "data", "geoip")
+	if err := os.MkdirAll(geoipDest, 0o700); err != nil {
+		return err
+	}
+	if err := copyFile(countryPath, filepath.Join(geoipDest, "GeoLite2-Country.mmdb")); err != nil {
+		return err
+	}
+	if err := copyFile(asnPath, filepath.Join(geoipDest, "GeoLite2-ASN.mmdb")); err != nil {
+		return err
+	}
+
+	mihariName := "mihari"
+	if goos == "windows" {
+		mihariName = "mihari.exe"
+	}
+	if err := copyFile(distBinaryName(o.MihariDir, goos, goarch), filepath.Join(stage, mihariName)); err != nil {
+		return err
+	}
+
+	script := "install-aio.sh"
+	if goos == "windows" {
+		script = "install-aio.ps1"
+	}
+	if err := copyFile(filepath.Join(o.ScriptsDir, script), filepath.Join(stage, script)); err != nil {
+		return err
+	}
+
+	files, err := relativeFiles(stage)
+	if err != nil {
+		return err
+	}
+	if err := assertStage(goos, files); err != nil {
+		return err
+	}
+	return packStage(stage, o.Out, goos, goarch)
+}
+
+// downloadGeoIP fetches Country+ASN MMDB once with the same checksum-verified
+// mechanism as the runtime geoip.Service (geoip.Downloader + .sha256sum).
+func downloadGeoIP(ctx context.Context, client *http.Client, destDir string, o options) (country, asn string, err error) {
+	countryURL, countryChecksum := geoip.DefaultCountryURL, geoip.DefaultCountryChecksumURL
+	asnURL, asnChecksum := geoip.DefaultASNURL, geoip.DefaultASNChecksumURL
+	allowHTTP := false
+	if o.GeoIPBase != "" {
+		allowHTTP = true
+		root := strings.TrimRight(o.GeoIPBase, "/")
+		countryURL = root + "/GeoLite2-Country.mmdb"
+		countryChecksum = countryURL + ".sha256sum"
+		asnURL = root + "/GeoLite2-ASN.mmdb"
+		asnChecksum = asnURL + ".sha256sum"
+	}
+	downloader := geoip.Downloader{Client: client, StagingDir: destDir, AllowHTTP: allowHTTP, Validate: o.GeoIPValidate}
+
+	country = filepath.Join(destDir, "GeoLite2-Country.mmdb")
+	countryCandidate, err := downloader.Prepare(ctx, geoip.DownloadSpec{URL: countryURL, ChecksumURL: countryChecksum, Destination: country})
+	if err != nil {
+		return "", "", err
+	}
+	if err := countryCandidate.Commit(); err != nil {
+		return "", "", err
+	}
+	asn = filepath.Join(destDir, "GeoLite2-ASN.mmdb")
+	asnCandidate, err := downloader.Prepare(ctx, geoip.DownloadSpec{URL: asnURL, ChecksumURL: asnChecksum, Destination: asn})
+	if err != nil {
+		return "", "", err
+	}
+	if err := asnCandidate.Commit(); err != nil {
+		return "", "", err
+	}
+	return country, asn, nil
+}
+
+// stageWhitelist enumerates every file permitted inside an all-in-one stage.
+// Anything outside this set (onboarding.json, mihari.yaml, control.token,
+// subscriptions/, logs/, web/, ...) must be explicitly approved — design §4.1
+// step 6/8.
+var stageWhitelist = map[string]bool{
+	"mihari": true, "mihari.exe": true,
+	"install-aio.sh": true, "install-aio.ps1": true,
+	"data/bin/mihomo": true, "data/bin/mihomo.exe": true,
+	"data/geoip/GeoLite2-Country.mmdb": true,
+	"data/geoip/GeoLite2-ASN.mmdb":     true,
+}
+
+func assertStage(goos string, files []string) error {
+	for _, file := range files {
+		if !stageWhitelist[file] {
+			return fmt.Errorf("bundler: unexpected stage file %q (whitelist approval required)", file)
+		}
+	}
+	suffix, script := "", "install-aio.sh"
+	if goos == "windows" {
+		suffix, script = ".exe", "install-aio.ps1"
+	}
+	required := []string{
+		"mihari" + suffix,
+		script,
+		"data/bin/mihomo" + suffix,
+		"data/geoip/GeoLite2-Country.mmdb",
+		"data/geoip/GeoLite2-ASN.mmdb",
+	}
+	seen := make(map[string]bool, len(files))
+	for _, file := range files {
+		seen[file] = true
+	}
+	for _, want := range required {
+		if !seen[want] {
+			return fmt.Errorf("bundler: missing required stage file %q", want)
+		}
+	}
+	return nil
+}
+
+func extractMihomo(archivePath, assetName, dest string) error {
+	if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
+		return err
+	}
+	switch lower := strings.ToLower(assetName); {
+	case strings.HasSuffix(lower, ".gz"):
+		return extractGzipSingle(archivePath, dest)
+	case strings.HasSuffix(lower, ".zip"):
+		return extractZipSingle(archivePath, dest)
+	default:
+		return fmt.Errorf("unsupported mihomo archive %q", assetName)
+	}
+}
+
+func extractGzipSingle(archivePath, dest string) error {
+	archive, err := os.Open(archivePath)
+	if err != nil {
+		return err
+	}
+	defer archive.Close()
+	reader, err := gzip.NewReader(archive)
+	if err != nil {
+		return errors.New("invalid mihomo gzip archive")
+	}
+	defer reader.Close()
+	return writeAll(dest, io.LimitReader(reader, maxMihomoBinary+1), maxMihomoBinary)
+}
+
+func extractZipSingle(archivePath, dest string) error {
+	archive, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return errors.New("invalid mihomo zip archive")
+	}
+	defer archive.Close()
+	for _, file := range archive.File {
+		base := strings.ToLower(filepath.Base(file.Name))
+		if file.FileInfo().IsDir() || !strings.Contains(base, "mihomo") || !strings.HasSuffix(base, ".exe") {
+			continue
+		}
+		source, err := file.Open()
+		if err != nil {
+			return err
+		}
+		err = writeAll(dest, io.LimitReader(source, maxMihomoBinary+1), maxMihomoBinary)
+		source.Close()
+		return err
+	}
+	return errors.New("mihomo executable is missing from archive")
+}
+
+// writeAll copies reader into dest, enforcing a maxBytes ceiling on the result.
+func writeAll(dest string, reader io.Reader, maxBytes int64) error {
+	file, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o700)
+	if err != nil {
+		return err
+	}
+	written, err := io.Copy(file, reader)
+	if closeErr := file.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return err
+	}
+	if written > maxBytes {
+		return errors.New("mihomo executable exceeds size limit")
+	}
+	return nil
+}
+
+// smokeMihomo runs `-v` for linux/amd64 (the only target the build host can
+// execute) and verifies the executable magic number for the other five
+// platforms — design §4.1 step 2.
+func smokeMihomo(ctx context.Context, goos, goarch, path string, runner core.CommandRunner) error {
+	if goos == "linux" && goarch == "amd64" {
+		runner := runner
+		if runner == nil {
+			runner = core.OSCommandRunner{}
+		}
+		output, err := runner.Run(ctx, path, "-v")
+		if err != nil {
+			return fmt.Errorf("mihomo -v smoke: %w", err)
+		}
+		if len(strings.TrimSpace(string(output))) == 0 {
+			return errors.New("mihomo -v produced no output")
+		}
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return checkMagic(goos, data)
+}
+
+func checkMagic(goos string, data []byte) error {
+	switch goos {
+	case "linux":
+		if len(data) >= 4 && bytes.Equal(data[:4], []byte{0x7f, 'E', 'L', 'F'}) {
+			return nil
+		}
+	case "darwin":
+		for _, magic := range [][]byte{
+			{0xfe, 0xed, 0xfa, 0xce}, // Mach-O 32 big-endian
+			{0xfe, 0xed, 0xfa, 0xcf}, // Mach-O 64 big-endian
+			{0xce, 0xfa, 0xed, 0xfe}, // Mach-O 32 little-endian
+			{0xcf, 0xfa, 0xed, 0xfe}, // Mach-O 64 little-endian (real amd64/arm64)
+			{0xca, 0xfe, 0xba, 0xbe}, // Universal/fat binary
+		} {
+			if len(data) >= 4 && bytes.Equal(data[:4], magic) {
+				return nil
+			}
+		}
+	case "windows":
+		if len(data) >= 2 && data[0] == 'M' && data[1] == 'Z' {
+			return nil
+		}
+	}
+	return fmt.Errorf("mihomo magic number mismatch for %s", goos)
+}
+
+func packStage(stage, out, goos, goarch string) error {
+	name := "mihari-all-in-one-" + goos + "-" + goarch
+	if goos == "windows" {
+		return zipStage(stage, filepath.Join(out, name+".zip"))
+	}
+	return tarStage(stage, filepath.Join(out, name+".tar.gz"))
+}
+
+func tarStage(stage, dest string) error {
+	out, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	gzipWriter := gzip.NewWriter(out)
+	defer gzipWriter.Close()
+	tarWriter := tar.NewWriter(gzipWriter)
+	defer tarWriter.Close()
+	return filepath.Walk(stage, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(stage, path)
+		if err != nil {
+			return err
+		}
+		header := &tar.Header{Name: filepath.ToSlash(rel), Mode: int64(info.Mode().Perm()), Size: info.Size(), Format: tar.FormatGNU}
+		if err := tarWriter.WriteHeader(header); err != nil {
+			return err
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(tarWriter, file)
+		file.Close()
+		return err
+	})
+}
+
+func zipStage(stage, dest string) error {
+	out, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	zipWriter := zip.NewWriter(out)
+	defer zipWriter.Close()
+	return filepath.Walk(stage, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(stage, path)
+		if err != nil {
+			return err
+		}
+		entry, err := zipWriter.Create(filepath.ToSlash(rel))
+		if err != nil {
+			return err
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(entry, file)
+		file.Close()
+		return err
+	})
+}
+
+func copyFile(source, dest string) error {
+	if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
+		return err
+	}
+	in, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(out, in)
+	if closeErr := out.Close(); err == nil {
+		err = closeErr
+	}
+	return err
+}
+
+func relativeFiles(root string) ([]string, error) {
+	var files []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		files = append(files, filepath.ToSlash(rel))
+		return nil
+	})
+	return files, err
+}
+
+func distBinaryName(dir, goos, goarch string) string {
+	name := "mihari-" + goos + "-" + goarch
+	if goos == "windows" {
+		name += ".exe"
+	}
+	return filepath.Join(dir, name)
+}
+
+func splitPlatform(platform string) (string, string, error) {
+	parts := strings.SplitN(platform, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid platform %q (want goos/goarch)", platform)
+	}
+	return parts[0], parts[1], nil
+}
+
+func splitPlatforms(csv string) []string {
+	var platforms []string
+	for raw := range strings.SplitSeq(csv, ",") {
+		if platform := strings.TrimSpace(raw); platform != "" {
+			platforms = append(platforms, platform)
+		}
+	}
+	return platforms
+}
+
+func newClient(token string) *http.Client {
+	if token == "" {
+		return &http.Client{Timeout: 15 * time.Minute}
+	}
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok || base == nil {
+		return &http.Client{Timeout: 15 * time.Minute}
+	}
+	transport := base.Clone()
+	return &http.Client{Timeout: 15 * time.Minute, Transport: &bearerTransport{base: transport, token: token}}
+}
+
+type bearerTransport struct {
+	base  http.RoundTripper
+	token string
+}
+
+func (t *bearerTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	cloned := request.Clone(request.Context())
+	cloned.Header.Set("Authorization", "Bearer "+t.token)
+	return t.base.RoundTrip(cloned)
+}

--- a/scripts/build-all-in-one/main_test.go
+++ b/scripts/build-all-in-one/main_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -21,11 +22,23 @@ import (
 	"github.com/mihari-proxy/mihari/internal/core"
 )
 
-// fakeRunner satisfies core.CommandRunner for the linux/amd64 `-v` smoke.
+// fakeRunner satisfies core.CommandRunner for the host-matching `-v` smoke.
 type fakeRunner struct{ output []byte }
 
 func (f fakeRunner) Run(_ context.Context, _ string, _ ...string) ([]byte, error) {
 	return f.output, nil
+}
+
+// recordingRunner records whether Run was invoked, so a test can assert that the
+// host-matching target goes through the exec path (not the magic-number path).
+type recordingRunner struct {
+	called bool
+	output []byte
+}
+
+func (r *recordingRunner) Run(_ context.Context, _ string, _ ...string) ([]byte, error) {
+	r.called = true
+	return r.output, nil
 }
 
 func TestBundlerProducesSixPlatformBundles(t *testing.T) {
@@ -90,11 +103,71 @@ func TestBundlerProducesSixPlatformBundles(t *testing.T) {
 				t.Fatalf("%s: missing %q in bundle, got=%v", platform, w, sortedKeys(got))
 			}
 		}
-		// mihomo magic number sanity (linux/amd64 was -v-smoked via fakeRunner; check bytes anyway).
+		// mihomo magic number sanity (the host-matching target was -v-smoked via
+		// fakeRunner; the other five went through the magic check; verify bytes).
 		if mihomo := entries["data/bin/mihomo"+suffix]; len(mihomo) == 0 {
 			t.Fatalf("%s: empty mihomo binary", platform)
 		}
 	}
+}
+
+func TestSmokeMihomoExecutesHostTarget(t *testing.T) {
+	ctx := context.Background()
+	// Deliberately invalid magic: the host-matching target must exec the runner
+	// (returning output), NOT fall through to the magic-number check. A
+	// host-assumption bug (hardcoding linux/amd64) fails this on any non-linux
+	// host because the magic check would reject the garbage bytes.
+	path := filepath.Join(t.TempDir(), "mihomo")
+	if err := os.WriteFile(path, []byte("not a valid executable magic"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingRunner{output: []byte("Mihomo Meta v1.19.0")}
+	if err := smokeMihomo(ctx, runtime.GOOS, runtime.GOARCH, path, runner); err != nil {
+		t.Fatalf("host-matching smoke: %v", err)
+	}
+	if !runner.called {
+		t.Fatal("host-matching platform must exec the runner, not magic-check")
+	}
+}
+
+func TestSmokeMihomoMagicChecksNonHostTarget(t *testing.T) {
+	ctx := context.Background()
+	goos, goarch := nonHostTarget(t)
+	validMagic := map[string][]byte{
+		"linux":   {0x7f, 'E', 'L', 'F'},
+		"darwin":  {0xcf, 0xfa, 0xed, 0xfe},
+		"windows": {'M', 'Z'},
+	}[goos]
+	path := filepath.Join(t.TempDir(), "mihomo")
+	if err := os.WriteFile(path, validMagic, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := smokeMihomo(ctx, goos, goarch, path, nil); err != nil {
+		t.Fatalf("non-host valid magic: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("bad magic"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := smokeMihomo(ctx, goos, goarch, path, nil); err == nil {
+		t.Fatal("expected magic mismatch error for non-host target")
+	}
+}
+
+// nonHostTarget returns any of the 6 supported platforms that is not the build
+// host's, so a magic-number test is deterministic regardless of where it runs.
+func nonHostTarget(t *testing.T) (string, string) {
+	t.Helper()
+	for _, target := range []struct{ goos, goarch string }{
+		{"linux", "amd64"}, {"linux", "arm64"},
+		{"darwin", "amd64"}, {"darwin", "arm64"},
+		{"windows", "amd64"}, {"windows", "arm64"},
+	} {
+		if target.goos != runtime.GOOS || target.goarch != runtime.GOARCH {
+			return target.goos, target.goarch
+		}
+	}
+	t.Fatal("could not find a non-host target")
+	return "", ""
 }
 
 func TestAssertStageEnforcesWhitelist(t *testing.T) {

--- a/scripts/build-all-in-one/main_test.go
+++ b/scripts/build-all-in-one/main_test.go
@@ -226,7 +226,7 @@ func fakeGitHubAPI(t *testing.T) *httptest.Server {
 			response.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(response).Encode(core.Release{TagName: "v1.19.0", Assets: assets})
 		case strings.HasPrefix(request.URL.Path, "/asset/"):
-			response.Write(archives[strings.TrimPrefix(request.URL.Path, "/asset/")])
+			_, _ = response.Write(archives[strings.TrimPrefix(request.URL.Path, "/asset/")])
 		default:
 			http.NotFound(response, request)
 		}
@@ -245,7 +245,7 @@ func fakeGeoIPServer(t *testing.T) *httptest.Server {
 	}
 	return httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		if data, ok := files[strings.TrimPrefix(request.URL.Path, "/")]; ok {
-			response.Write(data)
+			_, _ = response.Write(data)
 			return
 		}
 		http.NotFound(response, request)

--- a/scripts/build-all-in-one/main_test.go
+++ b/scripts/build-all-in-one/main_test.go
@@ -1,0 +1,304 @@
+package main
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/mihari-proxy/mihari/internal/core"
+)
+
+// fakeRunner satisfies core.CommandRunner for the linux/amd64 `-v` smoke.
+type fakeRunner struct{ output []byte }
+
+func (f fakeRunner) Run(_ context.Context, _ string, _ ...string) ([]byte, error) {
+	return f.output, nil
+}
+
+func TestBundlerProducesSixPlatformBundles(t *testing.T) {
+	api := fakeGitHubAPI(t)
+	defer api.Close()
+	geoipSrv := fakeGeoIPServer(t)
+	defer geoipSrv.Close()
+
+	mihariDir := t.TempDir()
+	writeMihariDist(t, mihariDir)
+
+	scriptsDir := t.TempDir()
+	for _, name := range []string{"install-aio.sh", "install-aio.ps1"} {
+		if err := os.WriteFile(filepath.Join(scriptsDir, name), []byte("# aio installer\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	out := t.TempDir()
+	err := run(options{
+		MihariDir: mihariDir, Out: out, ScriptsDir: scriptsDir,
+		Platforms:  []string{"linux/amd64", "linux/arm64", "darwin/amd64", "darwin/arm64", "windows/amd64", "windows/arm64"},
+		HTTPClient: api.Client(), APIBase: api.URL, Repository: "MetaCubeX/mihomo",
+		GeoIPBase: geoipSrv.URL, GeoIPValidate: func(string) error { return nil },
+		Runner: fakeRunner{output: []byte("Mihomo Meta v1.19.0")},
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	expected := map[string]string{
+		"linux/amd64":   "mihari-all-in-one-linux-amd64.tar.gz",
+		"linux/arm64":   "mihari-all-in-one-linux-arm64.tar.gz",
+		"darwin/amd64":  "mihari-all-in-one-darwin-amd64.tar.gz",
+		"darwin/arm64":  "mihari-all-in-one-darwin-arm64.tar.gz",
+		"windows/amd64": "mihari-all-in-one-windows-amd64.zip",
+		"windows/arm64": "mihari-all-in-one-windows-arm64.zip",
+	}
+	for platform, bundle := range expected {
+		entries := extractBundle(t, filepath.Join(out, bundle))
+		goos, _, _ := strings.Cut(platform, "/")
+		suffix, script := "", "install-aio.sh"
+		if goos == "windows" {
+			suffix, script = ".exe", "install-aio.ps1"
+		}
+		want := map[string]bool{
+			"mihari" + suffix:                  true,
+			script:                             true,
+			"data/bin/mihomo" + suffix:         true,
+			"data/geoip/GeoLite2-Country.mmdb": true,
+			"data/geoip/GeoLite2-ASN.mmdb":     true,
+		}
+		got := make(map[string]bool, len(entries))
+		for name := range entries {
+			got[name] = true
+		}
+		if len(got) != len(want) {
+			t.Fatalf("%s: bundle has %d entries, got=%v want=%v", platform, len(got), sortedKeys(got), sortedKeys(want))
+		}
+		for w := range want {
+			if !got[w] {
+				t.Fatalf("%s: missing %q in bundle, got=%v", platform, w, sortedKeys(got))
+			}
+		}
+		// mihomo magic number sanity (linux/amd64 was -v-smoked via fakeRunner; check bytes anyway).
+		if mihomo := entries["data/bin/mihomo"+suffix]; len(mihomo) == 0 {
+			t.Fatalf("%s: empty mihomo binary", platform)
+		}
+	}
+}
+
+func TestAssertStageEnforcesWhitelist(t *testing.T) {
+	tests := []struct {
+		name    string
+		goos    string
+		files   []string
+		wantErr bool
+	}{
+		{name: "unix complete", goos: "linux", files: []string{"mihari", "install-aio.sh", "data/bin/mihomo", "data/geoip/GeoLite2-Country.mmdb", "data/geoip/GeoLite2-ASN.mmdb"}},
+		{name: "windows complete", goos: "windows", files: []string{"mihari.exe", "install-aio.ps1", "data/bin/mihomo.exe", "data/geoip/GeoLite2-Country.mmdb", "data/geoip/GeoLite2-ASN.mmdb"}},
+		{name: "missing geoip", goos: "linux", files: []string{"mihari", "install-aio.sh", "data/bin/mihomo", "data/geoip/GeoLite2-Country.mmdb"}, wantErr: true},
+		{name: "forbidden onboarding.json", goos: "linux", files: []string{"mihari", "install-aio.sh", "data/bin/mihomo", "data/geoip/GeoLite2-Country.mmdb", "data/geoip/GeoLite2-ASN.mmdb", "onboarding.json"}, wantErr: true},
+		{name: "forbidden mihari.yaml", goos: "windows", files: []string{"mihari.exe", "install-aio.ps1", "data/bin/mihomo.exe", "data/geoip/GeoLite2-Country.mmdb", "data/geoip/GeoLite2-ASN.mmdb", "mihari.yaml"}, wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := assertStage(test.goos, test.files)
+			if test.wantErr && err == nil {
+				t.Fatal("expected whitelist violation, got nil")
+			}
+			if !test.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func fakeGitHubAPI(t *testing.T) *httptest.Server {
+	t.Helper()
+	names := []string{
+		"mihomo-linux-amd64-compatible-v1.19.0.gz",
+		"mihomo-linux-arm64-v1.19.0.gz",
+		"mihomo-darwin-amd64-compatible-v1.19.0.gz",
+		"mihomo-darwin-arm64-v1.19.0.gz",
+		"mihomo-windows-amd64-compatible-v1.19.0.zip",
+		"mihomo-windows-arm64-v1.19.0.zip",
+	}
+	archives := make(map[string][]byte, len(names))
+	for _, name := range names {
+		archives[name] = fakeMihomoArchive(t, name)
+	}
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.URL.Path == "/repos/MetaCubeX/mihomo/releases/latest":
+			assets := make([]core.Asset, 0, len(names))
+			for _, name := range names {
+				data := archives[name]
+				sum := sha256.Sum256(data)
+				assets = append(assets, core.Asset{
+					Name: name, URL: server.URL + "/asset/" + name,
+					Size: int64(len(data)), Digest: "sha256:" + hex.EncodeToString(sum[:]),
+				})
+			}
+			response.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(response).Encode(core.Release{TagName: "v1.19.0", Assets: assets})
+		case strings.HasPrefix(request.URL.Path, "/asset/"):
+			response.Write(archives[strings.TrimPrefix(request.URL.Path, "/asset/")])
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	return server
+}
+
+func fakeGeoIPServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	files := make(map[string][]byte)
+	for _, name := range []string{"GeoLite2-Country.mmdb", "GeoLite2-ASN.mmdb"} {
+		payload := []byte("fake-" + name)
+		files[name] = payload
+		sum := sha256.Sum256(payload)
+		files[name+".sha256sum"] = []byte(hex.EncodeToString(sum[:]) + "  " + name + "\n")
+	}
+	return httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if data, ok := files[strings.TrimPrefix(request.URL.Path, "/")]; ok {
+			response.Write(data)
+			return
+		}
+		http.NotFound(response, request)
+	}))
+}
+
+func fakeMihomoArchive(t *testing.T, name string) []byte {
+	t.Helper()
+	goos := "linux"
+	switch {
+	case strings.HasPrefix(name, "mihomo-darwin-"):
+		goos = "darwin"
+	case strings.HasPrefix(name, "mihomo-windows-"):
+		goos = "windows"
+	}
+	magic := map[string][]byte{
+		"linux":   {0x7f, 'E', 'L', 'F'},
+		"darwin":  {0xcf, 0xfa, 0xed, 0xfe}, // Mach-O 64 little-endian (real darwin/amd64+arm64)
+		"windows": {'M', 'Z'},
+	}[goos]
+	binary := append(append([]byte(nil), magic...), []byte("-fake-mihomo")...)
+	if strings.HasSuffix(name, ".gz") {
+		var buffer bytes.Buffer
+		writer := gzip.NewWriter(&buffer)
+		if _, err := writer.Write(binary); err != nil {
+			t.Fatal(err)
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatal(err)
+		}
+		return buffer.Bytes()
+	}
+	var buffer bytes.Buffer
+	writer := zip.NewWriter(&buffer)
+	entry, err := writer.Create("mihomo.exe")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := entry.Write(binary); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buffer.Bytes()
+}
+
+func writeMihariDist(t *testing.T, dir string) {
+	t.Helper()
+	for _, target := range []struct{ goos, goarch, ext string }{
+		{"linux", "amd64", ""}, {"linux", "arm64", ""},
+		{"darwin", "amd64", ""}, {"darwin", "arm64", ""},
+		{"windows", "amd64", ".exe"}, {"windows", "arm64", ".exe"},
+	} {
+		name := "mihari-" + target.goos + "-" + target.goarch + target.ext
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("dist-"+name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func extractBundle(t *testing.T, path string) map[string][]byte {
+	t.Helper()
+	entries := map[string][]byte{}
+	switch {
+	case strings.HasSuffix(path, ".tar.gz"):
+		file, err := os.Open(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer file.Close()
+		gz, err := gzip.NewReader(file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer gz.Close()
+		reader := tar.NewReader(gz)
+		for {
+			header, err := reader.Next()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if header.Typeflag != tar.TypeReg {
+				continue
+			}
+			data, err := io.ReadAll(reader)
+			if err != nil {
+				t.Fatal(err)
+			}
+			entries[header.Name] = data
+		}
+	case strings.HasSuffix(path, ".zip"):
+		reader, err := zip.OpenReader(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer reader.Close()
+		for _, file := range reader.File {
+			if file.FileInfo().IsDir() {
+				continue
+			}
+			rc, err := file.Open()
+			if err != nil {
+				t.Fatal(err)
+			}
+			data, err := io.ReadAll(rc)
+			rc.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+			entries[file.Name] = data
+		}
+	default:
+		t.Fatalf("unknown bundle type: %s", path)
+	}
+	return entries
+}
+
+func sortedKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/scripts/release-alist.py
+++ b/scripts/release-alist.py
@@ -2,8 +2,8 @@
 """AList drive distribution for mihari all-in-one releases (design §4.5).
 
 Runs inside the release.yml job after the GitHub release is published:
-  1. upload the 6 platform bundles (+ aio-only SHA256SUMS) into an immutable
-     per-version directory, then a COMPLETE marker (skip if already complete);
+  1. upload the 6 platform bundles (+ per-version SHA256SUMS + COMPLETE) into an
+     immutable per-version directory (skip if COMPLETE already exists);
   2. resolve the root index.txt sign (placeholder on first release);
   3. build index.txt (latest line + per-platform signed direct link + sha256)
      and overwrite-upload it (the publish-complete signal);
@@ -11,135 +11,31 @@ Runs inside the release.yml job after the GitHub release is published:
   5. prune old versions (keep N, index-pointed always retained);
   6. emit the signed URLs to GITHUB_ENV for the release-notes append step.
 
-Operations target the AList v3 REST API (login / fs/get / fs/list / fs/put /
-fs/remove / fs/mkdir) via requests — the standard surface the design's alist-cli
-wraps. The whole block is conditional on ALIST_URL in the workflow and is
-verified post-release (§9 prerequisites: alist-cli fork + secrets).
+The AList REST client and shared constants live in alist_client.py, imported by
+both this publish flow and the retract flow.
 """
 import argparse
-import hashlib
 import os
-import re
-import sys
 from pathlib import Path
-from urllib.parse import quote
 
-import requests
-
-DEFAULT_BASE_PATH = "/mihari"
-DEFAULT_KEEP_VERSIONS = 5
-PLATFORMS = [
-    "linux/amd64", "linux/arm64",
-    "darwin/amd64", "darwin/arm64",
-    "windows/amd64", "windows/arm64",
-]
-SEMVER_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
-INDEX_PLACEHOLDER = "__MIHARI_INDEX_URL__"
-
-
-def fail(message):
-    print(f"::error::{message}", file=sys.stderr)
-    sys.exit(1)
-
-
-def info(message):
-    print(f"::notice::{message}")
-
-
-def semver_key(name):
-    match = SEMVER_RE.match(name)
-    return tuple(int(x) for x in match.groups()) if match else None
-
-
-def sha256_file(path):
-    digest = hashlib.sha256()
-    with open(path, "rb") as handle:
-        for chunk in iter(lambda: handle.read(1 << 20), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def bundle_name(goos, goarch):
-    ext = ".zip" if goos == "windows" else ".tar.gz"
-    return f"mihari-all-in-one-{goos}-{goarch}{ext}"
-
-
-class AList:
-    """Thin client over the AList v3 REST API."""
-
-    def __init__(self, base_url, username, password):
-        self.base = base_url.rstrip("/")
-        self.session = requests.Session()
-        token = self._login(username, password)
-        self.session.headers["Authorization"] = token
-
-    def _post(self, path, **kwargs):
-        response = self.session.post(self.base + path, timeout=120, **kwargs)
-        response.raise_for_status()
-        return response.json()
-
-    def _login(self, username, password):
-        data = self._post("/api/auth/login", json={"username": username, "password": password})
-        if data.get("code") != 200:
-            fail(f"alist login failed: {data.get('message')}")
-        return data["data"]["token"]
-
-    def get(self, path):
-        return self._post("/api/fs/get", json={"path": path, "password": ""})
-
-    def exists(self, path):
-        return self.get(path).get("code") == 200
-
-    def sign_of(self, path):
-        data = self.get(path)
-        if data.get("code") != 200:
-            return None
-        return data["data"].get("sign", "")
-
-    def list_dir(self, path):
-        data = self._post("/api/fs/list", json={"path": path, "password": "", "page": 1, "per_page": 0, "refresh": False})
-        return data.get("data", {}).get("content") or []
-
-    def mkdir(self, path):
-        self._post("/api/fs/mkdir", json={"path": path})
-
-    def upload(self, local, remote_path):
-        with open(local, "rb") as handle:
-            response = self.session.put(
-                self.base + "/api/fs/put",
-                headers={
-                    "File-Path": quote(remote_path, safe=""),
-                    "As-Task": "false",
-                    "Content-Type": "application/octet-stream",
-                },
-                data=handle,
-                timeout=900,
-            )
-        response.raise_for_status()
-
-    def upload_text(self, text, remote_path):
-        response = self.session.put(
-            self.base + "/api/fs/put",
-            headers={
-                "File-Path": quote(remote_path, safe=""),
-                "As-Task": "false",
-                "Content-Type": "text/plain",
-            },
-            data=text.encode("utf-8"),
-            timeout=120,
-        )
-        response.raise_for_status()
-
-    def remove(self, dir_path, names):
-        self._post("/api/fs/remove", json={"dir": dir_path, "names": list(names)})
-
-    def signed_url(self, path, sign):
-        # /p<path>?sign=... is AList's proxy/stream route (design §4.4 URL form).
-        return f"{self.base}/p{path}?sign={sign}"
+from alist_client import (
+    AList,
+    DEFAULT_BASE_PATH,
+    DEFAULT_KEEP_VERSIONS,
+    INDEX_PLACEHOLDER,
+    PLATFORMS,
+    SEMVER_RE,
+    bundle_name,
+    connect,
+    fail,
+    info,
+    semver_key,
+    sha256_file,
+)
 
 
 def upload_version_dir(alist, dist_dir, base_path, version):
-    """Steps 1-2: upload bundles + aio SHA256SUMS, then COMPLETE. Immutable —
+    """Steps 1-2: upload bundles + per-version SHA256SUMS + COMPLETE. Immutable —
     skip the whole directory when COMPLETE already exists (idempotent re-run /
     rebuild after retract)."""
     version_dir = f"{base_path}/{version}"
@@ -147,12 +43,17 @@ def upload_version_dir(alist, dist_dir, base_path, version):
         info(f"version dir {version_dir} already complete — skipping upload")
         return version_dir
     alist.mkdir(version_dir)
+    sums_lines = []
     for goos, goarch in PLATFORMS:
         name = bundle_name(goos, goarch)
         local = Path(dist_dir) / name
         if not local.exists():
             fail(f"bundle artifact missing: {local}")
         alist.upload(str(local), f"{version_dir}/{name}")
+        sums_lines.append(f"{sha256_file(local)}  {name}")
+    # Per-version aio-only checksums: retract step 4 reads this to rebuild index
+    # when the retracted version was latest (design §4.5 step 2 / §4.6 step 4).
+    alist.upload_text("\n".join(sums_lines) + "\n", f"{version_dir}/SHA256SUMS.txt")
     alist.upload_text(f"{version}\n", f"{version_dir}/COMPLETE")
     return version_dir
 
@@ -250,13 +151,7 @@ def main():
     if not SEMVER_RE.match(args.version):
         fail(f"version {args.version!r} must match {SEMVER_RE.pattern}")
 
-    base_url = os.environ.get("ALIST_URL")
-    username = os.environ.get("ALIST_USERNAME")
-    password = os.environ.get("ALIST_PASSWORD")
-    if not base_url or not username or not password:
-        fail("ALIST_URL / ALIST_USERNAME / ALIST_PASSWORD are required")
-
-    alist = AList(base_url, username, password)
+    alist = connect()
     version_dir = upload_version_dir(alist, args.dist_dir, args.base_path, args.version)
     index_body, index_signed_url = build_index(alist, args.dist_dir, args.base_path, args.version)
     alist.upload_text(index_body, f"{args.base_path}/index.txt")

--- a/scripts/release-alist.py
+++ b/scripts/release-alist.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""AList drive distribution for mihari all-in-one releases (design §4.5).
+
+Runs inside the release.yml job after the GitHub release is published:
+  1. upload the 6 platform bundles (+ aio-only SHA256SUMS) into an immutable
+     per-version directory, then a COMPLETE marker (skip if already complete);
+  2. resolve the root index.txt sign (placeholder on first release);
+  3. build index.txt (latest line + per-platform signed direct link + sha256)
+     and overwrite-upload it (the publish-complete signal);
+  4. render the root downloader scripts (script 3) with the index link injected;
+  5. prune old versions (keep N, index-pointed always retained);
+  6. emit the signed URLs to GITHUB_ENV for the release-notes append step.
+
+Operations target the AList v3 REST API (login / fs/get / fs/list / fs/put /
+fs/remove / fs/mkdir) via requests — the standard surface the design's alist-cli
+wraps. The whole block is conditional on ALIST_URL in the workflow and is
+verified post-release (§9 prerequisites: alist-cli fork + secrets).
+"""
+import argparse
+import hashlib
+import os
+import re
+import sys
+from pathlib import Path
+from urllib.parse import quote
+
+import requests
+
+DEFAULT_BASE_PATH = "/mihari"
+DEFAULT_KEEP_VERSIONS = 5
+PLATFORMS = [
+    "linux/amd64", "linux/arm64",
+    "darwin/amd64", "darwin/arm64",
+    "windows/amd64", "windows/arm64",
+]
+SEMVER_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+INDEX_PLACEHOLDER = "__MIHARI_INDEX_URL__"
+
+
+def fail(message):
+    print(f"::error::{message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def info(message):
+    print(f"::notice::{message}")
+
+
+def semver_key(name):
+    match = SEMVER_RE.match(name)
+    return tuple(int(x) for x in match.groups()) if match else None
+
+
+def sha256_file(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def bundle_name(goos, goarch):
+    ext = ".zip" if goos == "windows" else ".tar.gz"
+    return f"mihari-all-in-one-{goos}-{goarch}{ext}"
+
+
+class AList:
+    """Thin client over the AList v3 REST API."""
+
+    def __init__(self, base_url, username, password):
+        self.base = base_url.rstrip("/")
+        self.session = requests.Session()
+        token = self._login(username, password)
+        self.session.headers["Authorization"] = token
+
+    def _post(self, path, **kwargs):
+        response = self.session.post(self.base + path, timeout=120, **kwargs)
+        response.raise_for_status()
+        return response.json()
+
+    def _login(self, username, password):
+        data = self._post("/api/auth/login", json={"username": username, "password": password})
+        if data.get("code") != 200:
+            fail(f"alist login failed: {data.get('message')}")
+        return data["data"]["token"]
+
+    def get(self, path):
+        return self._post("/api/fs/get", json={"path": path, "password": ""})
+
+    def exists(self, path):
+        return self.get(path).get("code") == 200
+
+    def sign_of(self, path):
+        data = self.get(path)
+        if data.get("code") != 200:
+            return None
+        return data["data"].get("sign", "")
+
+    def list_dir(self, path):
+        data = self._post("/api/fs/list", json={"path": path, "password": "", "page": 1, "per_page": 0, "refresh": False})
+        return data.get("data", {}).get("content") or []
+
+    def mkdir(self, path):
+        self._post("/api/fs/mkdir", json={"path": path})
+
+    def upload(self, local, remote_path):
+        with open(local, "rb") as handle:
+            response = self.session.put(
+                self.base + "/api/fs/put",
+                headers={
+                    "File-Path": quote(remote_path, safe=""),
+                    "As-Task": "false",
+                    "Content-Type": "application/octet-stream",
+                },
+                data=handle,
+                timeout=900,
+            )
+        response.raise_for_status()
+
+    def upload_text(self, text, remote_path):
+        response = self.session.put(
+            self.base + "/api/fs/put",
+            headers={
+                "File-Path": quote(remote_path, safe=""),
+                "As-Task": "false",
+                "Content-Type": "text/plain",
+            },
+            data=text.encode("utf-8"),
+            timeout=120,
+        )
+        response.raise_for_status()
+
+    def remove(self, dir_path, names):
+        self._post("/api/fs/remove", json={"dir": dir_path, "names": list(names)})
+
+    def signed_url(self, path, sign):
+        # /p<path>?sign=... is AList's proxy/stream route (design §4.4 URL form).
+        return f"{self.base}/p{path}?sign={sign}"
+
+
+def upload_version_dir(alist, dist_dir, base_path, version):
+    """Steps 1-2: upload bundles + aio SHA256SUMS, then COMPLETE. Immutable —
+    skip the whole directory when COMPLETE already exists (idempotent re-run /
+    rebuild after retract)."""
+    version_dir = f"{base_path}/{version}"
+    if alist.exists(f"{version_dir}/COMPLETE"):
+        info(f"version dir {version_dir} already complete — skipping upload")
+        return version_dir
+    alist.mkdir(version_dir)
+    for goos, goarch in PLATFORMS:
+        name = bundle_name(goos, goarch)
+        local = Path(dist_dir) / name
+        if not local.exists():
+            fail(f"bundle artifact missing: {local}")
+        alist.upload(str(local), f"{version_dir}/{name}")
+    alist.upload_text(f"{version}\n", f"{version_dir}/COMPLETE")
+    return version_dir
+
+
+def build_index(alist, dist_dir, base_path, version):
+    """Steps 2-3: resolve the root index sign + each bundle sign, then return
+    the index.txt body (latest line + per-platform <signed_url> <sha256>)."""
+    root_index_path = f"{base_path}/index.txt"
+    index_sign = alist.sign_of(root_index_path)
+    if index_sign is None:
+        # First release: upload an empty placeholder so fs/get yields a sign.
+        alist.upload_text("", root_index_path)
+        index_sign = alist.sign_of(root_index_path) or ""
+
+    lines = [f"latest {version}"]
+    for goos, goarch in PLATFORMS:
+        platform = f"{goos}-{goarch}"
+        name = bundle_name(goos, goarch)
+        remote = f"{base_path}/{version}/{name}"
+        sign = alist.sign_of(remote)
+        if sign is None:
+            fail(f"uploaded bundle not found for sign: {remote}")
+        signed = alist.signed_url(remote, sign)
+        digest = sha256_file(Path(dist_dir) / name)
+        lines.append(f"{platform} {signed} {digest}")
+    return "\n".join(lines) + "\n", alist.signed_url(root_index_path, index_sign)
+
+
+def render_root_scripts(alist, repo_root, base_path, index_signed_url):
+    """Step 4: inject the root index signed link into script 3 and upload to the
+    drive root (content is constant across releases; overwritten each time).
+    Returns the rendered scripts' signed direct links for release notes."""
+    rendered = {}
+    for filename in ("install-aio-remote.sh", "install-aio-remote.ps1"):
+        source = Path(repo_root) / filename
+        if not source.exists():
+            fail(f"downloader script missing: {source}")
+        text = source.read_text(encoding="utf-8").replace(INDEX_PLACEHOLDER, index_signed_url)
+        remote = f"{base_path}/{filename}"
+        alist.upload_text(text, remote)
+        sign = alist.sign_of(remote)
+        if sign is None:
+            fail(f"rendered script not found for sign: {remote}")
+        rendered[filename] = alist.signed_url(remote, sign)
+    return rendered
+
+
+def prune_versions(alist, base_path, version, keep):
+    """Step 5: keep the index-pointed version (not counted) + the newest keep-1
+    others; incomplete dirs (no COMPLETE) are deleted first without counting.
+    Index read failure → retry once, then skip pruning entirely (never block the
+    release on retention)."""
+    try:
+        entries = alist.list_dir(base_path)
+    except Exception:
+        try:
+            entries = alist.list_dir(base_path)
+        except Exception as error:
+            info(f"index/list failed twice — skipping retention: {error}")
+            return
+
+    version_dirs = [e["name"] for e in entries if e.get("is_dir") and semver_key(e["name"]) is not None]
+    incomplete = [name for name in version_dirs if not alist.exists(f"{base_path}/{name}/COMPLETE")]
+    for name in incomplete:
+        info(f"removing incomplete version dir: {name}")
+        alist.remove(base_path, [name])
+    version_dirs = [name for name in version_dirs if name not in incomplete and name != version]
+
+    # Keep the newest (keep-1) beyond the index-pointed version; delete the rest.
+    version_dirs.sort(key=semver_key, reverse=True)
+    survivors = set(version_dirs[: max(keep - 1, 0)])
+    for name in version_dirs:
+        if name not in survivors:
+            info(f"retention pruning old version: {name}")
+            alist.remove(base_path, [name])
+
+
+def emit_env(name, value):
+    gh_env = os.environ.get("GITHUB_ENV")
+    if not gh_env:
+        return
+    with open(gh_env, "a", encoding="utf-8") as handle:
+        handle.write(f"{name}={value}\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Publish mihari aio bundles to AList (design §4.5).")
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--dist-dir", required=True, help="directory holding the 6 bundle artifacts")
+    parser.add_argument("--repo-root", required=True, help="checkout root (for script 3 sources)")
+    parser.add_argument("--base-path", default=DEFAULT_BASE_PATH)
+    parser.add_argument("--keep-versions", type=int, default=DEFAULT_KEEP_VERSIONS)
+    args = parser.parse_args()
+
+    if not SEMVER_RE.match(args.version):
+        fail(f"version {args.version!r} must match {SEMVER_RE.pattern}")
+
+    base_url = os.environ.get("ALIST_URL")
+    username = os.environ.get("ALIST_USERNAME")
+    password = os.environ.get("ALIST_PASSWORD")
+    if not base_url or not username or not password:
+        fail("ALIST_URL / ALIST_USERNAME / ALIST_PASSWORD are required")
+
+    alist = AList(base_url, username, password)
+    version_dir = upload_version_dir(alist, args.dist_dir, args.base_path, args.version)
+    index_body, index_signed_url = build_index(alist, args.dist_dir, args.base_path, args.version)
+    alist.upload_text(index_body, f"{args.base_path}/index.txt")
+    rendered = render_root_scripts(alist, args.repo_root, args.base_path, index_signed_url)
+    prune_versions(alist, args.base_path, args.version, args.keep_versions)
+
+    emit_env("ALIST_INDEX_URL", index_signed_url)
+    emit_env("ALIST_VERSION_DIR", version_dir)
+    emit_env("ALIST_REMOTE_SH_URL", rendered["install-aio-remote.sh"])
+    emit_env("ALIST_REMOTE_PS1_URL", rendered["install-aio-remote.ps1"])
+    info(f"published {args.version} to {args.base_path}; index at {index_signed_url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/retract-alist.py
+++ b/scripts/retract-alist.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""AList drive retraction for a fatally-broken mihari release (design §4.6).
+
+Runs inside the retract.yml workflow (manual dispatch, double-confirm). Performs
+the AList side of the withdrawal — steps 2-4 of the design flow — while step 5
+(`gh release delete --cleanup-tag`) runs as a shell step in the workflow:
+
+  2. read index.txt to learn whether the retracted version is the current latest;
+  3. remove the AList version directory /mihari/<version>/;
+  4. rebuild index.txt ONLY when the retracted version was latest — point it at
+     the highest remaining COMPLETE version (sign from fs/get, sha256 read from
+     that version dir's SHA256SUMS.txt), or leave it empty if none remain.
+
+Withdrawal removes distribution channels only; already-installed users are not
+recallable (design §4.6 boundary). The AList client and shared helpers come from
+alist_client.py, shared with the publish flow.
+"""
+import argparse
+
+from alist_client import (
+    DEFAULT_BASE_PATH,
+    PLATFORMS,
+    bundle_name,
+    connect,
+    fail,
+    info,
+    semver_key,
+)
+
+
+def parse_latest(index_text):
+    """Extract the `latest <version>` value from an index.txt body, or None."""
+    for line in (index_text or "").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or line.startswith("//"):
+            continue
+        fields = line.split()
+        if fields and fields[0] == "latest" and len(fields) >= 2:
+            return fields[1]
+    return None
+
+
+def highest_complete(alist, base_path, excluded):
+    """Highest remaining version dir that has a COMPLETE marker (and is not the
+    excluded/retracted one). None if no complete version remains — incomplete
+    dirs are skipped so index never points at a publish-interrupted residue."""
+    entries = alist.list_dir(base_path)
+    candidates = [
+        e["name"] for e in entries
+        if e.get("is_dir")
+        and e["name"] != excluded
+        and semver_key(e["name"]) is not None
+        and alist.exists(f"{base_path}/{e['name']}/COMPLETE")
+    ]
+    if not candidates:
+        return None
+    candidates.sort(key=semver_key, reverse=True)
+    return candidates[0]
+
+
+def rebuild_index(alist, base_path, new_latest):
+    """Rewrite index.txt to point at new_latest: latest line + one per-platform
+    signed direct link (fs/get sign) + sha256 (read from that dir's
+    SHA256SUMS.txt). Uploads the new body."""
+    sums_text = alist.content(f"{base_path}/{new_latest}/SHA256SUMS.txt")
+    if sums_text is None:
+        fail(f"new-latest {new_latest} has no SHA256SUMS.txt — cannot rebuild index")
+    sums = {}
+    for line in sums_text.splitlines():
+        parts = line.split(None, 1)
+        if len(parts) == 2:
+            sums[parts[1].strip()] = parts[0].strip()
+
+    lines = [f"latest {new_latest}"]
+    for goos, goarch in PLATFORMS:
+        platform = f"{goos}-{goarch}"
+        name = bundle_name(goos, goarch)
+        remote = f"{base_path}/{new_latest}/{name}"
+        sign = alist.sign_of(remote)
+        if sign is None:
+            fail(f"new-latest bundle missing for sign: {remote}")
+        signed = alist.signed_url(remote, sign)
+        digest = sums.get(name)
+        if not digest:
+            fail(f"SHA256SUMS.txt in {new_latest} missing entry for {name}")
+        lines.append(f"{platform} {signed} {digest}")
+    alist.upload_text("\n".join(lines) + "\n", f"{base_path}/index.txt")
+    info(f"index.txt rebuilt to point at {new_latest}")
+
+
+def retract(alist, base_path, version):
+    root_index = f"{base_path}/index.txt"
+    current_latest = parse_latest(alist.content(root_index))
+
+    # Step 3: always remove the retracted version dir (idempotent if absent).
+    version_dir = f"{base_path}/{version}"
+    if alist.exists(version_dir):
+        info(f"removing AList version dir: {version_dir}")
+        alist.remove(base_path, [version])
+    else:
+        info(f"AList version dir not present (already removed?): {version_dir}")
+
+    # Step 4: rebuild index only when we just removed the current latest.
+    if current_latest != version:
+        info(
+            f"retracted {version} was not the current latest "
+            f"({current_latest!r}) — index.txt unchanged"
+        )
+        return
+
+    new_latest = highest_complete(alist, base_path, excluded=version)
+    if new_latest is None:
+        info("no complete version remains — setting index.txt empty")
+        alist.upload_text("", root_index)
+        return
+    rebuild_index(alist, base_path, new_latest)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Retract a mihari version from AList (design §4.6).")
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--base-path", default=DEFAULT_BASE_PATH)
+    args = parser.parse_args()
+
+    retract(connect(), args.base_path, args.version)
+    info(f"retraction of {args.version} complete on the AList drive")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

让墙内用户无需 GitHub 访问，一条命令安装 mihari：CI 自动打包 6 平台 all-in-one 整合包并上传到自建 AList 网盘；离线安装器落地二进制 + 核心 + GeoIP，引导 setup 本地通过。

### daemon 侧 setup 预检（离线闭环的关键）
- `MutationRequest.Source` 请求级字段，handler 透传（不再硬编码 `"control"`）
- `Source=="setup"` 时 `Manager.Install` 的 stepCore / `Manager.UpdateGeoIP` 的 stepGeoIP 本地有效即直接通过，不联网

### core.Prepare 增强
- 联网优先 + `CheckTimeout`（8s）快速失败，**不降级、无隐式回退**，报错并提示 aio 脚本
- 同版本 + 文件存在 + 对现有文件执行 `-v` 成功 → 短路（堵住"文件存在但损坏"缺口）

### 打包与分发
- `scripts/build-all-in-one`：6 平台打包工具，**一次 API 请求**，复用 `core.LatestRelease` / `Download`（不复制 `internal/update/self.go`——它缺 Digest 校验）
- 三脚本模型：`install-aio`（本地安装器）/ `install-aio-remote`（AList 根下载器，CI 注入 index 直链）
- `scripts/alist_client.py` + `release-alist.py` + `retract-alist.py`：AList v3 REST 客户端 + 发布/撤回流

### CI
- `release.yml`：版本闸门（拒绝 `-` 预发布后缀）+ 顶层 `VERSION` 真相源（修复 dispatch 时 `GITHUB_REF_NAME` 是分支名的版本注入 bug）+ bundle job + 双校验和 + 条件 AList 上传（`if: env.ALIST_URL != ''`，不阻塞 GitHub 发布）
- `retract.yml`：致命错误版本撤回（version + confirm 双保险，删 AList 目录 + 重建 index + `gh release delete --cleanup-tag`）

### 文档
- `docs/distribution.md`：运维/用户操作面（两入口、网盘结构、index.txt、发布顺序、保留策略、撤回）
- `docs/RELEASE.md`：同步 workflow 表、产物清单（6 二进制 + 6 aio 包）、手动触发必填 version、撤回用法

## 提交结构
14 个原子提交，逐 Task 切分，全部 DCO 签名。详见 commit history。

## 设计文档
all-in-one 分发设计稿（仓库外规划文档，十二轮收敛定稿）。

## Test Plan
- [x] `go test ./...` + `-race` 通过（46 包）
- [x] `go vet` / `gofmt` 通过
- [x] 6 平台交叉构建通过（Mach-O / ELF / PE32+ 各 amd64+arm64）
- [x] bundler 冒烟：6 包产出 + 结构白名单（5 项，无私有文件）
- [x] actionlint：release.yml / retract.yml 通过
- [x] Python 脚本 py_compile + import 链 + `--help`
- [ ] （端到端，需前置依赖就绪）tag/dispatch 触发 release.yml 全流程 + retract 撤回

## 备注
- `release.yml` 的 AList 上传步骤在无 `ALIST_URL` secret 时跳过，不阻塞 GitHub 发布
- 端到端发版验证依赖前置项（AList secrets + 首次发版回填 README），属发版后验证，不在本 PR CI 范围
- 验证中发现并修复 bundler 的主机假设缺陷（`smokeMihomo` 硬编码 linux/amd64 → 改为 `runtime.GOOS/GOARCH`，CI 行为不变）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
