### PR TITLE
fix(control): tolerate graceful-shutdown timeout in Serve

### DIFF
--- a/internal/control/server/serve_test.go
+++ b/internal/control/server/serve_test.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/mihari-proxy/mihari/internal/state"
+)
+
+// TestServeContextCancelToleratesShutdownTimeout is a regression guard for the
+// flaky integration test TestControlPlaneLifecycleAndConcurrentStatus: Serve
+// used to return http.Shutdown's error verbatim, so when in-flight connections
+// prevented draining within the shutdown budget, daemon.Run surfaced a spurious
+// "context deadline exceeded" and flaked the integration test under -race on
+// slow CI. Graceful-shutdown timeout is acceptable on the cancellation path,
+// so Serve must return nil unless a genuine (non-deadline) error occurs.
+func TestServeContextCancelToleratesShutdownTimeout(t *testing.T) {
+	store := state.NewStore(state.Snapshot{Version: "test", Health: "ok"})
+	srv := New(Options{Token: "t", Store: store})
+	// Short budget so the regression is observable quickly; the handler below
+	// never drains on its own, so Shutdown is guaranteed to hit the deadline.
+	srv.shutdownTimeout = 50 * time.Millisecond
+
+	handlerStarted := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	srv.http.Handler = http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		close(handlerStarted)
+		<-releaseHandler
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(ctx, listener) }()
+
+	// Fire an in-flight request that blocks inside the handler, keeping the
+	// connection active so Shutdown cannot drain and must time out.
+	go func() {
+		resp, err := http.Get("http://" + listener.Addr().String() + "/")
+		if err == nil {
+			resp.Body.Close()
+		}
+	}()
+
+	select {
+	case <-handlerStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("in-flight request never reached the handler")
+	}
+
+	// Cancellation enters the graceful-shutdown path. The blocked handler
+	// cannot drain, so http.Shutdown returns DeadlineExceeded after the budget.
+	cancel()
+
+	select {
+	case err := <-serveErr:
+		if err != nil {
+			t.Fatalf("Serve returned %v on context cancel; want nil (graceful-shutdown timeout must not surface as an error)", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Serve did not return after context cancel")
+	}
+
+	close(releaseHandler)
+}

--- a/internal/control/server/server.go
+++ b/internal/control/server/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/subtle"
 	"encoding/json"
+	"errors"
 	"net"
 	"net/http"
 	"sort"
@@ -21,11 +22,12 @@ type Options struct {
 }
 
 type Server struct {
-	token   string
-	store   *state.Store
-	runtime RuntimeAPI
-	now     func() time.Time
-	http    *http.Server
+	token           string
+	store           *state.Store
+	runtime         RuntimeAPI
+	now             func() time.Time
+	shutdownTimeout time.Duration
+	http            *http.Server
 }
 
 func New(options Options) *Server {
@@ -33,7 +35,7 @@ func New(options Options) *Server {
 	if now == nil {
 		now = time.Now
 	}
-	server := &Server{token: options.Token, store: options.Store, runtime: options.Runtime, now: now}
+	server := &Server{token: options.Token, store: options.Store, runtime: options.Runtime, now: now, shutdownTimeout: 5 * time.Second}
 	server.http = &http.Server{
 		Handler:           server.Handler(),
 		ReadHeaderTimeout: 5 * time.Second,
@@ -116,9 +118,17 @@ func (s *Server) Serve(ctx context.Context, listener net.Listener) error {
 		}
 		return err
 	case <-ctx.Done():
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), s.shutdownTimeout)
 		defer cancel()
-		return s.http.Shutdown(shutdownCtx)
+		// Graceful shutdown is best-effort: if in-flight connections prevent
+		// draining within the budget, http.Shutdown returns DeadlineExceeded.
+		// On the cancellation path that timeout is expected and must not be
+		// surfaced as a daemon error (it flaked the integration suite under
+		// -race on slow CI). Only propagate genuine, non-deadline errors.
+		if err := s.http.Shutdown(shutdownCtx); err != nil && !errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+		return nil
 	}
 }
 


### PR DESCRIPTION
## Summary

`control/server.Serve` returned `http.Shutdown`'s error verbatim. When in-flight connections prevented draining within the shutdown budget, `daemon.Run` surfaced a spurious `context deadline exceeded`, flaking `TestControlPlaneLifecycleAndConcurrentStatus`.

## Root cause

The integration test fires 64 concurrent `/v1/status` requests, then cancels the daemon context. On the cancellation path `Serve` calls `http.Shutdown(ctx)` and returns its result directly. On slow / `-race` CI the OS does not close the keep-alive connections within the 5s budget, so `Shutdown` returns `context.DeadlineExceeded`, which bubbles up through `daemon.Run` as a fatal error — even though the daemon was being asked to stop.

The same code passed in PR CI and only failed after merge to `main` (run 31174156925): `-race` + CI load widened the timing window. `internal/web/server.go` already does the right thing (`_ = s.httpServer.Shutdown(...)`); the control plane was inconsistent.

## Fix

- `Serve` treats `context.DeadlineExceeded` from `Shutdown` as acceptable on the cancellation path (returns `nil`), only propagating genuine errors.
- Adds a `shutdownTimeout` field (default `5s`) so the budget is configurable and the regression test can force the deadline deterministically.

## Test plan

- [x] New `TestServeContextCancelToleratesShutdownTimeout` deterministically forces the shutdown deadline and asserts `Serve` returns `nil` (RED before fix, GREEN after).
- [x] `go test -race ./internal/control/... ./internal/integration/... -count=5` — all green, incl. the previously flaky integration test.
- [x] `golangci-lint run ./...` — 0 issues.