### PR TITLE
fix(distribution): make AList writes land on the read path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - 修复国内离线安装命令失效：签名直链全部返回 `sign invalid`（401）。根因为 AList 签名机制在部署层失效；改公开分发后根除（前置：AList 存储关闭签名）。
+- 修复 AList 发版文件落点错误 + 上传静默失败：fs/put|mkdir|remove 把 File-Path 当相对存储根路径，首段挂载点 `/mihari-release` 被重复拼接，导致整个版本目录 + `index.txt` 实际写到 `/mihari-release/mihari-release/mihari/`（用户访问的读路径 `/mihari-release/mihari/` 读不到）。`alist_client._write_path` 在所有写操作里去掉首段，让写落到读路径；同时 `upload`/`upload_text` 改为检查 AList body `code`（AList 永远返 HTTP 200，真失败此前被静默吞掉），写失败即报错。
 
 ## [v0.2.0] - 2026-08-07
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -83,7 +83,11 @@ base_path 默认 `/mihari-release/mihari`（AList fs/API 路径，通过 GitHub 
 └── v0.1.0/
 ```
 
-> **AList 拓扑 quirk**：fs/API 路径（上传、list、get）用 `/mihari-release/mihari/…`，但**公开下载 URL** 需在 `/p` 后加 `/public` 挂载点前缀，即 `https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/…`（`alist_client.public_url` 自动处理）。若日后恢复 `/mihari` 挂载点，此 quirk 消失：base_path 改回 `/mihari`、`public_url` 去掉 `/public` 中缀。
+> **AList 拓扑 quirk（读路径 / 下载）**：fs/list、fs/get 用虚拟绝对路径 `/mihari-release/mihari/…`；**公开下载 URL** 需在 `/p` 后加 `/public` 挂载点前缀，即 `https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/…`（`alist_client.public_url` 自动处理）。
+>
+> **AList 拓扑 quirk（写路径）**：fs/put、fs/mkdir、fs/remove 把 File-Path 当成**相对存储根**的路径，首段（挂载点 `/mihari-release`）会被重复拼接——写 `/mihari-release/mihari/X` 实际落到 `/mihari-release/mihari-release/mihari/X`（读路径读不到）。读 API（list/get）不受影响。`alist_client._write_path` 在所有写操作里去掉首段，让写落到读路径；`upload`/`upload_text` 还会检查 AList body `code`（AList 永远返 HTTP 200，真失败此前被静默吞掉），写失败即报错。
+>
+> 若日后恢复 `/mihari` 挂载点（读写在同一路径、`/p` 也无需 `/public`），这两个 quirk 同时消失：base_path 改回 `/mihari`，`public_url` 去掉 `/public` 中缀，`_write_path` 改为原样返回。
 
 ### index.txt 格式
 

--- a/scripts/alist_client.py
+++ b/scripts/alist_client.py
@@ -90,38 +90,72 @@ class AList:
         data = self._post("/api/fs/list", json={"path": path, "password": "", "page": 1, "per_page": 0, "refresh": False})
         return data.get("data", {}).get("content") or []
 
+    def _write_path(self, path):
+        """Strip the leading mount segment so an fs/put|mkdir|remove write lands
+        where fs/list|get and /p/public downloads see it.
+
+        AList write-path quirk (verified 2026-08-10): fs/put, fs/mkdir and
+        fs/remove resolve the File-Path (and fs/remove's `dir`) RELATIVE to the
+        storage root, so the leading path segment — the mount point — gets
+        prepended again. A write of "/mihari-release/mihari/X" physically lands at
+        "/mihari-release/mihari-release/mihari/X", which is NOT where the read
+        APIs (virtual absolute) nor /p/public downloads serve it. The read APIs
+        are unaffected, so ONLY the write paths drop the first segment. Bound to
+        the current topology; if the drive is restructured so reads and writes
+        agree (e.g. a /mihari mount restored), make this return `path` unchanged.
+        """
+        rest = path.lstrip("/")
+        sep = rest.find("/")
+        if sep <= 0:
+            return path
+        return "/" + rest[sep + 1:]
+
+    def _check_write(self, response, remote_path):
+        """AList always answers HTTP 200 with the real status in the JSON body's
+        `code` (200 = ok). raise_for_status alone swallows a write failure as a
+        silent success — surface the message instead. Defensive: only fail when a
+        `code` is present and non-200, so a non-standard success body can't
+        false-alarm."""
+        response.raise_for_status()
+        try:
+            data = response.json()
+        except ValueError:
+            return
+        if data.get("code") not in (200, None):
+            fail(f"alist write failed for {remote_path}: {data.get('message')}")
+
     def mkdir(self, path):
-        self._post("/api/fs/mkdir", json={"path": path})
+        self._post("/api/fs/mkdir", json={"path": self._write_path(path)})
 
     def upload(self, local, remote_path):
         with open(local, "rb") as handle:
             response = self.session.put(
                 self.base + "/api/fs/put",
                 headers={
-                    "File-Path": quote(remote_path, safe=""),
+                    "File-Path": quote(self._write_path(remote_path), safe=""),
                     "As-Task": "false",
                     "Content-Type": "application/octet-stream",
                 },
                 data=handle,
                 timeout=900,
             )
-        response.raise_for_status()
+        self._check_write(response, remote_path)
 
     def upload_text(self, text, remote_path):
         response = self.session.put(
             self.base + "/api/fs/put",
             headers={
-                "File-Path": quote(remote_path, safe=""),
+                "File-Path": quote(self._write_path(remote_path), safe=""),
                 "As-Task": "false",
                 "Content-Type": "text/plain",
             },
             data=text.encode("utf-8"),
             timeout=120,
         )
-        response.raise_for_status()
+        self._check_write(response, remote_path)
 
     def remove(self, dir_path, names):
-        self._post("/api/fs/remove", json={"dir": dir_path, "names": list(names)})
+        self._post("/api/fs/remove", json={"dir": self._write_path(dir_path), "names": list(names)})
 
     def content(self, path):
         """Read a remote text file via its public proxy route. Returns None when

--- a/scripts/release-alist.py
+++ b/scripts/release-alist.py
@@ -4,12 +4,11 @@
 Runs inside the release.yml job after the GitHub release is published:
   1. upload the 6 platform bundles (+ per-version SHA256SUMS + COMPLETE) into an
      immutable per-version directory (skip if COMPLETE already exists);
-  2. resolve the root index.txt sign (placeholder on first release);
-  3. build index.txt (latest line + per-platform signed direct link + sha256)
-     and overwrite-upload it (the publish-complete signal);
-  4. render the root downloader scripts (script 3) with the index link injected;
+  2. build index.txt (latest line + per-platform public direct link + sha256);
+  3. overwrite-upload index.txt — the publish-complete signal;
+  4. overwrite the root downloader scripts (script 3) at the drive root;
   5. prune old versions (keep N, index-pointed always retained);
-  6. emit the signed URLs to GITHUB_ENV for the release-notes append step.
+  6. emit the version dir to GITHUB_ENV for the release-notes append step.
 
 The AList REST client and shared constants live in alist_client.py, imported by
 both this publish flow and the retract flow.

--- a/scripts/test_alist_client.py
+++ b/scripts/test_alist_client.py
@@ -55,6 +55,20 @@ def test_public_url_is_signless_proxy_route():
     assert bundle == "https://cloud.example.com/p/public/mihari-release/mihari/v0.3.0/mihari-all-in-one-linux-amd64.tar.gz"
 
 
+def test_write_path_strips_mount_segment():
+    # AList write-path doubling quirk: fs/put|mkdir|remove prepend the leading
+    # mount segment again, so a write of /mihari-release/mihari/X lands at
+    # /mihari-release/mihari-release/mihari/X. _write_path drops the first
+    # segment so writes land where reads (and /p/public downloads) see them.
+    alist = AList.__new__(AList)
+    assert alist._write_path("/mihari-release/mihari/v0.3.0/mihari-all-in-one-linux-amd64.tar.gz") == "/mihari/v0.3.0/mihari-all-in-one-linux-amd64.tar.gz"
+    assert alist._write_path("/mihari-release/mihari/index.txt") == "/mihari/index.txt"
+    # fs/remove's `dir` is the bare base_path.
+    assert alist._write_path("/mihari-release/mihari") == "/mihari"
+    # No leading segment to strip → returned unchanged (no crash on odd shapes).
+    assert alist._write_path("/mihari-release") == "/mihari-release"
+
+
 def _load_release_alist():
     # release-alist.py has a hyphen in its name, so import it manually.
     path = Path(__file__).with_name("release-alist.py")


### PR DESCRIPTION
## Problem

v0.3.0's release workflow reported `✓ Publish to AList drive`, but the files never landed where users download them. Verified empirically:

- **Read path** `/p/public/mihari-release/mihari/index.txt` → still the stale v0.2.0 index (dead `?sign=` links)
- **Write path** `/p/public/mihari-release/mihari-release/mihari/index.txt` → the new v0.3.0 index (correct, no sign)

## Root cause

AList `fs/put`|`fs/mkdir`|`fs/remove` resolve the File-Path (and `fs/remove`'s `dir`) **relative to the storage root**, so the leading mount segment `/mihari-release` gets prepended again: writing `/mihari-release/mihari/X` lands at physical `/mihari-release/mihari-release/mihari/X`. The read APIs (`fs/list`|`fs/get`) use the virtual absolute path and are unaffected — so reads and writes disagree.

This went unnoticed because `upload`/`upload_text` only checked the HTTP status, and AList always answers HTTP 200 with the real status in the JSON body `code` — a write failure was silently swallowed as success.

## Fix

- **`AList._write_path`**: drops the leading mount segment, applied in `mkdir`/`upload`/`upload_text`/`remove` so writes land on the read/download path.
- **`AList._check_write`**: `upload`/`upload_text` now parse the JSON body and `fail()` on `code != 200` — silent write failures become loud.

Adds a `_write_path` regression test (9 tests pass).

## After merge

Dispatch `release.yml` with `version=v0.3.0` to republish with the fixed code; the read-path `index.txt` will then point at v0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)