### PR TITLE
fix(tui): flag system-proxy desired/owned drift on Overview

### DIFF
--- a/internal/tui/pages/overview/model.go
+++ b/internal/tui/pages/overview/model.go
@@ -282,24 +282,30 @@ func formatSysProxyValue(theme ui.Theme, snap Snapshot) string {
 	if !snap.Connected || snap.SystemProxy == nil {
 		return ui.OverviewValueDash
 	}
-	obs := snap.SystemProxy.Observed
+	status := snap.SystemProxy
+	obs := status.Observed
 	var label string
 	tone := ui.ToneNeutral
 	switch {
 	case obs.Foreign:
-		label = ui.OverviewValueForeign
-		tone = ui.ToneCaution
+		label, tone = ui.OverviewValueForeign, ui.ToneCaution
 	case obs.Owned:
-		label = ui.OverviewValueOwned
-		tone = ui.TonePositive
+		label, tone = ui.OverviewValueOwned, ui.TonePositive
 	case obs.Enabled:
-		label = ui.OverviewValueOn
-		tone = ui.TonePositive
-	case snap.SystemProxy.Desired:
-		label = ui.OverviewValueOn
-		tone = ui.TonePositive
+		label, tone = ui.OverviewValueOn, ui.TonePositive
+	case status.Desired:
+		// Desired-on but not owned live: base the badge on intent; the drift
+		// suffix + caution tone below flag that it has not taken effect.
+		label, tone = ui.OverviewValueOn, ui.ToneCaution
 	default:
-		label = ui.OverviewValueOff
+		label, tone = ui.OverviewValueOff, ui.ToneNeutral
+	}
+	// Owned already implies Enabled (sysproxy.IsOwned gates on it), so
+	// comparing intent (Desired) against ownership is the precise drift check:
+	// it also catches enabled-but-wrong-server, which Desired!=Enabled misses.
+	if status.Desired != obs.Owned && !obs.Foreign {
+		label += " · " + ui.OverviewDriftLabel
+		tone = ui.ToneCaution
 	}
 	if snap.Stale {
 		// Keep the last-known value and mark it stale (design G2).

--- a/internal/tui/pages/overview/model.go
+++ b/internal/tui/pages/overview/model.go
@@ -285,7 +285,10 @@ func formatSysProxyValue(theme ui.Theme, snap Snapshot) string {
 	status := snap.SystemProxy
 	obs := status.Observed
 	var label string
-	tone := ui.ToneNeutral
+	// Declared without an initializer: every switch branch below (including
+	// default) assigns tone, so an initializer value would never be read
+	// (ineffassign). The zero value equals ToneNeutral regardless.
+	var tone ui.StatusTone
 	switch {
 	case obs.Foreign:
 		label, tone = ui.OverviewValueForeign, ui.ToneCaution
@@ -294,9 +297,10 @@ func formatSysProxyValue(theme ui.Theme, snap Snapshot) string {
 	case obs.Enabled:
 		label, tone = ui.OverviewValueOn, ui.TonePositive
 	case status.Desired:
-		// Desired-on but not owned live: base the badge on intent; the drift
-		// suffix + caution tone below flag that it has not taken effect.
-		label, tone = ui.OverviewValueOn, ui.ToneCaution
+		// Desired-on but not owned live: base the badge on intent. This branch
+		// only fires when Owned is false, so the drift block below is guaranteed
+		// to set the caution tone + suffix — no need to assign tone here.
+		label = ui.OverviewValueOn
 	default:
 		label, tone = ui.OverviewValueOff, ui.ToneNeutral
 	}

--- a/internal/tui/pages/overview/model_test.go
+++ b/internal/tui/pages/overview/model_test.go
@@ -89,6 +89,61 @@ func TestOverview_GeneralCardServiceMihariSysProxyTun(t *testing.T) {
 	}
 }
 
+func TestOverview_SysProxyDesiredObservedDrift(t *testing.T) {
+	model := New()
+	model.SetSize(100, 30)
+	// Desired on but observed off. Note Owned is false here: sysproxy.IsOwned
+	// gates on Enabled, so an off proxy can never be Owned. The daemon derives
+	// Owned=false for this state; Overview must still flag the Desired-vs-Owned
+	// drift (caution + "on · drift") instead of a green "on".
+	model.SetSnapshot(Snapshot{
+		Connected: true,
+		SystemProxy: &protocol.SystemProxyStatus{
+			Desired:  true,
+			Observed: protocol.SystemProxyObserved{Enabled: false, Owned: false},
+		},
+		Core: protocol.CoreStatus{Status: "running"},
+	})
+	view := model.View()
+	want := ui.OverviewValueOn + " · " + ui.OverviewDriftLabel
+	if !strings.Contains(view, want) {
+		t.Fatalf("drift badge should render %q:\n%s", want, view)
+	}
+
+	// Desired on but enabled to the wrong server (owned=false, foreign=false):
+	// Desired!=Owned catches this; the older Desired!=Enabled check would miss
+	// it because Enabled happens to be true.
+	model.SetSnapshot(Snapshot{
+		Connected: true,
+		SystemProxy: &protocol.SystemProxyStatus{
+			Desired:  true,
+			Observed: protocol.SystemProxyObserved{Enabled: true, Server: "10.0.0.1:1", Owned: false, Foreign: false},
+		},
+		Core: protocol.CoreStatus{Status: "running"},
+	})
+	view = model.View()
+	if !strings.Contains(view, ui.OverviewValueOn+" · "+ui.OverviewDriftLabel) {
+		t.Fatalf("enabled-but-not-owned drift should render %q:\n%s", ui.OverviewValueOn+" · "+ui.OverviewDriftLabel, view)
+	}
+
+	// When desired and ownership agree (owned), the badge stays clean.
+	model.SetSnapshot(Snapshot{
+		Connected: true,
+		SystemProxy: &protocol.SystemProxyStatus{
+			Desired:  true,
+			Observed: protocol.SystemProxyObserved{Enabled: true, Owned: true},
+		},
+		Core: protocol.CoreStatus{Status: "running"},
+	})
+	view = model.View()
+	if strings.Contains(view, ui.OverviewDriftLabel) {
+		t.Fatalf("no drift suffix when desired==owned:\n%s", view)
+	}
+	if !strings.Contains(view, ui.OverviewValueOwned) {
+		t.Fatalf("owned badge should render %q:\n%s", ui.OverviewValueOwned, view)
+	}
+}
+
 func TestOverview_SectionTitlesEmbeddedInBorder(t *testing.T) {
 	model := New()
 	model.SetSize(90, 28)

--- a/internal/tui/pages/system/model.go
+++ b/internal/tui/pages/system/model.go
@@ -1515,15 +1515,15 @@ func coreValue(theme ui.Theme, core protocol.CoreStatus) string {
 }
 
 // proxyTone derives the system-proxy status tone: a foreign observer or a
-// desired/observed drift needs attention (Caution); an owned, enabled proxy is
-// Positive; otherwise (off) Neutral.
+// desired/owned drift needs attention (Caution); an owned proxy is Positive
+// (Owned already implies Enabled, per sysproxy.IsOwned); otherwise (off) Neutral.
 func proxyTone(status protocol.SystemProxyStatus) ui.StatusTone {
 	switch {
 	case status.Observed.Foreign:
 		return ui.ToneCaution
-	case status.Desired != status.Observed.Enabled:
+	case status.Desired != status.Observed.Owned:
 		return ui.ToneCaution
-	case status.Observed.Owned && status.Observed.Enabled:
+	case status.Observed.Owned:
 		return ui.TonePositive
 	default:
 		return ui.ToneNeutral

--- a/internal/tui/ui/strings.go
+++ b/internal/tui/ui/strings.go
@@ -66,6 +66,9 @@ const (
 	OverviewValueOwned    = "owned"
 	OverviewValueForeign  = "foreign"
 	OverviewValueDash     = "—"
+	// OverviewDriftLabel flags a desired/observed system-proxy drift on the
+	// Overview badge (appended as "on · drift") so it matches the System page.
+	OverviewDriftLabel = "drift"
 	// Section titles are embedded in the top border line (╭─── Name ───╮), not body text.
 	MonitorTrafficTitle      = "Traffic · 60 s"
 	MonitorMemoryTitle       = "Memory · 60 s"


### PR DESCRIPTION
## 问题

Overview 与 System 两个页面对「系统代理」状态的判定**不一致**:

同一份 `SystemProxyStatus`,在 `Desired=on / Observed=off` 时:
- **Overview** 的 SysProxy 徽章显示**绿色「on」**(只要 `Desired=true` 就当绿色 on,掩盖了漂移)
- **System** 页却把同一状态标**黄(caution)**

用户在两个页面看到矛盾的状态指示。

## 修复

两页共享**一套 drift 定义**:`Desired != Observed.Owned`。

为什么是 `Owned` 而不是 `Enabled`:`sysproxy.IsOwned` 内部已经先判 `Enabled`,所以 **Owned 蕴含 Enabled**。直接比 `Desired != Owned` 比旧的 `Desired != Enabled` 更准,还额外覆盖了「Enabled 但 Server 错/空」这条罕见边界(此时 Enabled=true 但 Owned=false,旧判定会漏)。

### 改动(4 文件,+79/−15)

| 文件 | 改动 |
|---|---|
| `internal/tui/ui/strings.go` | 新增 `OverviewDriftLabel = "drift"`(复用 StaleLabel 的「 · 」后缀渲染) |
| `internal/tui/pages/overview/model.go` | `formatSysProxyValue`:drift 判定改为 `Desired != Observed.Owned`,命中渲染 🟡「on · drift」;去掉冗余 `&& obs.Enabled` |
| `internal/tui/pages/system/model.go` | `proxyTone` 对齐到同一 `Desired != Owned`,去掉冗余 `&& Enabled` |
| `internal/tui/pages/overview/model_test.go` | 新增 `TestOverview_SysProxyDesiredObservedDrift`:覆盖 desired-on/observed-off、enabled-but-wrong-server 边界、owned 无漂移回归;顺带修正旧夹具里 `Enabled:false, Owned:true` 这个不可能状态(Owned 蕴含 Enabled) |

## 验证

- `go build ./...` ✅
- `go test ./internal/tui/...` 全过(overview / system / ui 三个包 `-count=1` 强制重跑 ✅)
- 新增 `TestOverview_SysProxyDesiredObservedDrift` PASS ✅

## 范围说明

本 PR 只动 TUI 两页的状态判定,与 install 脚本修复(PR #21)**零文件重叠**,各自独立。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
