### PR TITLE
feat(tui): stale footer 显示最后观测时间 last observed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- TUI stale footer 显示最后数据时间 `last observed HH:MM`：daemon 控制连接断开后，footer stale 横幅追加最后一次成功数据推送的本地时间，便于判断屏幕上冻结数据的新旧（#37）
+
 ### Fixed
 
 - System 页 daemon / mihomo core 行在控制连接断开后降级显示：保留末值但圆点转黄并追加 `· Stale`,与 Overview core 卡及同页其它行一致（#36）

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -977,7 +977,11 @@ func (model Model) footerGlobalSegment() string {
 		}
 		return ui.SpinnerLabel(model.now, label)
 	}
-	return ui.GlobalStateLabel(model.globalState)
+	label := ui.GlobalStateLabel(model.globalState)
+	if model.globalState == ui.StateStale && !model.lastObservedAt.IsZero() {
+		label += " · last observed " + model.lastObservedAt.Local().Format("15:04")
+	}
+	return label
 }
 
 func (model Model) View() tea.View {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -54,7 +54,7 @@ type Model struct {
 	setupReturn       ui.PageID
 	pendingActions    map[string]ui.Action
 	globalState       ui.GlobalState
-	lastObservedAt    time.Time // last successful daemon data push; shown in stale footer
+	lastObservedAt    time.Time // last daemon stream sample; shown in stale footer
 	relaunchRequested bool
 	relaunchWarning   string
 	now               time.Time // spinner clock; advanced only while work is pending
@@ -503,8 +503,8 @@ func (model Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 func (model *Model) applySessionEvent(event session.Event) tea.Cmd {
 	var command tea.Cmd
 	model.monitor.Observe(event)
-	// Only push-stream events carry a non-zero ObservedAt; control/error events
-	// are zero-valued, so this freezes at the last successful data push.
+	// Only push-stream events carry a non-zero ObservedAt; non-stream events
+	// are synthesized locally (zero ObservedAt), so this freezes at the last push.
 	if !event.ObservedAt.IsZero() {
 		model.lastObservedAt = event.ObservedAt
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -54,6 +54,7 @@ type Model struct {
 	setupReturn       ui.PageID
 	pendingActions    map[string]ui.Action
 	globalState       ui.GlobalState
+	lastObservedAt    time.Time // last successful daemon data push; shown in stale footer
 	relaunchRequested bool
 	relaunchWarning   string
 	now               time.Time // spinner clock; advanced only while work is pending
@@ -502,6 +503,11 @@ func (model Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 func (model *Model) applySessionEvent(event session.Event) tea.Cmd {
 	var command tea.Cmd
 	model.monitor.Observe(event)
+	// Only push-stream events carry a non-zero ObservedAt; control/error events
+	// are zero-valued, so this freezes at the last successful data push.
+	if !event.ObservedAt.IsZero() {
+		model.lastObservedAt = event.ObservedAt
+	}
 	switch event.Kind {
 	case session.EventStatus:
 		model.status = event.Status

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -758,3 +758,24 @@ func TestActionCompletedRecordsOperations(t *testing.T) {
 		}
 	}
 }
+
+func TestApplySessionEvent_RecordsLastObservedAt(t *testing.T) {
+	model := NewModel()
+	fixed := time.Date(2026, 8, 12, 14, 32, 0, 0, time.UTC)
+
+	model.applySessionEvent(session.Event{
+		Kind:       session.EventTraffic,
+		ObservedAt: fixed,
+		Traffic:    protocol.TrafficSample{},
+	})
+	if !model.lastObservedAt.Equal(fixed) {
+		t.Fatalf("lastObservedAt=%v want %v", model.lastObservedAt, fixed)
+	}
+
+	// Error/control events carry a zero ObservedAt and must not advance the frozen timestamp.
+	before := model.lastObservedAt
+	model.applySessionEvent(session.Event{Kind: session.EventReconnecting})
+	if !model.lastObservedAt.Equal(before) {
+		t.Fatalf("reconnecting must not change lastObservedAt: %v", model.lastObservedAt)
+	}
+}

--- a/internal/tui/shell_view_test.go
+++ b/internal/tui/shell_view_test.go
@@ -137,6 +137,37 @@ func TestShellView_StaleUsesRightStatusNotSpinner(t *testing.T) {
 	}
 }
 
+func TestShellView_StaleFooterShowsLastObserved(t *testing.T) {
+	freezeUTC(t)
+	model := NewModel()
+	model.width, model.height = 100, 28
+	model.resizePages()
+	model.stale = true
+	model.globalState = ui.StateStale
+	model.lastObservedAt = time.Date(2026, 8, 12, 14, 32, 0, 0, time.UTC)
+	model.monitor.SetStale(true)
+
+	plain := normalizeRender(model.View().Content)
+	want := "last observed " + model.lastObservedAt.Local().Format("15:04")
+	if !strings.Contains(plain, want) {
+		t.Fatalf("stale footer missing %q:\n%s", want, plain)
+	}
+
+	// Zero timestamp (disconnect before any data): suffix must not appear.
+	model.lastObservedAt = time.Time{}
+	if plain := normalizeRender(model.View().Content); strings.Contains(plain, "last observed") {
+		t.Fatalf("zero lastObservedAt must not show suffix:\n%s", plain)
+	}
+
+	// Non-stale state must not show the suffix.
+	model.lastObservedAt = time.Date(2026, 8, 12, 14, 32, 0, 0, time.UTC)
+	model.globalState = ui.StateReconnected
+	model.stale = false
+	if plain := normalizeRender(model.View().Content); strings.Contains(plain, "last observed") {
+		t.Fatalf("non-stale footer must not show last observed:\n%s", plain)
+	}
+}
+
 func TestShellView_RightStatusDualServiceAndDaemon(t *testing.T) {
 	model := NewModel()
 	model.width, model.height = 120, 28


### PR DESCRIPTION
## Summary

daemon 控制连接断开进入全局 stale 态时，footer 横幅追加 `· last observed HH:MM`，让用户判断屏幕上冻结的数据停在何时。Closes #37。

- 时间取**最后一次成功数据推送**的本地时间（`session.Event.ObservedAt`），不是进入 stale 的时刻 —— 回答「这屏数据还能不能信」
- shell `Model` 新增 `lastObservedAt`，在 `applySessionEvent` 统一分发点对非零 `ObservedAt` 事件记录；控制/错误/内部事件 `ObservedAt` 天然为零被过滤，断开瞬间定格
- `footerGlobalSegment` 非 spinner 分支：`globalState == StateStale && !lastObservedAt.IsZero()` 时追加 ` · last observed HH:MM`
- **仅 footer 一处展示**：断开是全局事件，所有页面数据同一瞬间冻结，footer 单一信息源即覆盖全部；各页面 `· Stale` 短标记、状态栏右上 badge、core 圆点降色等行为不变
- MVP 绝对时间（`HH:MM`），静态渲染、无 tick；相对时长（`3m ago`）为后续可选项

## Test Plan

- [x] `gofmt -l .` 为空（CI Format 步骤）
- [x] `go build ./...` 通过
- [x] `go test ./...` 全部通过
- [x] `TestApplySessionEvent_RecordsLastObservedAt` —— 数据事件记录时间，reconnecting 不推进（断开不污染时间戳）
- [x] `TestShellView_StaleFooterShowsLastObserved` —— stale+非零显示 / 零值（断开前无数据）不显示 / 非 stale 不显示
- [x] 回归 `TestShellView_StaleUsesRightStatusNotSpinner`、`TestMonitor_StaleSummaryKeepsLastValues`、stale golden 渲染字节不变
- [ ] 手动：启动 `mihari tui` → 停 daemon → footer 出现 `Daemon disconnected — actions paused · last observed HH:MM`，`HH:MM` 停在断开前最后刷新时间 → 恢复 daemon 后后缀消失；各页面 `· Stale` 行为与改动前一致

## Commits

- `feat(tui): record last observed timestamp on session data events`
- `refactor(tui): tighten lastObservedAt comment wording`
- `feat(tui): show last observed time in stale footer`
- `docs(changelog): 记录 stale footer last observed（#37）`