### PR TITLE
fix(tui): grow Rules Type column to fit DomainSuffix/DomainKeyword

### DIFF
--- a/internal/tui/pages/rules/model.go
+++ b/internal/tui/pages/rules/model.go
@@ -350,13 +350,16 @@ func (m *Model) activateControl() tea.Cmd {
 
 const rulesColGap = 2
 
-// rulesColumnSpec: priorities are protective — 4 cols (34 + 6 gaps = 40)
+// rulesColumnSpec: priorities are protective — 4 cols (36 + 6 gaps = 42)
 // always fit the narrowest content width, so no column ever drops in
 // practice; the priority order just pins what would go first if it did.
+// Type is a flex column: MinWidth 12 covers the common DomainSuffix, and it
+// grows toward MaxWidth 18 to fit DomainKeyword (and any future longer tokens
+// from upstream mihomo) instead of truncating at a fixed width (issue #29).
 func (m *Model) rulesColumnSpec() []ui.TableColumn {
 	return []ui.TableColumn{
 		{ID: "num", Title: "#", MinWidth: 4, MaxWidth: 4, Flex: 0, Align: ui.AlignRight, Priority: 4},
-		{ID: "type", Title: ui.TypeLabel, MinWidth: 10, MaxWidth: 18, Flex: 0, Priority: 3},
+		{ID: "type", Title: ui.TypeLabel, MinWidth: 12, MaxWidth: 18, Flex: 1, Priority: 3},
 		{ID: "payload", Title: ui.PayloadLabel, MinWidth: 12, Flex: 3, Priority: 1},
 		{ID: "target", Title: ui.TargetLabel, MinWidth: 8, MaxWidth: 16, Flex: 1, Priority: 2},
 	}

--- a/internal/tui/pages/rules/model_test.go
+++ b/internal/tui/pages/rules/model_test.go
@@ -403,6 +403,25 @@ func TestProviders_PinsFocusByNameAcrossReload(t *testing.T) {
 	}
 }
 
+func TestView_RuleTypeNotTruncated(t *testing.T) {
+	// Regression for #29: the Type column must render the longest common
+	// mihomo rule types (DomainSuffix, DomainKeyword) in full. Type arrives from
+	// upstream mihomo as an unconstrained string, so the column grows via Flex
+	// rather than betting on a fixed enumeration width.
+	model := New(nil, nil)
+	model.SetSize(160, 30)
+	model.SetRules(protocol.RuleList{Rules: []protocol.Rule{
+		{Type: "DomainSuffix", Payload: "steamcontent.com", Proxy: "DIRECT"},
+		{Type: "DomainKeyword", Payload: "steam", Proxy: "DIRECT"},
+	}})
+	view := model.View()
+	for _, want := range []string{"DomainSuffix", "DomainKeyword"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("view missing full type %q (truncated?):\n%s", want, view)
+		}
+	}
+}
+
 type fakeClient struct {
 	rules     protocol.RuleList
 	providers protocol.RuleProviderList

--- a/internal/tui/ui/priority_test.go
+++ b/internal/tui/ui/priority_test.go
@@ -152,6 +152,46 @@ func TestFitPriorityColumns_EdgeCases(t *testing.T) {
 	})
 }
 
+func widthFor(cols []TableColumn, widths []int, id string) int {
+	for i, col := range cols {
+		if col.ID == id {
+			return widths[i]
+		}
+	}
+	return -1
+}
+
+func TestFitPriorityColumns_TypeColumnGrowsToFit(t *testing.T) {
+	// Modeled on the rules page (issue #29): the Type column is a flex column
+	// so the longest common mihomo rule types render in full rather than being
+	// truncated at a fixed MinWidth.
+	cols := []TableColumn{
+		{ID: "num", MinWidth: 4, MaxWidth: 4, Flex: 0, Align: AlignRight, Priority: 4},
+		{ID: "type", MinWidth: 12, MaxWidth: 18, Flex: 1, Priority: 3},
+		{ID: "payload", MinWidth: 12, Flex: 3, Priority: 1},
+		{ID: "target", MinWidth: 8, MaxWidth: 16, Flex: 1, Priority: 2},
+	}
+	// Wide terminal: all four columns kept; type grows toward MaxWidth 18 and
+	// clears DomainKeyword (13), the longest common type.
+	kept, widths := FitPriorityColumns(cols, 100, 2)
+	if ids(kept) != "num,type,payload,target" {
+		t.Fatalf("kept=%q", ids(kept))
+	}
+	tw := widthFor(kept, widths, "type")
+	if tw < 13 {
+		t.Fatalf("wide type width %d < 13 (DomainKeyword)", tw)
+	}
+	if tw > 18 {
+		t.Fatalf("wide type width %d > MaxWidth 18", tw)
+	}
+	// Just above the all-fit threshold (36 MinWidth + 6 gaps = 42): type still
+	// meets its MinWidth 12, which covers the common DomainSuffix.
+	kept, widths = FitPriorityColumns(cols, 44, 2)
+	if tw := widthFor(kept, widths, "type"); tw < 12 {
+		t.Fatalf("narrow type width %d < MinWidth 12", tw)
+	}
+}
+
 func TestPriorityBar_ByBudget(t *testing.T) {
 	segments := []PrioritySegment{
 		{Priority: 6, Render: func() string { return "Mihari" }},


### PR DESCRIPTION
Fixes #29.

## 问题

Rules 页面的 Type 列宽度固定为 10 字符，`DomainSuffix`(12)、`DomainKeyword`(13) 等较长类型被 `TruncateVisible` 截断为 `DomainSuf…`、`DomainKey…`。

## 根因

`internal/tui/pages/rules/model.go` 中 Type 列声明为 `Flex: 0`。在 `FitColumnWidths` 里，`Flex<=0` 的列固定在 `min(MinWidth, MaxWidth) = 10`，因此 `MaxWidth: 18` 形同虚设。渲染时 `PadCell → TruncateVisible(s, widths[1])`，截断点就是这 10 列。

Type 的值由上游 mihomo 的 `/v1/rules` 透传，mihari 侧是**不受约束的自由字符串**（连 Type 筛选下拉的候选项都是动态收集的 `ruleValues`），所以不能靠"枚举全集最大长度"定宽——内核升级新增更长类型又会复现。

## 方案

让 Type 列参与剩余空间分配，而非固定宽度：

```diff
-		{ID: "type", Title: ui.TypeLabel, MinWidth: 10, MaxWidth: 18, Flex: 0, Priority: 3},
+		{ID: "type", Title: ui.TypeLabel, MinWidth: 12, MaxWidth: 18, Flex: 1, Priority: 3},
```

- **`Flex: 0 → 1`**：Type 成为弹性列，空间充足时向 `MaxWidth: 18` 增长，容纳当前已知最长的 `DomainKeyword`(13) 及未来更长的类型——从结构上摆脱对"枚举全集"的依赖。
- **`MinWidth: 10 → 12`**：保证最高频的 `DomainSuffix` 在任何能 keep 住 Type 的宽度下都不截断（即使没拿到 flex 额外分配）。
- **`MaxWidth: 18`** 不变，封顶防止 Type 过宽抢占 Payload。

窄终端退化行为**不变**：`FitPriorityColumns` 仅凭 MinWidth 判定 keep/drop，MinWidth 仅 10→12、Priority 不变，drop 顺序与全 keep 阈值（36 + 6 gaps = 42）几乎一致。

| total（列表文本宽） | 终端宽（约） | type 列宽 | DomainSuffix | DomainKeyword |
|---|---|---|---|---|
| 42（全 keep 临界） | ~50 | 12 | ✓ | 差 1 |
| 60 | ~70 | 14 | ✓ | ✓ |
| ≥80 | ≥90 | 18（封顶） | ✓ | ✓ |

## 测试

- `TestView_RuleTypeNotTruncated`（rules 包）：构造 `DomainSuffix` + `DomainKeyword` 规则，宽终端下断言渲染输出含完整类型名；未修复（Flex:0）时会失败。
- `TestFitPriorityColumns_TypeColumnGrowsToFit`（ui 包）：断言宽 total 下 Type 宽度落在 13..18，全 keep 阈值处仍 ≥ MinWidth 12。
- `go build ./...` 通过，`go test ./internal/tui/...` 全绿。

## Scope

Providers 页的 Type 列（`MinWidth:6, MaxWidth:10, Flex:0`）同模式，但 provider type 取值短（`RuleSet` 等 ≤7），`MaxWidth:10` 足够，**不在本次改动范围**。
