### PR TITLE
fix(distribution): apply fs-path transform to reads too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### Fixed
 
 - 修复国内离线安装命令失效：签名直链全部返回 `sign invalid`（401）。根因为 AList 签名机制在部署层失效；改公开分发后根除（前置：AList 存储关闭签名）。
-- 修复 AList 发版文件落点错误 + 上传静默失败：fs/put|mkdir|remove 把 File-Path 当相对存储根路径，首段挂载点 `/mihari-release` 被重复拼接，导致整个版本目录 + `index.txt` 实际写到 `/mihari-release/mihari-release/mihari/`（用户访问的读路径 `/mihari-release/mihari/` 读不到）。`alist_client._write_path` 在所有写操作里去掉首段，让写落到读路径；同时 `upload`/`upload_text` 改为检查 AList body `code`（AList 永远返 HTTP 200，真失败此前被静默吞掉），写失败即报错。
+- 修复 AList 发版文件落点错误 + 上传静默失败：**所有** fs API（get/list/put/mkdir/remove）都把传入路径当相对存储根 `/mihari-release` 解析、再拼一次前缀，导致读（`exists`/`list`）查的是 `/mihari-release/mihari-release/mihari/`、写也落到那里，而 `/p/public` 公开下载用的是逻辑路径 `/mihari-release/mihari/`——三者不一致：v0.3.0 的 `index.txt` 更新了但 bundle 仍指向读路径上不存在的文件。`alist_client._fs_path` 对**所有 fs 操作（读+写）**去掉首段，让读、写、公开下载落到同一处；同时 `upload`/`upload_text` 改为检查 AList body `code`（AList 永远返 HTTP 200，真失败此前被静默吞掉），写失败即报错。
 
 ## [v0.2.0] - 2026-08-07
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -83,11 +83,11 @@ base_path 默认 `/mihari-release/mihari`（AList fs/API 路径，通过 GitHub 
 └── v0.1.0/
 ```
 
-> **AList 拓扑 quirk（读路径 / 下载）**：fs/list、fs/get 用虚拟绝对路径 `/mihari-release/mihari/…`；**公开下载 URL** 需在 `/p` 后加 `/public` 挂载点前缀，即 `https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/…`（`alist_client.public_url` 自动处理）。
+> **AList 拓扑 quirk（读路径 / 下载）**：**公开下载 URL** 需在 `/p` 后加 `/public` 挂载点前缀，即 `https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/…`（`alist_client.public_url` 自动处理）。
 >
-> **AList 拓扑 quirk（写路径）**：fs/put、fs/mkdir、fs/remove 把 File-Path 当成**相对存储根**的路径，首段（挂载点 `/mihari-release`）会被重复拼接——写 `/mihari-release/mihari/X` 实际落到 `/mihari-release/mihari-release/mihari/X`（读路径读不到）。读 API（list/get）不受影响。`alist_client._write_path` 在所有写操作里去掉首段，让写落到读路径；`upload`/`upload_text` 还会检查 AList body `code`（AList 永远返 HTTP 200，真失败此前被静默吞掉），写失败即报错。
+> **AList 拓扑 quirk（fs API 路径）**：**所有** fs API（get/list/put/mkdir/remove）都把传入路径当**相对存储根** `/mihari-release` 解析、再拼一次前缀——`/mihari-release/mihari/X` 会被当成 `/mihari-release/mihari-release/mihari/X`（写落到那里、读也从那里查）。而 `/p/public` 下载用的是逻辑虚拟绝对路径。`alist_client._fs_path` 对**所有 fs 操作**（读+写）去掉首段 `/mihari-release`，让读、写、公开下载三者落到同一处。`upload`/`upload_text` 还会检查 AList body `code`（AList 永远返 HTTP 200，真失败此前被静默吞掉），写失败即报错。
 >
-> 若日后恢复 `/mihari` 挂载点（读写在同一路径、`/p` 也无需 `/public`），这两个 quirk 同时消失：base_path 改回 `/mihari`，`public_url` 去掉 `/public` 中缀，`_write_path` 改为原样返回。
+> 若日后恢复 `/mihari` 挂载点（fs API 与 `/p` 用同一路径），这两个 quirk 同时消失：base_path 改回 `/mihari`，`public_url` 去掉 `/public` 中缀，`_fs_path` 改为原样返回。
 
 ### index.txt 格式
 

--- a/scripts/alist_client.py
+++ b/scripts/alist_client.py
@@ -81,28 +81,31 @@ class AList:
         return data["data"]["token"]
 
     def get(self, path):
-        return self._post("/api/fs/get", json={"path": path, "password": ""})
+        return self._post("/api/fs/get", json={"path": self._fs_path(path), "password": ""})
 
     def exists(self, path):
         return self.get(path).get("code") == 200
 
     def list_dir(self, path):
-        data = self._post("/api/fs/list", json={"path": path, "password": "", "page": 1, "per_page": 0, "refresh": False})
+        data = self._post("/api/fs/list", json={"path": self._fs_path(path), "password": "", "page": 1, "per_page": 0, "refresh": False})
         return data.get("data", {}).get("content") or []
 
-    def _write_path(self, path):
-        """Strip the leading mount segment so an fs/put|mkdir|remove write lands
-        where fs/list|get and /p/public downloads see it.
+    def _fs_path(self, path):
+        """Convert a logical base_path path into the path the AList fs API needs.
 
-        AList write-path quirk (verified 2026-08-10): fs/put, fs/mkdir and
-        fs/remove resolve the File-Path (and fs/remove's `dir`) RELATIVE to the
-        storage root, so the leading path segment — the mount point — gets
-        prepended again. A write of "/mihari-release/mihari/X" physically lands at
-        "/mihari-release/mihari-release/mihari/X", which is NOT where the read
-        APIs (virtual absolute) nor /p/public downloads serve it. The read APIs
-        are unaffected, so ONLY the write paths drop the first segment. Bound to
-        the current topology; if the drive is restructured so reads and writes
-        agree (e.g. a /mihari mount restored), make this return `path` unchanged.
+        AList topology quirk (verified 2026-08-10): EVERY fs API op (get/list/
+        put/mkdir/remove) resolves its path RELATIVE to the storage root_folder
+        (/mihari-release), prepending the root again — so a logical path like
+        "/mihari-release/mihari/X" must be handed to the fs API as "/mihari/X", or
+        it lands at (writes) / is looked up at (reads) the doubled physical
+        "/mihari-release/mihari-release/mihari/X". The /p/public download route,
+        by contrast, serves the logical (virtual absolute) path verbatim. So the
+        fs-API path = logical path with its leading mount segment dropped, and
+        ALL fs ops (read AND write) go through this so reads, writes, and public
+        downloads agree on one location. public_url does NOT transform (it takes
+        the logical path). Bound to the current topology; if the drive is
+        restructured so the fs API takes the logical path verbatim, make this
+        return `path` unchanged.
         """
         rest = path.lstrip("/")
         sep = rest.find("/")
@@ -125,14 +128,14 @@ class AList:
             fail(f"alist write failed for {remote_path}: {data.get('message')}")
 
     def mkdir(self, path):
-        self._post("/api/fs/mkdir", json={"path": self._write_path(path)})
+        self._post("/api/fs/mkdir", json={"path": self._fs_path(path)})
 
     def upload(self, local, remote_path):
         with open(local, "rb") as handle:
             response = self.session.put(
                 self.base + "/api/fs/put",
                 headers={
-                    "File-Path": quote(self._write_path(remote_path), safe=""),
+                    "File-Path": quote(self._fs_path(remote_path), safe=""),
                     "As-Task": "false",
                     "Content-Type": "application/octet-stream",
                 },
@@ -145,7 +148,7 @@ class AList:
         response = self.session.put(
             self.base + "/api/fs/put",
             headers={
-                "File-Path": quote(self._write_path(remote_path), safe=""),
+                "File-Path": quote(self._fs_path(remote_path), safe=""),
                 "As-Task": "false",
                 "Content-Type": "text/plain",
             },
@@ -155,7 +158,7 @@ class AList:
         self._check_write(response, remote_path)
 
     def remove(self, dir_path, names):
-        self._post("/api/fs/remove", json={"dir": self._write_path(dir_path), "names": list(names)})
+        self._post("/api/fs/remove", json={"dir": self._fs_path(dir_path), "names": list(names)})
 
     def content(self, path):
         """Read a remote text file via its public proxy route. Returns None when

--- a/scripts/test_alist_client.py
+++ b/scripts/test_alist_client.py
@@ -55,18 +55,19 @@ def test_public_url_is_signless_proxy_route():
     assert bundle == "https://cloud.example.com/p/public/mihari-release/mihari/v0.3.0/mihari-all-in-one-linux-amd64.tar.gz"
 
 
-def test_write_path_strips_mount_segment():
-    # AList write-path doubling quirk: fs/put|mkdir|remove prepend the leading
-    # mount segment again, so a write of /mihari-release/mihari/X lands at
-    # /mihari-release/mihari-release/mihari/X. _write_path drops the first
-    # segment so writes land where reads (and /p/public downloads) see them.
+def test_fs_path_strips_mount_segment():
+    # AList fs-path quirk: EVERY fs API op (get/list/put/mkdir/remove) resolves
+    # its path relative to the storage root (/mihari-release), prepending it
+    # again — so /mihari-release/mihari/X must be passed as /mihari/X or it
+    # reads/writes the doubled location. _fs_path drops the first segment for
+    # ALL fs ops (read and write) so they agree with /p/public downloads.
     alist = AList.__new__(AList)
-    assert alist._write_path("/mihari-release/mihari/v0.3.0/mihari-all-in-one-linux-amd64.tar.gz") == "/mihari/v0.3.0/mihari-all-in-one-linux-amd64.tar.gz"
-    assert alist._write_path("/mihari-release/mihari/index.txt") == "/mihari/index.txt"
-    # fs/remove's `dir` is the bare base_path.
-    assert alist._write_path("/mihari-release/mihari") == "/mihari"
+    assert alist._fs_path("/mihari-release/mihari/v0.3.0/mihari-all-in-one-linux-amd64.tar.gz") == "/mihari/v0.3.0/mihari-all-in-one-linux-amd64.tar.gz"
+    assert alist._fs_path("/mihari-release/mihari/index.txt") == "/mihari/index.txt"
+    # fs/remove's `dir` / fs:list of base_path is the bare base_path.
+    assert alist._fs_path("/mihari-release/mihari") == "/mihari"
     # No leading segment to strip → returned unchanged (no crash on odd shapes).
-    assert alist._write_path("/mihari-release") == "/mihari-release"
+    assert alist._fs_path("/mihari-release") == "/mihari-release"
 
 
 def _load_release_alist():


### PR DESCRIPTION
## Problem

PR #18 fixed the write path but not the read path. The re-dispatched v0.3.0 run still failed end-to-end:

```
version dir /mihari-release/mihari/v0.3.0 already complete — skipping upload
```

`exists()` (fs/get) found the **original run's** COMPLETE marker — because fs/get ALSO resolves paths relative to the storage root, looking up the **doubled** location `/mihari-release/mihari-release/mihari/v0.3.0/`. So `upload_version_dir` skipped re-uploading the bundles. Result: `index.txt` updated correctly (top-level file) but its bundle links point at files absent from the read path → every bundle URL returns `{"code":500,"message":"object not found"}`.

## Root cause

The AList fs-path quirk affects **every** fs API op (get/list/put/mkdir/remove), not just writes. Reads (get/list) resolve the path relative to the storage root too. PR #18 only transformed writes.

## Fix

Rename `_write_path` → `_fs_path` and route **all** fs ops (read and write) through it, so reads, writes, and `/p/public` downloads all target the same location. `public_url` stays on the logical path (it feeds `/p`). 9 tests pass.

## After merge

Dispatch `release.yml` with `version=v0.3.0`. Now `exists(COMPLETE)` checks the read path (empty) → upload proceeds → bundles land on the read path → index links work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)