### PR TITLE
fix(tui): System 页 daemon/core 行断连后降级显示 Stale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- System 页 daemon / mihomo core 行在控制连接断开后降级显示：保留末值但圆点转黄并追加 `· Stale`,与 Overview core 卡及同页其它行一致（#36）
+
 ## [v0.4.0] - 2026-08-12
 
 ### Added

--- a/internal/tui/pages/system/model.go
+++ b/internal/tui/pages/system/model.go
@@ -918,12 +918,12 @@ func (m *Model) rows() []row {
 	}
 	daemon := fmt.Sprintf("Version %s\nUptime %s\nHealth %s\nRevision %d\nConfig %s", valueOr(m.status.DaemonVersion, ui.UnknownLabel), uptime(m.status.StartedAt), valueOr(m.status.Health, ui.UnknownLabel), m.status.Revision, configState)
 	core := fmt.Sprintf("Status %s\nVersion %s\nPID %d\nRestarts %d", valueOr(m.core.Status, ui.UnknownLabel), valueOr(m.core.Version, ui.UnknownLabel), m.core.PID, m.core.Restarts)
-	rows := []row{{id: rowDaemon, section: ui.DaemonSectionTitle, label: ui.DaemonLabel, value: daemonValue(m.theme, m.status), detail: daemon}}
+	rows := []row{{id: rowDaemon, section: ui.DaemonSectionTitle, label: ui.DaemonLabel, value: daemonValue(m.theme, m.status, !m.mutationsEnabled), detail: daemon}}
 	rows = append(rows, m.endpointRows()...)
 	rows = append(rows, m.mihariUpdateRow())
 	rows = append(rows,
 		row{id: rowRunSetup, section: ui.DaemonSectionTitle, label: ui.RunSetupLabel, detail: ui.RunSetupDetail},
-		row{id: rowCore, section: ui.CoreSectionTitle, label: ui.MihomoCoreLabel, value: coreValue(m.theme, m.core), detail: core},
+		row{id: rowCore, section: ui.CoreSectionTitle, label: ui.MihomoCoreLabel, value: coreValue(m.theme, m.core, !m.mutationsEnabled), detail: core},
 		row{id: rowCoreUpdate, section: ui.CoreSectionTitle, label: m.coreActionLabel(), value: actionState(m.hasCapability(protocol.CapabilityCore), m.mutationsEnabled), detail: ui.UpdateCoreImpact},
 		row{id: rowCoreRestart, section: ui.CoreSectionTitle, label: ui.RestartCoreLabel, value: actionState(m.hasCapability(protocol.CapabilityCore), m.mutationsEnabled), detail: ui.RestartCoreImpact},
 	)
@@ -1664,10 +1664,17 @@ func actionState(available, enabled bool) string {
 }
 
 // daemonValue renders the daemon row value: a status dot for health (tone from
-// the health word) followed by the version as muted context.
-func daemonValue(theme ui.Theme, status protocol.Status) string {
+// the health word) followed by the version as muted context. When the control
+// connection is stale the dot degrades to caution yellow and the health word is
+// marked stale (design G2), mirroring the Overview core card.
+func daemonValue(theme ui.Theme, status protocol.Status, stale bool) string {
 	health := valueOr(status.Health, ui.UnknownLabel)
-	return ui.StatusDot(theme, ui.ClassifyStatusTone(health), health) + "  " +
+	tone := ui.ClassifyStatusTone(health)
+	if stale {
+		tone = ui.ToneCaution
+		health += " · " + ui.StaleLabel
+	}
+	return ui.StatusDot(theme, tone, health) + "  " +
 		theme.Muted.Render(valueOr(status.DaemonVersion, ui.UnknownLabel))
 }
 
@@ -1686,10 +1693,17 @@ func coreTone(status string) ui.StatusTone {
 }
 
 // coreValue renders the core row value: a status dot (tone from coreTone) and
-// the version as muted context.
-func coreValue(theme ui.Theme, core protocol.CoreStatus) string {
+// the version as muted context. When the control connection is stale the dot
+// degrades to caution yellow and the status word is marked stale (design G2),
+// mirroring the Overview core card.
+func coreValue(theme ui.Theme, core protocol.CoreStatus, stale bool) string {
 	status := valueOr(core.Status, ui.UnknownLabel)
-	return ui.StatusDot(theme, coreTone(core.Status), status) + "  " +
+	tone := coreTone(core.Status)
+	if stale {
+		tone = ui.ToneCaution
+		status += " · " + ui.StaleLabel
+	}
+	return ui.StatusDot(theme, tone, status) + "  " +
 		theme.Muted.Render(valueOr(core.Version, ui.UnknownLabel))
 }
 

--- a/internal/tui/pages/system/model_test.go
+++ b/internal/tui/pages/system/model_test.go
@@ -1654,27 +1654,37 @@ func TestSystemDaemonCoreRowsDegradeWhenDisconnected(t *testing.T) {
 		protocol.CoreStatus{Status: "running", Version: "v1.19.0"},
 	)
 
-	// Online: daemon shows the raw health word, core the raw status word — no
-	// stale marker on either row.
+	// Online: positive green dots (78), raw health/status words, no stale
+	// marker and no caution color on either row.
 	model.SetMutationsEnabled(true)
 	online := model.View()
-	for _, want := range []string{"v0.4.0", "v1.19.0"} {
+	for _, want := range []string{"v0.4.0", "v1.19.0", "38;5;78"} { // 78 = TonePositive (Success)
 		if !strings.Contains(online, want) {
 			t.Fatalf("online view missing %q:\n%s", want, online)
 		}
 	}
-	if strings.Contains(online, "ok · "+ui.StaleLabel) || strings.Contains(online, "running · "+ui.StaleLabel) {
-		t.Fatalf("online daemon/core rows should not be marked stale:\n%s", online)
+	for _, stale := range []string{"ok · " + ui.StaleLabel, "running · " + ui.StaleLabel, "38;5;214"} { // 214 = ToneCaution (Warning)
+		if strings.Contains(online, stale) {
+			t.Fatalf("online daemon/core rows should not be stale:\n%s", online)
+		}
 	}
 
-	// Disconnected: keep the last value (version stays) but degrade the dot and
-	// append " · Stale" (design G2), matching the Overview core card and the
-	// rest of the System page.
+	// Disconnected: keep the last value (version stays) but degrade the dot to
+	// caution yellow and append " · Stale" (design G2), matching the Overview
+	// core card and the rest of the System page.
 	model.SetMutationsEnabled(false)
 	disconnected := model.View()
-	for _, want := range []string{"ok · " + ui.StaleLabel, "running · " + ui.StaleLabel, "v0.4.0", "v1.19.0"} {
+	for _, want := range []string{"ok · " + ui.StaleLabel, "running · " + ui.StaleLabel, "v0.4.0", "v1.19.0", "38;5;214"} {
 		if !strings.Contains(disconnected, want) {
 			t.Fatalf("disconnected view missing %q:\n%s", want, disconnected)
 		}
+	}
+
+	// Reconnect: stale marker and caution color clear, green dot returns — the
+	// degradation must be reversible, not sticky.
+	model.SetMutationsEnabled(true)
+	reconnected := model.View()
+	if strings.Contains(reconnected, " · "+ui.StaleLabel) || !strings.Contains(reconnected, "38;5;78") {
+		t.Fatalf("reconnected view should drop stale and restore green:\n%s", reconnected)
 	}
 }

--- a/internal/tui/pages/system/model_test.go
+++ b/internal/tui/pages/system/model_test.go
@@ -1646,3 +1646,35 @@ func updateKey(t *testing.T, model *Model, key tea.KeyPressMsg) *Model {
 	updated, _ := model.Update(key)
 	return updated.(*Model)
 }
+
+func TestSystemDaemonCoreRowsDegradeWhenDisconnected(t *testing.T) {
+	model := New(&fakeClient{}, func() string { return "system-op" })
+	model.SetSnapshot(
+		protocol.Status{DaemonVersion: "v0.4.0", Health: "ok", Capabilities: []string{protocol.CapabilityCore}},
+		protocol.CoreStatus{Status: "running", Version: "v1.19.0"},
+	)
+
+	// Online: daemon shows the raw health word, core the raw status word — no
+	// stale marker on either row.
+	model.SetMutationsEnabled(true)
+	online := model.View()
+	for _, want := range []string{"v0.4.0", "v1.19.0"} {
+		if !strings.Contains(online, want) {
+			t.Fatalf("online view missing %q:\n%s", want, online)
+		}
+	}
+	if strings.Contains(online, "ok · "+ui.StaleLabel) || strings.Contains(online, "running · "+ui.StaleLabel) {
+		t.Fatalf("online daemon/core rows should not be marked stale:\n%s", online)
+	}
+
+	// Disconnected: keep the last value (version stays) but degrade the dot and
+	// append " · Stale" (design G2), matching the Overview core card and the
+	// rest of the System page.
+	model.SetMutationsEnabled(false)
+	disconnected := model.View()
+	for _, want := range []string{"ok · " + ui.StaleLabel, "running · " + ui.StaleLabel, "v0.4.0", "v1.19.0"} {
+		if !strings.Contains(disconnected, want) {
+			t.Fatalf("disconnected view missing %q:\n%s", want, disconnected)
+		}
+	}
+}

--- a/internal/tui/pages/system/section_test.go
+++ b/internal/tui/pages/system/section_test.go
@@ -15,6 +15,11 @@ func TestView_SectionGroups(t *testing.T) {
 		protocol.Status{DaemonVersion: "v0.4.0", Health: "ok", Capabilities: []string{protocol.CapabilityCore}},
 		protocol.CoreStatus{Status: "running", Version: "v1.19.0"},
 	)
+	// This test asserts section structure and the constant border palette; take
+	// it online so the daemon/core status dots use their positive (green) tone
+	// instead of the caution-yellow stale tone, which would otherwise bleed
+	// warning color into the palette assertion below.
+	model.SetMutationsEnabled(true)
 	view := model.View()
 	if !strings.Contains(view, "╭") || !strings.Contains(view, "╰") {
 		t.Fatalf("missing section borders:\n%s", view)


### PR DESCRIPTION
## 背景

Closes #36。

卸载 service(或任何断开 daemon 控制连接的操作)后,System 页出现矛盾状态:右上角 \`Reconnecting\`、底部 \`Daemon disconnected\`、红字 \`System endpoint state unavailable\`,**但** Daemon 行仍显示绿色 \`● ok\`、mihomo core 行仍显示绿色 \`● running\`。同页的 Update/Restart core、System proxy、TUN 行却已正确降级成 \`Stale\`。

## 根因

\`daemonValue\` / \`coreValue\` 两个渲染 helper 未消费 \`mutationsEnabled\`(在根 Model 里与 \`connected\`/\`stale\` 严格同步的断连信号),直接把缓存里的 \`Health="ok"\` / \`Status="running"\` 染成绿色原样输出。同页的 \`networkRows\` / \`actionState\` 都已正确消费它,唯独这两个 helper 漏了。

## 方案

复用 \`m.mutationsEnabled\`,**不改 \`SetSnapshot\` 签名**(36 个调用点,改签名收益为零、成本为 35 处机械修改)。给两个 helper 加 \`stale bool\` 形参,按仓库既定的断连降级惯例(Overview core 卡 design G2、状态栏 \`coreStatusGlyph\`)降级:**保留末值 + 圆点 \`ToneCaution\`(黄)+ 追加 \` · Stale\`**。

| 行 | 在线 | 断连 |
|---|---|---|
| Daemon | \`● ok  v0.3.0\`(绿) | \`● ok · Stale  v0.3.0\`(黄点) |
| mihomo core | \`● running  v1.19.29\`(绿) | \`● running · Stale  v1.19.29\`(黄点) |

## 改动

全部在 \`internal/tui/pages/system/\`:
- \`daemonValue\` / \`coreValue\`:加 \`stale bool\` 参数;stale 时 tone 覆盖 \`ui.ToneCaution\`、health/status 文本 append \`" · " + ui.StaleLabel\`
- \`rows()\`:两处调用点传 \`!m.mutationsEnabled\`
- \`TestView_SectionGroups\`:改为在线态(\`SetMutationsEnabled(true)\`),避免 stale 黄点(214)误触其 section 调色板断言
- 新增 \`TestSystemDaemonCoreRowsDegradeWhenDisconnected\`:断连含 \`StaleLabel\`、在线不含、版本号始终保留

## 验证

- \`go test ./...\` 全绿(40+ 包)
- \`gofmt -l .\` 为空(CI gofmt 预检)
- 不动 Overview(已是 G2 参考实现)、不改 \`SetSnapshot\` 签名、不动顶部状态栏

🤖 Generated with [Claude Code](https://claude.com/claude-code)