### PR TITLE
fix(release): recover aio install links after token rotation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,15 +165,20 @@ jobs:
             --keep-versions "${MIHARI_KEEP_VERSIONS:-5}"
 
       - name: Append offline install commands to release notes
-        # design §4.5 step 7. Idempotent via a marker (generate_release_notes
-        # regenerates the body each publish, so the appendix is re-added cleanly).
+        # design §4.5 step 7. Re-renders the appendix from the marker onward
+        # every publish (idempotent + self-healing: a token rotation that
+        # invalidated prior links is recovered on the next run).
         if: ${{ env.ALIST_URL != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           NOTES="$(gh release view "${VERSION}" --json body -q .body)"
           MARKER='<!-- aio-install -->'
-          printf '%s\n' "$NOTES" | grep -qF "$MARKER" && { echo "install commands already present"; exit 0; }
+          # Replace (not skip) any existing aio-install section so the freshest
+          # signed URLs re-render every publish — recovers from a token rotation
+          # that invalidated previously injected links. The marker is unique to
+          # this appendix, so from it through EOF is ours to overwrite.
+          NOTES="$(printf '%s\n' "$NOTES" | awk -v m="$MARKER" 'index($0,m){f=1} !f')"
           # Quoted heredoc delimiter: backticks and placeholders pass through
           # verbatim (no shell expansion); the two URLs are injected via sed.
           cat > /tmp/aio_append.md <<'TEMPLATE'


### PR DESCRIPTION
## 背景

离线安装命令 (aio) 的签名直链 `?sign=...` 依赖 AList 站点 Token。一旦 Token 被改，所有用旧 Token 算的 sign 全部返回 401 `sign invalid`。

源码实证（AList `pkg/sign/hmac.go`）：`sign = base64url(HMAC-SHA256(Token, path + ":" + expire))`，**不含文件内容**，`expire=0` 永不过期。所以「文件被覆盖」不会让 sign 失效，唯一原因就是站点 Token 变了。

更糟的是：`release.yml` 的 release-notes 步骤用 `<!-- aio-install -->` marker 做幂等去重 —— marker 一旦存在就 `exit 0` 跳过，所以 **Token 变更后，无论重跑多少次 workflow，release notes 里那条失效 sign 永远不会被刷新**，用户复制的安装命令始终是旧的、失效的。

## 改动

把「marker 存在则跳过」改成「marker 存在则**替换该段**」：用 awk 删除 marker 到 EOF 的旧内容，然后总是用最新 URL 重新追加。

- 幂等 + 自愈：Token 轮换后，重跑一次 release workflow，release notes 的安装命令自动更新成有效 sign。
- 首次发布（无 marker）行为不变。
- awk 逻辑已本地验证（有 marker / 无 marker 两种情况均符合预期）。

## 验证计划

合并到 main 后（需 `--admin` 绕过 review）：
1. 固定 AList Token，别再改
2. `gh workflow run release.yml -f version=v0.2.0` 重跑
3. 确认 release notes 的 aio-install 段被新 sign 覆盖、命令可用
4. 把有效命令回填 README.zh-CN.md / README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)