### PR TITLE
fix(distribution): stop PS5.1 octet-stream crash in remote installer

### DIFF
--- a/install-aio-remote.ps1
+++ b/install-aio-remote.ps1
@@ -22,7 +22,7 @@ $indexUrl = if ($env:MIHARI_INDEX_URL) { $env:MIHARI_INDEX_URL } else { 'https:/
 $bundleUrl = $env:MIHARI_BUNDLE_URL
 
 function Info($m) { Write-Host "* $m" -ForegroundColor Cyan }
-function Fail($m) { Write-Host "error: $m" -ForegroundColor Red; exit 1 }
+function Fail($m) { Write-Host "error: $m" -ForegroundColor Red; throw $m }
 function Confirm($p) {
   # Read-Host reads the host console (not the stdin pipe), so no /dev/tty
   # special-casing is needed (design 4.4 step 2).
@@ -45,7 +45,13 @@ if (-not $resolvedUrl) {
   # index.txt line format: "<key> <rest...>". key="latest" -> <version>;
   # key="<goos>-<goarch>" -> <public_url> <sha256>.
   $index = ''
-  try { $index = (Invoke-WebRequest -Uri $indexUrl -UseBasicParsing).Content } catch { $index = '' }
+  try {
+    $resp = Invoke-WebRequest -Uri $indexUrl -UseBasicParsing
+    # PS 5.1 returns .Content as [byte[]] for application/octet-stream (AList serves
+    # every file with that content-type), which would defeat the string -split below.
+    # Decode to UTF-8 text so parsing works on any PS version / content-type.
+    if ($resp.Content -is [byte[]]) { $index = [System.Text.Encoding]::UTF8.GetString($resp.Content) } else { $index = $resp.Content }
+  } catch { $index = '' }
   if (-not $index) { Fail "尚未发布完成：无法获取 index（请稍后重试，或检查网络/网盘可用性）。" }
   foreach ($line in ($index -split "`n")) {
     $line = $line.Trim()

--- a/install-aio.ps1
+++ b/install-aio.ps1
@@ -20,7 +20,7 @@ $ErrorActionPreference = 'Stop'
 if (-not $BundleDir) { $BundleDir = if ($PSScriptRoot) { $PSScriptRoot } else { (Get-Location).Path } }
 
 function Info($m) { Write-Host "* $m" -ForegroundColor Cyan }
-function Fail($m) { Write-Host "error: $m" -ForegroundColor Red; exit 1 }
+function Fail($m) { Write-Host "error: $m" -ForegroundColor Red; throw $m }
 # Invoke-MihariService runs a `mihari service ...` step, elevating via UAC when
 # the current session is not admin (service control needs elevation on Windows).
 function Invoke-MihariService([string[]]$ServiceArgs) {


### PR DESCRIPTION
## Problem
Running the one-liner on Windows PowerShell 5.1 silently closed the window (looked like a crash):

```powershell
& ([scriptblock]::Create((irm https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.ps1)))
```

Root cause (verified on PS 5.1.26100.8875):
- AList serves every file as `application/octet-stream`. PS 5.1's `Invoke-WebRequest` returns `.Content` as `[byte[]]` for that content-type — unlike `Invoke-RestMethod`, which returns a string.
- `install-aio-remote.ps1` parsed index.txt via `(IWR).Content` split on newline, so on PS5.1 it received a byte array, every field missed, and `$latest` stayed empty.
- That hit `Fail()` → `exit 1`. Since the installer runs as `& ([scriptblock]::Create(...))` inside an interactive session, `exit` terminated the whole PowerShell window — users saw a one-line red flash and the window disappeared.

## Fix
- `install-aio-remote.ps1`: decode `Invoke-WebRequest` `.Content` as UTF-8 when it is `[byte[]]`, so index parsing resolves `latest` + bundle URL on any PS version / content-type.
- `install-aio.ps1` / `install-aio-remote.ps1`: `Fail()` now `throw`s instead of `exit 1`. Interactive `& scriptblock` runs print the error and return to the prompt instead of killing the window; `-File` runs still exit non-zero via the unhandled exception.

## Verification
- Smoke run of the patched remote installer on PS 5.1: `latest=v0.3.0` + bundle URL + sha256 all resolve (were all empty before the fix).
- `test_install_scripts_hardcode_public_index_url` still passes.
- Both scripts parse with 0 errors (`ReadAllText` + `ParseInput`; note `Parser::ParseFile`/`-File` misread the Chinese-bearing scripts as GBK and report false syntax errors).

## Note
After merge, the two scripts must be re-published to the AList drive (`scripts/release-alist.py`) — the drive still serves the old v0.3.0 scripts, so the one-liner keeps crashing until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
