### PR TITLE
fix(release): use body field for gh release view notes append

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          NOTES="$(gh release view "${VERSION}" --json notes -q .notes)"
+          NOTES="$(gh release view "${VERSION}" --json body -q .body)"
           MARKER='<!-- aio-install -->'
           printf '%s\n' "$NOTES" | grep -qF "$MARKER" && { echo "install commands already present"; exit 0; }
           # Quoted heredoc delimiter: backticks and placeholders pass through


### PR DESCRIPTION
## Problem
v0.2.0 重跑时 release job 最后一步 `Append offline install commands to release notes` 失败：
```
Unknown JSON field: "notes"
```
`gh release view --json notes` 字段名错了——gh CLI 的 release 正文字段是 `body`。这步首次实跑（之前它在 AList publish 步骤之后，而 AList 步骤直到本轮 #14 修复后才成功）。

## Fix
`release.yml:174`: `--json notes -q .notes` → `--json body -q .body`。`gh release edit --notes` 不变（edit 用 `--notes` flag、view 用 `body` 字段，是 gh CLI 的不对称）。

## Test
- [x] 本地验证：`gh release view v0.2.0 --json body -q '.body | length'` → 866；`--json notes` 被拒。
- [x] 当前 v0.2.0 release notes 无 `aio-install` marker，重跑后 append 会执行。
- [ ] 合并后第三次重跑 release v0.2.0，确认 release notes 含国内离线安装命令、release job 全绿。