### PR TITLE
fix(release): make PLATFORMS (goos, goarch) pairs for AList scripts

### DIFF
--- a/scripts/alist_client.py
+++ b/scripts/alist_client.py
@@ -18,10 +18,13 @@ import requests
 
 DEFAULT_BASE_PATH = "/mihari"
 DEFAULT_KEEP_VERSIONS = 5
+# (goos, goarch) pairs so the release/retract `for goos, goarch in PLATFORMS`
+# loops unpack correctly. v0.2.0 crashed at release-alist.py:47 because these
+# were "goos/goarch" strings; test_alist_client.test_platforms_* pins the shape.
 PLATFORMS = [
-    "linux/amd64", "linux/arm64",
-    "darwin/amd64", "darwin/arm64",
-    "windows/amd64", "windows/arm64",
+    ("linux", "amd64"), ("linux", "arm64"),
+    ("darwin", "amd64"), ("darwin", "arm64"),
+    ("windows", "amd64"), ("windows", "arm64"),
 ]
 SEMVER_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
 INDEX_PLACEHOLDER = "__MIHARI_INDEX_URL__"

--- a/scripts/test_alist_client.py
+++ b/scripts/test_alist_client.py
@@ -1,0 +1,40 @@
+"""Regression tests for the alist_client shared constants/helpers.
+
+Guards the PLATFORMS shape that release-alist.py and retract-alist.py consume
+via `for goos, goarch in PLATFORMS`. The first v0.2.0 release crashed at
+release-alist.py:47 (ValueError: too many values to unpack) because PLATFORMS
+was a list of "goos/goarch" strings — unpacking an 11-char string into two
+names yields too many values. These tests pin PLATFORMS to (goos, goarch)
+pairs so neither the publish nor the retract flow can regress.
+"""
+from alist_client import PLATFORMS, bundle_name, semver_key
+
+
+def test_platforms_unpack_as_goos_goarch_pairs():
+    # The exact unpacking the publish/retract loops perform — must not raise.
+    names = [bundle_name(goos, goarch) for goos, goarch in PLATFORMS]
+    assert len(names) == len(PLATFORMS)
+
+
+def test_platforms_are_two_tuples_not_strings():
+    # The bug: a "linux/amd64" string unpacks into >2 values. Reject that shape.
+    for entry in PLATFORMS:
+        assert not isinstance(entry, str), f"PLATFORMS entry must be a pair, got string {entry!r}"
+        goos, goarch = entry
+        assert isinstance(goos, str) and isinstance(goarch, str)
+
+
+def test_platforms_cover_six_targets():
+    assert len(PLATFORMS) == 6
+
+
+def test_bundle_name_formats():
+    assert bundle_name("linux", "amd64") == "mihari-all-in-one-linux-amd64.tar.gz"
+    assert bundle_name("darwin", "arm64") == "mihari-all-in-one-darwin-arm64.tar.gz"
+    assert bundle_name("windows", "arm64") == "mihari-all-in-one-windows-arm64.zip"
+
+
+def test_semver_key_orders_versions():
+    assert semver_key("v0.2.0") == (0, 2, 0)
+    assert semver_key("v0.10.3") == (0, 10, 3)
+    assert semver_key("not-a-version") is None


### PR DESCRIPTION
## Problem
v0.2.0 的 AList 国内分发步骤在 `release-alist.py:47` 崩溃：
```
ValueError: too many values to unpack (expected 2)
```
`alist_client.PLATFORMS` 是 `"goos/goarch"` 字符串列表，但 publish/retract 脚本用 `for goos, goarch in PLATFORMS` 解包——字符串解包成 >2 个字符。#11 引入 AList 分发后从未实跑过（PR 的 CI 只跑 Go 测试 + py_compile），v0.2.0 首次发版才暴露。GitHub Release 本身已成功发布（14 个资产），仅国内分发渠道失败。

## Fix
`PLATFORMS` 改为 `(goos, goarch)` 元组列表——改一处定义，3 个消费点全部修正：
- `release-alist.py:47`（上传整合包，崩溃处）
- `release-alist.py:72`（建 index.txt）
- `retract-alist.py:75`（撤回时重建 index）

## Test
- [x] 新增 `scripts/test_alist_client.py`（pytest）：pin PLATFORMS 为 (goos,goarch) 对、覆盖 bundle_name / semver_key。修复前 RED（ValueError），修复后 GREEN（5 passed）。
- [x] `python -m py_compile alist_client.py release-alist.py retract-alist.py` 通过。
- [x] 迭代 `bundle_name(g,a) for g,a in PLATFORMS` 产出 6 个整合包名。

## 后续
合并后用 `workflow_dispatch release.yml version=v0.2.0` 重跑补传 AList（幂等：GitHub release 更新、整合包重传、index.txt 建立、离线安装命令追加到 release notes）。