### PR TITLE
fix(distribution): AList 离线分发适配公开深层路径（去 sign）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,26 +161,26 @@ jobs:
             --version "${VERSION}" \
             --dist-dir dist \
             --repo-root . \
-            --base-path "${ALIST_BASE_PATH:-/mihari}" \
+            --base-path "${ALIST_BASE_PATH:-/mihari-release/mihari}" \
             --keep-versions "${MIHARI_KEEP_VERSIONS:-5}"
 
       - name: Append offline install commands to release notes
-        # design §4.5 step 7. Re-renders the appendix from the marker onward
-        # every publish (idempotent + self-healing: a token rotation that
-        # invalidated prior links is recovered on the next run).
+        # design §4.5 step 7. The install commands are fixed public direct
+        # links (signing is off on the AList drive), so they never change
+        # between releases — append once per release; skip if the marker is
+        # already present (idempotent re-runs).
         if: ${{ env.ALIST_URL != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           NOTES="$(gh release view "${VERSION}" --json body -q .body)"
           MARKER='<!-- aio-install -->'
-          # Replace (not skip) any existing aio-install section so the freshest
-          # signed URLs re-render every publish — recovers from a token rotation
-          # that invalidated previously injected links. The marker is unique to
-          # this appendix, so from it through EOF is ours to overwrite.
-          NOTES="$(printf '%s\n' "$NOTES" | awk -v m="$MARKER" 'index($0,m){f=1} !f')"
-          # Quoted heredoc delimiter: backticks and placeholders pass through
-          # verbatim (no shell expansion); the two URLs are injected via sed.
+          if printf '%s' "$NOTES" | grep -qF "$MARKER"; then
+            echo "offline install section already present — skipping"
+            exit 0
+          fi
+          # Quoted heredoc delimiter: backticks and the irm scriptblock pass
+          # through verbatim (no shell expansion). URLs are fixed public links.
           cat > /tmp/aio_append.md <<'TEMPLATE'
 
           <!-- aio-install -->
@@ -189,14 +189,13 @@ jobs:
           Linux / macOS：
 
           ```bash
-          curl -fsSL __SH_URL__ | bash
+          curl -fsSL https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.sh | bash
           ```
 
           Windows (PowerShell)：
 
           ```powershell
-          & ([scriptblock]::Create((irm __PS1_URL__)))
+          & ([scriptblock]::Create((irm https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.ps1)))
           ```
           TEMPLATE
-          sed -i "s#__SH_URL__#${ALIST_REMOTE_SH_URL}#g; s#__PS1_URL__#${ALIST_REMOTE_PS1_URL}#g" /tmp/aio_append.md
           gh release edit "${VERSION}" --notes "$(printf '%s\n%s\n' "$NOTES" "$(cat /tmp/aio_append.md)")"

--- a/.github/workflows/retract.yml
+++ b/.github/workflows/retract.yml
@@ -57,7 +57,7 @@ jobs:
           python -c "import requests" 2>/dev/null || pip install requests
           python scripts/retract-alist.py \
             --version "${VERSION}" \
-            --base-path "${ALIST_BASE_PATH:-/mihari}"
+            --base-path "${ALIST_BASE_PATH:-/mihari-release/mihari}"
 
       - name: Delete GitHub release
         # design §4.6 step 5: release + assets + tag. --cleanup-tag lets the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 本文件记录 Mihari 每个版本的变更。版本遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
+## [Unreleased]
+
+### Changed
+
+- 离线分发去 sign 化 + 适配 AList 深层路径：AList 改为公开分发（关闭签名），所有直链去掉 `?sign=`；`install-aio-remote.{sh,ps1}` 改为硬编码固定公开 `INDEX_URL`（去掉 CI 占位符注入），README 安装命令变为永久固定字面量，复制即用、无需手改。base_path 适配当前 AList 拓扑 `/mihari-release/mihari`，`public_url` 注入 `/public` 中缀以绕过 AList 的 fs/API 路径与 `/p` 下载路由前缀不一致的 quirk。
+
+### Fixed
+
+- 修复国内离线安装命令失效：签名直链全部返回 `sign invalid`（401）。根因为 AList 签名机制在部署层失效；改公开分发后根除（前置：AList 存储关闭签名）。
+
 ## [v0.2.0] - 2026-08-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -52,19 +52,19 @@ Or download the binary for your platform from the [Releases page](https://github
 
 **China / no GitHub access (offline)**
 
-An all-in-one bundle (mihari binary + mihomo core + GeoIP, sha256-verified) is mirrored on a self-hosted AList drive, so installs never touch GitHub. The signed one-line installer URL for each platform is appended to every release's notes under "国内离线安装":
+An all-in-one bundle (mihari binary + mihomo core + GeoIP, sha256-verified) is mirrored on a self-hosted AList drive, so installs never touch GitHub. One fixed command per platform — copy and run:
 
 ```sh
 # Linux / macOS
-curl -fsSL <install-aio-remote.sh signed link from release notes> | bash
+curl -fsSL https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.sh | bash
 ```
 
 ```powershell
 # Windows (PowerShell)
-& ([scriptblock]::Create((irm <install-aio-remote.ps1 signed link from release notes>)))
+& ([scriptblock]::Create((irm https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.ps1)))
 ```
 
-Copy the real signed link from the [latest release notes](https://github.com/mihari-proxy/mihari/releases). See [docs/distribution.md](docs/distribution.md) for the offline distribution design.
+See [docs/distribution.md](docs/distribution.md) for the offline distribution design.
 
 **First run**
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -52,19 +52,19 @@ irm https://raw.githubusercontent.com/mihari-proxy/mihari/main/install.ps1 | iex
 
 **国内 / 无 GitHub 访问（离线）**
 
-整合包（mihari 二进制 + mihomo 核心 + GeoIP,含 sha256 校验）镜像在自建 AList 网盘上,安装全程不触碰 GitHub。各平台的签名直链一键安装命令会追加到每个 release notes 的「国内离线安装」一节:
+整合包（mihari 二进制 + mihomo 核心 + GeoIP,含 sha256 校验）镜像在自建 AList 网盘上,安装全程不触碰 GitHub。各平台一条固定命令,复制即用:
 
 ```sh
 # Linux / macOS
-curl -fsSL <install-aio-remote.sh 签名直链> | bash
+curl -fsSL https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.sh | bash
 ```
 
 ```powershell
 # Windows (PowerShell)
-& ([scriptblock]::Create((irm <install-aio-remote.ps1 签名直链>)))
+& ([scriptblock]::Create((irm https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.ps1)))
 ```
 
-真实签名直链从[最新 release notes](https://github.com/mihari-proxy/mihari/releases) 复制。离线分发设计见 [docs/distribution.md](docs/distribution.md)。
+离线分发设计见 [docs/distribution.md](docs/distribution.md)。
 
 **首次运行**
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -29,17 +29,17 @@ curl -fsSL https://raw.githubusercontent.com/mihari-proxy/mihari/main/install.sh
 
 ```bash
 # Linux / macOS
-curl -fsSL <install-aio-remote.sh 签名直链> | bash
+curl -fsSL https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.sh | bash
 
 # Windows (PowerShell)
-& ([scriptblock]::Create((irm <install-aio-remote.ps1 签名直链>)))
+& ([scriptblock]::Create((irm https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.ps1)))
 ```
 
-> **签名直链从哪里来**：每个 GitHub Release 的 release notes 会自动追加「国内离线安装」一节，含上述两条命令的真实签名直链。首次发版后，把这两条命令回填到 README 即可。
+> 命令中的网址是 AList 网盘的固定公开直链（签名已关闭），永久不变，复制即用。
 
 脚本3 下载器的执行流程：
 
-1. 下载根目录 `index.txt`（固定签名直链，永久有效），解析出最新版本号与本平台的整合包签名直链 + sha256；
+1. 下载根目录 `index.txt`（固定公开直链，永久有效），解析出最新版本号与本平台的整合包公开直链 + sha256；
 2. 询问确认（`--yes` / `-y` 可跳过；stdin 非 tty 时读 `/dev/tty`）；
 3. 下载整合包 → `Downloads/mihari-aio/` → sha256 校验；
 4. 解压到 `Downloads/mihari-aio/`；
@@ -62,19 +62,19 @@ sh install-aio.sh        # Windows: powershell -File install-aio.ps1
 |------|--------|------|
 | `MIHARI_BIN` | `/usr/local/bin`（Linux/macOS）<br>`%LOCALAPPDATA%\Programs\mihari`（Windows） | mihari 二进制安装目录 |
 | `MIHARI_DATA` | `$HOME/.mihari`（Linux/macOS）<br>`%USERPROFILE%\.mihari`（Windows） | 数据根目录（核心 + GeoIP 落地处） |
-| `MIHARI_INDEX_URL` | （CI 注入） | index.txt 签名直链（脚本3） |
+| `MIHARI_INDEX_URL` | 公开直链（见脚本默认值） | index.txt 公开直链（脚本3） |
 | `MIHARI_BUNDLE_URL` | 空 | 显式指定整合包 URL，**跳过 index 与 sha256 校验**（信任自担） |
 
 ---
 
 ## 二、AList 网盘目录结构
 
-base_path 默认 `/mihari`（通过 GitHub 变量 `ALIST_BASE_PATH` 配置）：
+base_path 默认 `/mihari-release/mihari`（AList fs/API 路径，通过 GitHub 变量 `ALIST_BASE_PATH` 配置）：
 
 ```
-/mihari/
-├── index.txt                       路由表（根目录固定签名直链）
-├── install-aio-remote.sh / .ps1    脚本3 下载器（CI 注入 index 直链，每次发布覆盖）
+/mihari-release/mihari/             base_path（fs/API 路径）
+├── index.txt                       路由表（公开直链）
+├── install-aio-remote.sh / .ps1    脚本3 下载器（内含固定公开 index 直链，每次发布覆盖）
 ├── v0.3.0/                         不可变版本目录
 │   ├── mihari-all-in-one-{linux,darwin,windows}-{amd64,arm64}.tar.gz / .zip
 │   ├── SHA256SUMS.txt              本版本 6 个整合包的 sha256
@@ -83,19 +83,21 @@ base_path 默认 `/mihari`（通过 GitHub 变量 `ALIST_BASE_PATH` 配置）：
 └── v0.1.0/
 ```
 
+> **AList 拓扑 quirk**：fs/API 路径（上传、list、get）用 `/mihari-release/mihari/…`，但**公开下载 URL** 需在 `/p` 后加 `/public` 挂载点前缀，即 `https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/…`（`alist_client.public_url` 自动处理）。若日后恢复 `/mihari` 挂载点，此 quirk 消失：base_path 改回 `/mihari`、`public_url` 去掉 `/public` 中缀。
+
 ### index.txt 格式
 
 ```
 latest v0.3.0
-linux-amd64   <签名直链>  <sha256>
-linux-arm64   <签名直链>  <sha256>
-darwin-amd64  <签名直链>  <sha256>
-darwin-arm64  <签名直链>  <sha256>
-windows-amd64 <签名直链>  <sha256>
-windows-arm64 <签名直链>  <sha256>
+linux-amd64   <公开直链>  <sha256>
+linux-arm64   <公开直链>  <sha256>
+darwin-amd64  <公开直链>  <sha256>
+darwin-arm64  <公开直链>  <sha256>
+windows-amd64 <公开直链>  <sha256>
+windows-arm64 <公开直链>  <sha256>
 ```
 
-每行 `<key> <rest...>`：`latest` 行的 key 后是版本号；平台行的 key 是 `<goos>-<goarch>`，后跟签名直链与 sha256。脚本3 按此解析。
+每行 `<key> <rest...>`：`latest` 行的 key 后是版本号；平台行的 key 是 `<goos>-<goarch>`，后跟公开直链与 sha256。脚本3 按此解析。
 
 ### 发布顺序（零失败窗口）
 
@@ -125,7 +127,7 @@ release workflow 的 AList 步骤顺序保证用户永远拿不到半成品：
 
 1. `workflow_dispatch` 输入 `version`（纯 semver 闸门）+ `confirm`（布尔双保险）；
 2. 读 `index.txt` 判断撤回版本是否为当前 latest；
-3. 删除 AList 版本目录 `/mihari/<version>/`；
+3. 删除 AList 版本目录 `<base_path>/<version>/`；
 4. **仅当撤回的是 latest** 才重建 `index.txt`：latest 改为现存最高且完整（含 `COMPLETE`）的版本（sha256 从该目录的 `SHA256SUMS.txt` 读取）；无完整版本 → `index.txt` 置空；
 5. `gh release delete <version> --yes --cleanup-tag`（删 release + 资产 + tag，允许修复后同版本号重发）。
 
@@ -153,7 +155,7 @@ AList 分发步骤在 release workflow 中以 `if: env.ALIST_URL != ''` 包裹�
 
 | Variable | 默认值 | 用途 |
 |----------|--------|------|
-| `ALIST_BASE_PATH` | `/mihari` | 网盘 base_path |
+| `ALIST_BASE_PATH` | `/mihari-release/mihari` | 网盘 base_path（fs/API 路径） |
 | `MIHARI_KEEP_VERSIONS` | `5` | 保留版本数 |
 
-> **签名直链失效**：直链的 sign 依赖 AList 站点 **Token**（后台 settings 的 `token` 项，非登录 JWT）。直接改登录账号密码**不**作废直链；改站点 Token 才让全部旧 sign 失效。恢复 = **重跑 release workflow**（fs/get 现有 index.txt 取新 sign 重建，幂等）。
+> **前置：关闭签名**。AList 存储必须关闭「签名」（per-storage Sign 关），公开直链才不会 401。

--- a/install-aio-remote.ps1
+++ b/install-aio-remote.ps1
@@ -1,23 +1,24 @@
 # mihari all-in-one REMOTE downloader for Windows (script 3). Fetches the
-# platform bundle from the AList drive (index.txt -> signed direct link +
+# platform bundle from the AList drive (index.txt -> public direct link +
 # sha256), verifies it, extracts, and hands off to the local installer
 # (script 2) inside the bundle.
-#   & ([scriptblock]::Create((irm <ALIST>/p/mihari/install-aio-remote.ps1?sign=<fixed>)))
-#   & ([scriptblock]::Create((irm <ALIST>/p/mihari/install-aio-remote.ps1?sign=<fixed>))) -Yes
+#   & ([scriptblock]::Create((irm https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.ps1)))
+#   & ([scriptblock]::Create((irm https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.ps1))) -Yes
 #
 # One-time: only the first offline install goes through this downloader; later
 # reinstalls run script 2 (install-aio.ps1) directly from an existing bundle.
 #
 # Environment overrides:
-#   $env:MIHARI_INDEX_URL   index.txt signed direct link (default: CI-injected placeholder)
+#   $env:MIHARI_INDEX_URL   index.txt public direct link (default: the fixed public URL below)
 #   $env:MIHARI_BUNDLE_URL  explicit bundle URL (skips index + sha256)
 param([switch]$Yes)
 $ErrorActionPreference = 'Stop'
 
-# Placeholder: the release workflow (design 4.5 step 5) injects the root
-# index.txt signed direct link here. Pre-injection this token is not a URL, so
-# the index fetch fails with a clear "not published yet" message.
-$indexUrl = if ($env:MIHARI_INDEX_URL) { $env:MIHARI_INDEX_URL } else { '__MIHARI_INDEX_URL__' }
+# Fixed public direct link to the root index.txt. mihari distribution is fully
+# public (signing disabled on the AList drive), so this URL is stable and
+# identical across releases — copy-paste, never hand-edit. The release workflow
+# uploads index.txt to this exact path each publish.
+$indexUrl = if ($env:MIHARI_INDEX_URL) { $env:MIHARI_INDEX_URL } else { 'https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/index.txt' }
 $bundleUrl = $env:MIHARI_BUNDLE_URL
 
 function Info($m) { Write-Host "* $m" -ForegroundColor Cyan }
@@ -42,7 +43,7 @@ $platform = "windows-$arch"
 $latest = ''; $wantSum = ''; $resolvedUrl = $bundleUrl
 if (-not $resolvedUrl) {
   # index.txt line format: "<key> <rest...>". key="latest" -> <version>;
-  # key="<goos>-<goarch>" -> <signed_url> <sha256>.
+  # key="<goos>-<goarch>" -> <public_url> <sha256>.
   $index = ''
   try { $index = (Invoke-WebRequest -Uri $indexUrl -UseBasicParsing).Content } catch { $index = '' }
   if (-not $index) { Fail "尚未发布完成：无法获取 index（请稍后重试，或检查网络/网盘可用性）。" }

--- a/install-aio-remote.sh
+++ b/install-aio-remote.sh
@@ -1,22 +1,23 @@
 #!/usr/bin/env sh
 # mihari all-in-one REMOTE downloader (script 3). Fetches the platform bundle
-# from the AList drive (index.txt → signed direct link + sha256), verifies it,
+# from the AList drive (index.txt → public direct link + sha256), verifies it,
 # extracts, and hands off to the local installer (script 2) inside the bundle.
-#   curl -fsSL <ALIST>/p/mihari/install-aio-remote.sh?sign=<fixed> | bash
+#   curl -fsSL https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.sh | bash
 #   sh install-aio-remote.sh [--yes|-y]
 #
 # One-time: only the first offline install goes through this downloader; later
 # reinstalls run script 2 (install-aio.sh) directly from an existing bundle.
 #
 # Environment overrides:
-#   MIHARI_INDEX_URL   index.txt signed direct link (default: CI-injected placeholder)
+#   MIHARI_INDEX_URL   index.txt public direct link (default: the fixed public URL below)
 #   MIHARI_BUNDLE_URL  explicit bundle URL (skips index + sha256 — trust borne by user)
 set -eu
 
-# Placeholder: the release workflow (design §4.5 step 5) injects the root
-# index.txt signed direct link here. Pre-injection this token is not a URL, so
-# the index fetch fails with a clear "not published yet" message.
-INDEX_URL="${MIHARI_INDEX_URL:-__MIHARI_INDEX_URL__}"
+# Fixed public direct link to the root index.txt. mihari distribution is fully
+# public (signing disabled on the AList drive), so this URL is stable and
+# identical across releases — copy-paste, never hand-edit. The release workflow
+# uploads index.txt to this exact path each publish.
+INDEX_URL="${MIHARI_INDEX_URL:-https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/index.txt}"
 BUNDLE_URL="${MIHARI_BUNDLE_URL:-}"
 YES=0
 for arg in "$@"; do
@@ -88,7 +89,7 @@ if [ -n "$BUNDLE_URL" ]; then
   bundle_url="$BUNDLE_URL"
 else
   # index.txt line format: "<key> <rest...>". key="latest" → <version>;
-  # key="<goos>-<goarch>" → <signed_url> <sha256>.
+  # key="<goos>-<goarch>" → <public_url> <sha256>.
   index="$(fetch "$INDEX_URL" 2>/dev/null || true)"
   [ -n "$index" ] || err "尚未发布完成：无法获取 index（请稍后重试，或检查网络/网盘可用性）。"
   # Heredoc (not a pipe) so parsed values survive outside the loop's subshell.

--- a/scripts/alist_client.py
+++ b/scripts/alist_client.py
@@ -16,7 +16,11 @@ from urllib.parse import quote
 
 import requests
 
-DEFAULT_BASE_PATH = "/mihari"
+# AList topology quirk: the fs API (list/get/put/mkdir) addresses files under
+# the root storage (paths rooted at /), so this is the *fs* base path. The /p
+# download route needs a different prefix — see AList.public_url. Verified
+# 2026-08; if a /mihari mount is ever restored, set this back to "/mihari".
+DEFAULT_BASE_PATH = "/mihari-release/mihari"
 DEFAULT_KEEP_VERSIONS = 5
 # (goos, goarch) pairs so the release/retract `for goos, goarch in PLATFORMS`
 # loops unpack correctly. v0.2.0 crashed at release-alist.py:47 because these
@@ -27,7 +31,6 @@ PLATFORMS = [
     ("windows", "amd64"), ("windows", "arm64"),
 ]
 SEMVER_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
-INDEX_PLACEHOLDER = "__MIHARI_INDEX_URL__"
 
 
 def fail(message):
@@ -83,12 +86,6 @@ class AList:
     def exists(self, path):
         return self.get(path).get("code") == 200
 
-    def sign_of(self, path):
-        data = self.get(path)
-        if data.get("code") != 200:
-            return None
-        return data["data"].get("sign", "")
-
     def list_dir(self, path):
         data = self._post("/api/fs/list", json={"path": path, "password": "", "page": 1, "per_page": 0, "refresh": False})
         return data.get("data", {}).get("content") or []
@@ -127,19 +124,27 @@ class AList:
         self._post("/api/fs/remove", json={"dir": dir_path, "names": list(names)})
 
     def content(self, path):
-        """Read a remote text file via its signed proxy route. Returns None when
-        the file does not exist (sign_of is None). Used by retract to read the
-        root index.txt and a version dir's SHA256SUMS.txt."""
-        sign = self.sign_of(path)
-        if sign is None:
+        """Read a remote text file via its public proxy route. Returns None when
+        the file does not exist. Used by retract to read the root index.txt and
+        a version dir's SHA256SUMS.txt."""
+        if not self.exists(path):
             return None
-        response = self.session.get(self.signed_url(path, sign), timeout=120)
+        response = self.session.get(self.public_url(path), timeout=120)
         response.raise_for_status()
         return response.text
 
-    def signed_url(self, path, sign):
-        # /p<path>?sign=... is AList's proxy/stream route (design §4.4 URL form).
-        return f"{self.base}/p{path}?sign={sign}"
+    def public_url(self, path):
+        # Turn an fs API path into a working public download URL. AList topology
+        # quirk (verified 2026-08): the fs API (list/get/put/mkdir) addresses
+        # files under the root storage (paths like /mihari-release/mihari/…), but
+        # the /p download route only serves the explicit "/public" mount point,
+        # so "/public" must be injected between /p and the fs path. No `?sign=` —
+        # mihari distribution is fully public (signing disabled on the drive).
+        # Fragile: bound to the current AList layout; if the drive is restructured
+        # (e.g. a /mihari mount restored), drop the "/public" infix and set
+        # DEFAULT_BASE_PATH back to /mihari. Derived from self.base (ALIST_URL);
+        # the install scripts hardcode the same domain — keep them in sync.
+        return f"{self.base}/p/public{path}"
 
 
 def connect():

--- a/scripts/regenerate-index.py
+++ b/scripts/regenerate-index.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""One-shot index.txt regeneration for the current AList topology.
+
+The on-disk index.txt carries bundle URLs (and sha256) baked in when it was last
+uploaded. After an AList layout change — e.g. the /mihari mount was removed and
+the files now live under /mihari-release/mihari (served via /p/public/...) — an
+older index.txt still points at dead /p/mihari/... links, so installs fetch the
+index fine but then fail on every bundle URL.
+
+This rewrites index.txt to match the *current* topology: it finds the highest
+version dir with a COMPLETE marker, reads that dir's SHA256SUMS.txt, and re-emits
+index.txt with public_url() links (current base_path + /public prefix, no sign).
+Run locally once with AList write credentials after a layout change; the release
+workflow does the same rebuild on every publish, so this is only needed to fix
+an index that predates a manual AList reconfiguration.
+
+Usage:
+    ALIST_URL=https://... ALIST_USERNAME=... ALIST_PASSWORD=... \
+        python scripts/regenerate-index.py
+"""
+import argparse
+import importlib.util
+from pathlib import Path
+
+from alist_client import DEFAULT_BASE_PATH, connect, fail, info
+
+
+def _load_retract():
+    # retract-alist.py has a hyphen in its name — import it manually, exactly as
+    # test_alist_client.py does for release-alist.py.
+    path = Path(__file__).with_name("retract-alist.py")
+    spec = importlib.util.spec_from_file_location("retract_alist", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Regenerate index.txt for the current AList topology."
+    )
+    parser.add_argument("--base-path", default=DEFAULT_BASE_PATH)
+    args = parser.parse_args()
+
+    retract = _load_retract()
+    alist = connect()
+
+    latest = retract.highest_complete(alist, args.base_path, excluded=None)
+    if latest is None:
+        fail("no COMPLETE version dir found — nothing to rebuild index from")
+    info(f"highest complete version: {latest}")
+    retract.rebuild_index(alist, args.base_path, latest)
+    info("index.txt regenerated with current public_url() links")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release-alist.py
+++ b/scripts/release-alist.py
@@ -22,7 +22,6 @@ from alist_client import (
     AList,
     DEFAULT_BASE_PATH,
     DEFAULT_KEEP_VERSIONS,
-    INDEX_PLACEHOLDER,
     PLATFORMS,
     SEMVER_RE,
     bundle_name,
@@ -59,46 +58,33 @@ def upload_version_dir(alist, dist_dir, base_path, version):
 
 
 def build_index(alist, dist_dir, base_path, version):
-    """Steps 2-3: resolve the root index sign + each bundle sign, then return
-    the index.txt body (latest line + per-platform <signed_url> <sha256>)."""
+    """Steps 2-3: return the index.txt body (latest line + per-platform
+    <public_url> <sha256>) plus the root index's public direct link. Public
+    links need no per-file sign, so there's no first-release placeholder dance."""
     root_index_path = f"{base_path}/index.txt"
-    index_sign = alist.sign_of(root_index_path)
-    if index_sign is None:
-        # First release: upload an empty placeholder so fs/get yields a sign.
-        alist.upload_text("", root_index_path)
-        index_sign = alist.sign_of(root_index_path) or ""
 
     lines = [f"latest {version}"]
     for goos, goarch in PLATFORMS:
         platform = f"{goos}-{goarch}"
         name = bundle_name(goos, goarch)
         remote = f"{base_path}/{version}/{name}"
-        sign = alist.sign_of(remote)
-        if sign is None:
-            fail(f"uploaded bundle not found for sign: {remote}")
-        signed = alist.signed_url(remote, sign)
+        if not alist.exists(remote):
+            fail(f"uploaded bundle not found: {remote}")
+        public = alist.public_url(remote)
         digest = sha256_file(Path(dist_dir) / name)
-        lines.append(f"{platform} {signed} {digest}")
-    return "\n".join(lines) + "\n", alist.signed_url(root_index_path, index_sign)
+        lines.append(f"{platform} {public} {digest}")
+    return "\n".join(lines) + "\n", alist.public_url(root_index_path)
 
 
-def render_root_scripts(alist, repo_root, base_path, index_signed_url):
-    """Step 4: inject the root index signed link into script 3 and upload to the
-    drive root (content is constant across releases; overwritten each time).
-    Returns the rendered scripts' signed direct links for release notes."""
-    rendered = {}
+def upload_root_scripts(alist, repo_root, base_path):
+    """Step 4: upload the (now static) downloader scripts to the drive root.
+    They hardcode the public INDEX_URL, so no injection is needed; they're
+    overwritten each release purely to keep the AList copy self-healing."""
     for filename in ("install-aio-remote.sh", "install-aio-remote.ps1"):
         source = Path(repo_root) / filename
         if not source.exists():
             fail(f"downloader script missing: {source}")
-        text = source.read_text(encoding="utf-8").replace(INDEX_PLACEHOLDER, index_signed_url)
-        remote = f"{base_path}/{filename}"
-        alist.upload_text(text, remote)
-        sign = alist.sign_of(remote)
-        if sign is None:
-            fail(f"rendered script not found for sign: {remote}")
-        rendered[filename] = alist.signed_url(remote, sign)
-    return rendered
+        alist.upload_text(source.read_text(encoding="utf-8"), f"{base_path}/{filename}")
 
 
 def prune_versions(alist, base_path, version, keep):
@@ -153,16 +139,13 @@ def main():
 
     alist = connect()
     version_dir = upload_version_dir(alist, args.dist_dir, args.base_path, args.version)
-    index_body, index_signed_url = build_index(alist, args.dist_dir, args.base_path, args.version)
+    index_body, index_url = build_index(alist, args.dist_dir, args.base_path, args.version)
     alist.upload_text(index_body, f"{args.base_path}/index.txt")
-    rendered = render_root_scripts(alist, args.repo_root, args.base_path, index_signed_url)
+    upload_root_scripts(alist, args.repo_root, args.base_path)
     prune_versions(alist, args.base_path, args.version, args.keep_versions)
 
-    emit_env("ALIST_INDEX_URL", index_signed_url)
     emit_env("ALIST_VERSION_DIR", version_dir)
-    emit_env("ALIST_REMOTE_SH_URL", rendered["install-aio-remote.sh"])
-    emit_env("ALIST_REMOTE_PS1_URL", rendered["install-aio-remote.ps1"])
-    info(f"published {args.version} to {args.base_path}; index at {index_signed_url}")
+    info(f"published {args.version} to {args.base_path}; index at {index_url}")
 
 
 if __name__ == "__main__":

--- a/scripts/retract-alist.py
+++ b/scripts/retract-alist.py
@@ -6,10 +6,10 @@ the AList side of the withdrawal — steps 2-4 of the design flow — while step
 (`gh release delete --cleanup-tag`) runs as a shell step in the workflow:
 
   2. read index.txt to learn whether the retracted version is the current latest;
-  3. remove the AList version directory /mihari/<version>/;
+  3. remove the AList version directory <base_path>/<version>/;
   4. rebuild index.txt ONLY when the retracted version was latest — point it at
-     the highest remaining COMPLETE version (sign from fs/get, sha256 read from
-     that version dir's SHA256SUMS.txt), or leave it empty if none remain.
+     the highest remaining COMPLETE version (public direct link, sha256 read
+     from that version dir's SHA256SUMS.txt), or leave it empty if none remain.
 
 Withdrawal removes distribution channels only; already-installed users are not
 recallable (design §4.6 boundary). The AList client and shared helpers come from
@@ -60,8 +60,8 @@ def highest_complete(alist, base_path, excluded):
 
 def rebuild_index(alist, base_path, new_latest):
     """Rewrite index.txt to point at new_latest: latest line + one per-platform
-    signed direct link (fs/get sign) + sha256 (read from that dir's
-    SHA256SUMS.txt). Uploads the new body."""
+    public direct link + sha256 (read from that dir's SHA256SUMS.txt). Uploads
+    the new body."""
     sums_text = alist.content(f"{base_path}/{new_latest}/SHA256SUMS.txt")
     if sums_text is None:
         fail(f"new-latest {new_latest} has no SHA256SUMS.txt — cannot rebuild index")
@@ -76,14 +76,13 @@ def rebuild_index(alist, base_path, new_latest):
         platform = f"{goos}-{goarch}"
         name = bundle_name(goos, goarch)
         remote = f"{base_path}/{new_latest}/{name}"
-        sign = alist.sign_of(remote)
-        if sign is None:
-            fail(f"new-latest bundle missing for sign: {remote}")
-        signed = alist.signed_url(remote, sign)
+        if not alist.exists(remote):
+            fail(f"new-latest bundle missing: {remote}")
+        public = alist.public_url(remote)
         digest = sums.get(name)
         if not digest:
             fail(f"SHA256SUMS.txt in {new_latest} missing entry for {name}")
-        lines.append(f"{platform} {signed} {digest}")
+        lines.append(f"{platform} {public} {digest}")
     alist.upload_text("\n".join(lines) + "\n", f"{base_path}/index.txt")
     info(f"index.txt rebuilt to point at {new_latest}")
 

--- a/scripts/test_alist_client.py
+++ b/scripts/test_alist_client.py
@@ -7,7 +7,10 @@ was a list of "goos/goarch" strings — unpacking an 11-char string into two
 names yields too many values. These tests pin PLATFORMS to (goos, goarch)
 pairs so neither the publish nor the retract flow can regress.
 """
-from alist_client import PLATFORMS, bundle_name, semver_key
+import importlib.util
+from pathlib import Path
+
+from alist_client import AList, PLATFORMS, bundle_name, semver_key
 
 
 def test_platforms_unpack_as_goos_goarch_pairs():
@@ -38,3 +41,61 @@ def test_semver_key_orders_versions():
     assert semver_key("v0.2.0") == (0, 2, 0)
     assert semver_key("v0.10.3") == (0, 10, 3)
     assert semver_key("not-a-version") is None
+
+
+def test_public_url_is_signless_proxy_route():
+    # AList.__init__ would hit the network (_login); bypass it and set only the
+    # attribute public_url reads.
+    alist = AList.__new__(AList)
+    alist.base = "https://cloud.example.com"
+    # public_url injects "/public" between /p and the fs path (AList topology quirk).
+    assert alist.public_url("/mihari-release/mihari/index.txt") == "https://cloud.example.com/p/public/mihari-release/mihari/index.txt"
+    bundle = alist.public_url("/mihari-release/mihari/v0.3.0/mihari-all-in-one-linux-amd64.tar.gz")
+    assert "?sign=" not in bundle
+    assert bundle == "https://cloud.example.com/p/public/mihari-release/mihari/v0.3.0/mihari-all-in-one-linux-amd64.tar.gz"
+
+
+def _load_release_alist():
+    # release-alist.py has a hyphen in its name, so import it manually.
+    path = Path(__file__).with_name("release-alist.py")
+    spec = importlib.util.spec_from_file_location("release_alist", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_index_emits_public_urls_no_sign():
+    release = _load_release_alist()
+
+    class FakeAList:
+        base = "https://cloud.example.com"
+
+        def exists(self, path):
+            return True
+
+        def public_url(self, path):
+            return f"{self.base}/p/public{path}"
+
+    # Stub sha256_file so build_index needs no real bundle files on disk.
+    release.sha256_file = lambda _path: "deadbeef" * 8
+
+    body, index_url = release.build_index(FakeAList(), "dist", "/mihari-release/mihari", "v0.3.0")
+    lines = body.splitlines()
+    assert lines[0] == "latest v0.3.0"
+    assert len(lines) == 1 + len(PLATFORMS)
+    for line in lines[1:]:
+        platform, url, digest = line.split()
+        assert url.startswith("https://cloud.example.com/p/public/mihari-release/mihari/v0.3.0/")
+        assert "?sign=" not in url
+        assert digest == "deadbeef" * 8
+    assert index_url == "https://cloud.example.com/p/public/mihari-release/mihari/index.txt"
+
+
+def test_install_scripts_hardcode_public_index_url():
+    repo_root = Path(__file__).resolve().parent.parent
+    for name in ("install-aio-remote.sh", "install-aio-remote.ps1"):
+        text = (repo_root / name).read_text(encoding="utf-8")
+        assert "__MIHARI_INDEX_URL__" not in text, f"{name} still has the CI placeholder"
+        assert "https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/index.txt" in text, (
+            f"{name} lacks the fixed public index URL"
+        )


### PR DESCRIPTION
## 背景

AList 布局漂移：`/mihari` 挂载被移除，文件现在位于 `/mihari-release/mihari`，通过 `/p/public/...` 公开提供（签名已关闭）。旧代码假设 `base_path /mihari` + 签名直链，导致每条安装链接返回 `storage not found` / `sign invalid`，国内离线安装全断。

## 改动

- **`alist_client.py`**：`DEFAULT_BASE_PATH` → `/mihari-release/mihari`（fs/API 路径）；`public_url` 在 `/p` 与 fs 路径间注入 `/public`（AList 拓扑 quirk：fs API 与 `/p` 下载路由前缀不一致），无 `?sign=`
- **`install-aio-remote.{sh,ps1}`**：硬编码固定公开 `INDEX_URL`（去掉 CI 占位符注入）；README/docs/release.yml 用同一字面量 URL
- **去 sign**：删除 `sign_of`、`signed_url`、`INDEX_PLACEHOLDER`、`ALIST_INDEX_URL/REMOTE_*` env 注入
- **`regenerate-index.py`**（新增）：AList 布局变更后一键重建 index.txt
- **测试**：固定 `/p/public` 前缀、无 sign URL、硬编码 index URL（8 用例全过）

## 验证

- ✅ `python -m pytest test_alist_client.py` → 8 passed
- ✅ 下载端冒烟：`/p/public/mihari-release/mihari/` 下 index.txt、install 脚本、v0.2.0 bundle（HTTP 206）均可达
- ⏳ 上传端（fs/put/mkdir 到新 base_path）：合并后发 v0.3.0 时由 CI 验证

## 发版后验证清单（v0.3.0）

1. CI 通过，AList 出现 `/mihari-release/mihari/v0.3.0/` + 刷新后的 `index.txt`
2. `curl index.txt` → 指向 v0.3.0 + `/p/public/...` + 无 `?sign=`
3. release notes 含「国内离线安装」字面量命令段

## 注意

当前磁盘 index.txt 仍是坏的（指向旧 `/p/mihari`）。合并后发 v0.3.0，CI 会用新代码重写 index.txt 指向 v0.3.0（v0.2.0 不再被引用），端到端即通。

🤖 Generated with [Claude Code](https://claude.com/claude-code)