### PR TITLE
test: 完成测试治理 Phase A-D 与 CI 观察覆盖

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,22 +19,79 @@ jobs:
           # configs targeting go1.26 (go.mod); action v6 does not support v2.
           version: v2.12.2
 
-  test:
-    runs-on: windows-latest
+  unit:
+    name: unit (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - name: Test
-        run: go test ./...
+        run: go test -count=1 ./...
+
+  # Fan-in for branch protection rules that still require a status named "test".
+  test:
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [unit]
+    steps:
+      - name: Verify unit matrix
+        run: |
+          for result in ${{ join(needs.unit.result, ' ') }}; do
+            [ "$result" = "success" ] || { echo "unit matrix result: $result"; exit 1; }
+          done
+
+  race:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
       - name: Race
-        run: go test -race ./...
+        run: go test -count=1 -race ./...
+
+  vet-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
       - name: Vet
         run: go vet ./...
       - name: Format
-        shell: bash
         run: test -z "$(gofmt -l .)"
+
+  # Observe-only coverage: reports total/critical packages; does not fail on percentage.
+  # Relative regression gate (Task 4) requires ≥10 successful main observations first.
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+      - name: Coverage profile
+        shell: bash
+        run: |
+          profile="$RUNNER_TEMP/mihari-coverage.out"
+          go test -count=1 -covermode=atomic -coverpkg=./... -coverprofile="$profile" ./...
+          go test -count=1 ./scripts/coverage-gate
+          go run ./scripts/coverage-gate report -profile "$profile" | tee -a "$GITHUB_STEP_SUMMARY"
+      - name: Upload coverage profile
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mihari-coverage-profile
+          path: ${{ runner.temp }}/mihari-coverage.out
+          retention-days: 14
+          if-no-files-found: ignore
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,76 @@
+name: fuzz
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  bounded-fuzz:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - name: Fuzz subscription document parser
+        id: fuzz_document
+        run: go test -run '^$' -fuzz '^FuzzParseDocument$' -fuzztime=60s ./internal/subscription
+
+      - name: Fuzz archive path safety
+        id: fuzz_archive
+        run: go test -run '^$' -fuzz '^FuzzSafeArchivePath$' -fuzztime=60s ./internal/panel/archive
+
+      - name: Fuzz control JSON decoder
+        id: fuzz_json
+        run: go test -run '^$' -fuzz '^FuzzDecodeControlJSON$' -fuzztime=60s ./internal/control/server
+
+      - name: Fuzz subscription userinfo
+        id: fuzz_userinfo
+        run: go test -run '^$' -fuzz '^FuzzParseUserInfo$' -fuzztime=60s ./internal/subscription
+
+      - name: Collect failure corpus (sanitized)
+        if: failure()
+        shell: bash
+        run: |
+          set -euo pipefail
+          out="$RUNNER_TEMP/fuzz-failure"
+          mkdir -p "$out/logs"
+          # Capture recent test output is already in job logs; collect corpus candidates only.
+          mapfile -t dirs < <(find internal -type d -path '*/testdata/fuzz/*' 2>/dev/null || true)
+          upload_corpus=1
+          for dir in "${dirs[@]:-}"; do
+            [ -d "$dir" ] || continue
+            # Reject oversized individual files.
+            while IFS= read -r -d '' file; do
+              size=$(wc -c <"$file")
+              if [ "$size" -gt 1048576 ]; then
+                echo "skip oversized corpus file: $file ($size bytes)"
+                upload_corpus=0
+              fi
+            done < <(find "$dir" -type f -print0 2>/dev/null || true)
+            # Reject likely-sensitive content.
+            if command -v rg >/dev/null 2>&1; then
+              if rg -a -n '(https?://|Bearer |token=|secret=)' "$dir" >/dev/null 2>&1; then
+                echo "sensitive pattern in corpus $dir; skipping corpus upload"
+                upload_corpus=0
+              fi
+            fi
+            if [ "$upload_corpus" -eq 1 ]; then
+              mkdir -p "$out/corpus"
+              cp -a "$dir" "$out/corpus/" || true
+            fi
+          done
+          echo "corpus_upload=$upload_corpus" >>"$GITHUB_OUTPUT"
+          echo "prepared=$out" >>"$GITHUB_OUTPUT"
+
+      - name: Upload fuzz failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-failure
+          path: ${{ runner.temp }}/fuzz-failure
+          retention-days: 7
+          if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,5 +183,7 @@ $env:GOOS = 'darwin';  $env:GOARCH = 'arm64'; go build ./cmd/mihari
 ## 10. 当前治理状态
 
 - 本文件只建立开发与测试规范，不代表现有代码已经通过规范审计。
-- 当前不新增或修改测试代码、CI、Git hooks，也不迁移目录。
-- 覆盖率固定门槛、测试分层一致性、fixture 治理、CI 矩阵与 hooks 留待后续独立审计和仓库完善阶段处理。
+- 用户已授权按 `docs/superpowers/plans/2026-08-12-test-governance-roadmap.md` 完整实施 Phase A-D，包括计划内测试、被测试证明必要的最小生产修复、CI/Actions、提交、推送与 PR。
+- 各阶段仍按计划边界和独立评审切分实施，不把无关重构混入测试治理变更。
+- 覆盖率当前先进入观察期；相对回归门禁必须满足至少 10 次成功 `main` workflow 的数据前置条件，固定覆盖率门槛仍须基于至少 30 次数据另行审核，不能提前写死。
+- Git hooks、目录迁移、真实订阅、真实 mihomo、系统服务安装及其他 testenv 操作不在本次授权范围内。

--- a/docs/superpowers/plans/2026-08-12-test-governance-phase-a-control-websocket.md
+++ b/docs/superpowers/plans/2026-08-12-test-governance-phase-a-control-websocket.md
@@ -1,0 +1,289 @@
+# Phase A Control Protocol and WebSocket Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 补齐订阅 `/v1` server/client 契约矩阵，并直接验证 Web gateway 的 WebSocket 双向代理与关闭语义。
+
+**Architecture:** handler 测试使用现有 `fakeSubscriptionRuntime` 和 `httptest`；client 测试扩展现有有限端点表；IPC 仅增加删除与迟到 refresh 的跨包不变量；WebSocket 使用两个本地 `httptest.Server` 组成 browser → gateway → fake controller 链路。
+
+**Tech Stack:** Go `testing`、`net/http/httptest`、`encoding/json`、`github.com/coder/websocket`、现有 protocol/runtime fake。
+
+## Global Constraints
+
+- 遵守总路线图的全部 Global Constraints 与 Governance Gate。
+- 不改变现有订阅路由、DTO 或客户端公开方法签名。
+- WebSocket 测试不得使用固定端口、固定 sleep 或公网。
+- controller secret 只允许出现在 gateway → fake controller 请求头中。
+
+---
+
+### Task 1: Subscription Server Contract Matrix
+
+**Files:**
+- Modify: `internal/control/server/subscription_test.go`
+- Verify: `internal/control/server/subscription.go:22`
+
+**Interfaces:**
+- Consumes: `Server.Handler() http.Handler`、`subscriptionAPI`。
+- Produces: `fakeSubscriptionRuntime` 的调用记录字段，以及 list/show/refresh/use/enable/remove 的直接契约测试。
+
+- [ ] **Step 1: 记录覆盖基线**
+
+```console
+go test -count=1 -coverprofile=subscription-server-before.out ./internal/control/server
+go tool cover -func=subscription-server-before.out
+```
+
+Expected: `showSubscription`、`enableSubscription`、`removeSubscription` 等目标函数显示 0.0%；报告文件放在系统临时目录或验证后删除，不提交。
+
+- [ ] **Step 2: 扩展 fake 调用记录**
+
+在 `fakeSubscriptionRuntime` 增加 `catalog`、`operation`、`profileID`、`enabled`、`err` 字段；每个 mutation fake 保存收到的参数并返回语义明确的 profile。核心结构：
+
+```go
+type fakeSubscriptionRuntime struct {
+    *fakeRuntime
+    catalog   subscription.PublicCatalog
+    operation runtimeapi.Operation
+    profileID string
+    enabled   bool
+    err       error
+    added     runtimeapi.AddSubscriptionInput
+    setInput  runtimeapi.SetSubscriptionInput
+}
+```
+
+- [ ] **Step 3: 增加读端点测试**
+
+新增 `TestSubscriptionListAndShowRoutesReturnSecretFreeDTOs` 和 `TestSubscriptionShowRouteMapsNotFound`。构造包含流量字段、`ProxyMode` 和不应出现在响应中的 URL 语义数据，断言 schema、revision、active ID、字段映射及 `CodeInvalidArgument`。
+
+- [ ] **Step 4: 增加 mutation 表驱动测试**
+
+新增 `TestSubscriptionProfileMutationRoutesForwardOperation`，覆盖 refresh/use/enable/remove：
+
+```go
+tests := []struct {
+    name, method, path, body string
+    wantEnabled *bool
+}{
+    {name: "refresh", method: http.MethodPost, path: "/v1/subscriptions/one/refresh", body: `{"operation_id":"refresh-1","if_revision":7}`},
+    {name: "use", method: http.MethodPut, path: "/v1/subscriptions/one/active", body: `{"operation_id":"use-1","if_revision":7}`},
+    {name: "enable false", method: http.MethodPut, path: "/v1/subscriptions/one/enabled", body: `{"operation_id":"enable-1","if_revision":7,"enabled":false}`},
+    {name: "remove", method: http.MethodDelete, path: "/v1/subscriptions/one", body: `{"operation_id":"remove-1","if_revision":7}`},
+}
+```
+
+断言 source 为 `control`、ID/revision/profile ID 完整转发，显式 `false` 未丢失，响应 operation ID 和提交后 revision 正确。
+
+- [ ] **Step 5: 增加公共错误测试**
+
+新增 `TestSubscriptionRoutesRejectInvalidBodiesAndUnavailableRuntime`，覆盖未知字段、第二个 JSON 对象、超大 body、缺失 operation ID、runtime capability 缺失和 fake 返回稳定 `APIError`。
+
+- [ ] **Step 6: 运行目标测试与覆盖验证**
+
+```console
+go test -count=1 -run '^TestSubscription' ./internal/control/server
+go test -count=1 -coverprofile=subscription-server-after.out ./internal/control/server
+go tool cover -func=subscription-server-after.out
+```
+
+Expected: 新测试通过；目标 handler 不再为 0.0%。
+
+- [ ] **Step 7: Commit（仅用户明确要求时）**
+
+```console
+git add internal/control/server/subscription_test.go
+git commit -s -m "test(control): 补齐订阅服务端契约矩阵"
+```
+
+### Task 2: Typed Subscription Client Matrix
+
+**Files:**
+- Modify: `internal/control/client/runtime_test.go`
+- Modify: `internal/control/client/webgui_test.go`
+- Verify: `internal/control/client/runtime.go:200`
+- Verify: `internal/control/client/webgui.go:45`
+
+**Interfaces:**
+- Consumes: `Client.doRuntime`、现有 `TestRuntimeClientFiniteEndpoints` 表。
+- Produces: 所有 subscription 与 panel mutation 的 method/path/body/response 契约断言。
+
+- [ ] **Step 1: 记录客户端零覆盖方法**
+
+```console
+go test -count=1 -coverprofile=control-client-before.out ./internal/control/client
+go tool cover -func=control-client-before.out
+```
+
+Expected: `Subscription`、enable/update/remove 及若干 panel mutation 为 0.0%。
+
+- [ ] **Step 2: 扩展有限端点表**
+
+向 `TestRuntimeClientFiniteEndpoints` 增加 show/use/enable/update/remove。路径中使用 `id/one` 证明 `url.PathEscape`：
+
+```go
+{"subscription show", http.MethodGet, "/v1/subscriptions/id%2Fone", "", subscriptionJSON, invokeShow},
+{"subscription use", http.MethodPut, "/v1/subscriptions/id%2Fone/active", mutationJSON, subscriptionJSON, invokeUse},
+{"subscription enable", http.MethodPut, "/v1/subscriptions/id%2Fone/enabled", enabledJSON, subscriptionJSON, invokeEnable},
+{"subscription update", http.MethodPatch, "/v1/subscriptions/id%2Fone", updateJSON, subscriptionJSON, invokeUpdate},
+{"subscription remove", http.MethodDelete, "/v1/subscriptions/id%2Fone", mutationJSON, mutationResultJSON, invokeRemove},
+```
+
+`updateJSON` 必须同时包含 `auto_refresh:false` 和 `interval:""`，证明 pointer 字段不会因零值丢失。
+
+- [ ] **Step 3: 补齐 panel client mutation 表**
+
+在 `webgui_test.go` 增加 update/activate/rollback/uninstall/reinstall 的方法、escaped path、operation ID 与 revision 断言，复用现有本地 HTTP server 模式。
+
+- [ ] **Step 4: 增加 API error 解码断言**
+
+让一个订阅端点返回 409 和 `revision_conflict` envelope，断言 `errors.As(err, *protocol.APIError)` 以及 code/details，不匹配底层错误文本。
+
+- [ ] **Step 5: 验证客户端包**
+
+```console
+go test -count=1 ./internal/control/client
+go test -count=1 -coverprofile=control-client-after.out ./internal/control/client
+go tool cover -func=control-client-after.out
+```
+
+Expected: 新增方法全部被执行；请求 JSON 与稳定响应类型正确。
+
+- [ ] **Step 6: Commit（仅用户明确要求时）**
+
+```console
+git add internal/control/client/runtime_test.go internal/control/client/webgui_test.go
+git commit -s -m "test(control): 补齐订阅与面板客户端契约"
+```
+
+### Task 3: Subscription Removal IPC Invariant
+
+**Files:**
+- Modify: `internal/integration/control_test.go`
+- Reuse: `internal/runtime/subscription_test.go:146`
+
+**Interfaces:**
+- Consumes: daemon IPC fixture、typed client、subscription service controlled fetcher。
+- Produces: 跨 IPC 删除成功且迟到 refresh 不复活对象的集成证明。
+
+- [ ] **Step 1: 记录跨包覆盖基线**
+
+```console
+go test -count=1 -covermode=atomic -coverpkg=./... -coverprofile="$env:TEMP\mihari-integration-before.out" ./internal/integration
+go tool cover -func="$env:TEMP\mihari-integration-before.out"
+```
+
+Expected: runtime 的“迟到 refresh 不复活已删除对象”由包内测试覆盖，但没有 client→IPC→runtime 的 remove/refresh 完整链路。该任务属于既有不变量的跨层覆盖，不制造错误断言。
+
+- [ ] **Step 2: 最小扩展 integration fixture**
+
+给现有 fixture 注入 channel-controlled `subscription.Fetcher`，并用 `t.Cleanup` 释放阻塞调用。不要复制 runtime 的提交判断。
+
+- [ ] **Step 3: 写跨 IPC 场景**
+
+新增 `TestSubscriptionRemoveOverIPCRejectsLateRefreshCommit`。用 channel 阻塞 fetch：启动 refresh → 等待进入下载 → 通过 client remove → 释放下载 → 断言 refresh 返回冲突/不存在，最终 list 中无该 ID。
+
+- [ ] **Step 4: 运行 Red–Green 验证**
+
+```console
+go test -count=1 -run '^TestSubscriptionRemoveOverIPCRejectsLateRefreshCommit$' ./internal/integration
+go test -count=1 ./internal/integration
+```
+
+Expected: 两条命令通过，测试结束后无 daemon、listener 或 goroutine 遗留；若测试揭示跨 IPC 缺陷，先保留失败证据，再做最小生产修复。
+
+- [ ] **Step 5: Commit（仅用户明确要求时）**
+
+```console
+git add internal/integration/control_test.go
+git commit -s -m "test(integration): 验证订阅删除拒绝迟到刷新"
+```
+
+### Task 4: WebSocket Authentication and Relay
+
+**Files:**
+- Modify: `internal/web/server_test.go`
+- Verify: `internal/web/server.go:650`
+
+**Interfaces:**
+- Consumes: `web.New(Options)`、`Server.Serve`、`websocket.Accept/Dial`。
+- Produces: browser → gateway → controller 的双向消息和 secret 隔离测试。
+
+- [ ] **Step 1: 记录 `proxyWebSocket` 0% 基线**
+
+```console
+go test -count=1 -coverprofile=web-before.out ./internal/web
+go tool cover -func=web-before.out
+```
+
+- [ ] **Step 2: 增加 fake WebSocket controller helper**
+
+helper 接受期望 secret，记录 path/query/auth，回显收到的 message type/data，并在 `t.Cleanup` 关闭：
+
+```go
+func newWebSocketController(t *testing.T, wantSecret string) *httptest.Server
+```
+
+- [ ] **Step 3: 增加成功双向代理测试**
+
+新增 `TestGatewayWebSocketRelaysBidirectionallyAndInjectsOnlyControllerSecret`：browser 使用 Web credential 取得 session，再连接 gateway stream；发送 text 与 binary frame；断言 controller 收到 controller secret、原 path/query 和相同帧，浏览器响应及 gateway 可见 header/body 均不含 secret。
+
+- [ ] **Step 4: 运行成功路径测试**
+
+```console
+go test -count=1 -run '^TestGatewayWebSocketRelaysBidirectionallyAndInjectsOnlyControllerSecret$' ./internal/web
+```
+
+Expected: PASS；`proxyWebSocket` 覆盖不再为 0%。
+
+### Task 5: WebSocket Shutdown and Error Paths
+
+**Files:**
+- Modify: `internal/web/server_test.go`
+- Modify only if test proves a defect: `internal/web/server.go:650`
+
+**Interfaces:**
+- Consumes: Task 4 WebSocket helper。
+- Produces: 上游关闭、客户端关闭、context 取消、握手错误的有界退出证明。
+
+- [ ] **Step 1: 写关闭行为测试**
+
+新增：
+
+```go
+func TestGatewayWebSocketUpstreamCloseStopsRelay(t *testing.T)
+func TestGatewayWebSocketClientCloseStopsUpstream(t *testing.T)
+func TestGatewayWebSocketContextCancelReleasesBothSides(t *testing.T)
+```
+
+使用 `done` channel 和 3 秒 context deadline 等待确定事件；禁止 `time.Sleep`。
+
+- [ ] **Step 2: 写握手失败表驱动测试**
+
+覆盖上游 401、500、不可连接和非法 controller URL，断言安全 HTTP 状态、响应不含 controller secret 或上游 body。
+
+- [ ] **Step 3: 运行测试并只在失败时修实现**
+
+```console
+go test -count=1 -run '^TestGatewayWebSocket' ./internal/web
+```
+
+Expected: 若现实现泄漏 goroutine 或没有传播关闭，测试先失败；最小修复应让一个 relay 方向结束时取消共享 context 并关闭两端，不改变公开接口。
+
+- [ ] **Step 4: 扩大验证**
+
+```console
+go test -count=1 ./internal/web ./internal/control/server ./internal/control/client ./internal/integration
+go test -count=1 -race ./internal/web ./internal/integration
+go vet ./...
+gofmt -l internal/control internal/web internal/integration
+```
+
+Expected: 全部通过，`gofmt -l` 无输出。
+
+- [ ] **Step 5: Commit（仅用户明确要求时）**
+
+```console
+git add internal/web/server.go internal/web/server_test.go
+git commit -s -m "test(web): 覆盖 WebSocket 双向代理生命周期"
+```

--- a/docs/superpowers/plans/2026-08-12-test-governance-phase-b-mutation-platform.md
+++ b/docs/superpowers/plans/2026-08-12-test-governance-phase-b-mutation-platform.md
@@ -1,0 +1,230 @@
+# Phase B Mutation and Platform Lifecycle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 直接保护公开 mutation 的 coordinator/revision/rollback 语义，并补齐安全、无持久副作用的平台生命周期测试。
+
+**Architecture:** app 的 Web mutation 通过使用方附近的最小接口解除具体 `*runtime.Manager` 测试耦合；runtime 复用现有 fake controller/panels；supervisor 扩展 fake child 验证 terminate→kill；平台包只测试命令构造、路径、分类和注入 backend，不操作真实系统状态。
+
+**Tech Stack:** Go `testing`、现有 `state.Coordinator`、channel-controlled fake、平台 build tags。
+
+## Global Constraints
+
+- 遵守总路线图 Global Constraints 与 Governance Gate。
+- 不扩大 daemon 单写入者边界，不新增通用 mock 框架。
+- 慢 IO 和等待不得位于 coordinator 临界区。
+- 平台测试不得安装服务、写真实 registry/system proxy 或启动提权流程。
+
+---
+
+### Task 1: App Web Mutation Boundary
+
+**Files:**
+- Modify: `internal/app/runtime.go:246`
+- Modify: `internal/app/runtime_test.go`
+
+**Interfaces:**
+- Consumes: runtime manager mutation methods。
+- Produces: 使用方最小接口 `webMutationRuntime`，让 `webMutator` 可用 recording fake 测试。
+
+- [ ] **Step 1: 写编译失败的接口驱动测试**
+
+新增 recording fake 并让 `webMutator{manager: fake}` 编译；测试 `SelectProxy`、单个/全部关闭及 TUN patch。Expected: FAIL，因为字段当前要求 `*runtime.Manager`。
+
+- [ ] **Step 2: 引入最小接口**
+
+```go
+type webMutationRuntime interface {
+    SelectProxy(context.Context, runtimeapi.Operation, string, string) error
+    CloseConnection(context.Context, runtimeapi.Operation, string) error
+    CloseAllConnections(context.Context, runtimeapi.Operation) error
+    EnableTun(context.Context, runtimeapi.Operation) (protocol.TunStatus, error)
+    DisableTun(context.Context, runtimeapi.Operation) (protocol.TunStatus, error)
+}
+```
+
+将 `webMutator.manager` 改为该接口；`*runtime.Manager` 自动满足，不改变装配行为。
+
+- [ ] **Step 3: 完成行为断言**
+
+新增 `TestWebMutatorRoutesOperationsThroughRuntime` 与 `TestWebMutatorConfigPatchAllowlist`，断言 operation source=`web`、ID 非空且前缀正确、参数原样转发；缺失 tun、非 object、非 bool 分别返回稳定错误码。
+
+- [ ] **Step 4: Red–Green 验证**
+
+```console
+go test -count=1 -run '^TestWebMutator' ./internal/app
+go test -count=1 ./internal/app
+```
+
+- [ ] **Step 5: Commit（仅用户明确要求时）**
+
+```console
+git add internal/app/runtime.go internal/app/runtime_test.go
+git commit -s -m "test(app): 覆盖 Web mutation 装配边界"
+```
+
+### Task 2: Runtime Controller Mutations
+
+**Files:**
+- Modify: `internal/runtime/manager_test.go`
+- Verify: `internal/runtime/manager.go:450`
+
+**Interfaces:**
+- Consumes: `fakeController`、`newTestManager`、`Operation`。
+- Produces: select/close/config mutation 的 revision、幂等和错误传播测试。
+
+- [ ] **Step 1: 扩展 fakeController 记录**
+
+增加调用计数、参数、可注入 error 和 channel gate；现有方法保持零值可用。
+
+- [ ] **Step 2: 增加 mutation 表驱动测试**
+
+新增 `TestControllerMutationsCommitRevisionAndPropagateErrors`，覆盖 SelectProxy、CloseConnection、CloseAllConnections；断言成功 revision +1，controller error 不提交 revision，参数和 context 传递正确。
+
+- [ ] **Step 3: 增加幂等与 restart 串行测试**
+
+对同一 operation ID 并发调用两次，断言 controller 只执行一次；使用 channel gate 证明 mutation 等待 maintenance/restart 后再进入 controller，不使用 sleep。
+
+- [ ] **Step 4: 验证**
+
+```console
+go test -count=1 -run '^(TestControllerMutations|TestDuplicateOperationID|TestRuntimeMutationWaits)' ./internal/runtime
+go test -count=1 -race ./internal/runtime
+```
+
+- [ ] **Step 5: Commit（仅用户明确要求时）**
+
+```console
+git add internal/runtime/manager_test.go
+git commit -s -m "test(runtime): 补齐 controller mutation 事务语义"
+```
+
+### Task 3: Panel Mutation Symmetry
+
+**Files:**
+- Modify: `internal/runtime/panel_test.go`
+- Verify: `internal/runtime/panel.go`
+
+**Interfaces:**
+- Consumes: `fakePanels`、`Manager` panel methods。
+- Produces: update/uninstall/reinstall 的 coordinator、stale revision 和失败不提交测试。
+
+- [ ] **Step 1: 扩展 fakePanels**
+
+为 uninstall/reinstall 增加函数钩子与调用记录；锁只保护记录，不在锁内等待 channel。
+
+- [ ] **Step 2: 写三个表驱动场景**
+
+每个 mutation 验证：成功 revision +1；stale revision 时 service 未调用；service error 时 revision 不变。Update 另用 channel 证明准备/下载在提交锁外。
+
+- [ ] **Step 3: 运行并最小修复真实缺陷**
+
+```console
+go test -count=1 -run 'Panel' ./internal/runtime
+```
+
+Expected: 测试先暴露任何不对称行为；只修改 `panel.go` 中被证明有问题的路径。
+
+- [ ] **Step 4: Commit（仅用户明确要求时）**
+
+```console
+git add internal/runtime/panel.go internal/runtime/panel_test.go
+git commit -s -m "test(runtime): 补齐面板 mutation 回滚与 revision 路径"
+```
+
+### Task 4: Supervisor Terminate-to-Kill Lifecycle
+
+**Files:**
+- Modify: `internal/supervisor/supervisor_test.go`
+- Modify only if needed: `internal/supervisor/supervisor.go:234`
+
+**Interfaces:**
+- Consumes: `fakeChild`、fake waiter、`Supervisor.stopChild`。
+- Produces: graceful terminate、timeout kill、kill error、wait completion和取消路径测试。
+
+- [ ] **Step 1: 让 fakeChild 可分别控制 Terminate/Kill/Wait**
+
+增加 `terminateErr`、`killErr`、`terminateCalled`、`killCalled` 和独立 `done` 控制，避免 `Terminate` 自动结束所有场景。
+
+- [ ] **Step 2: 增加测试**
+
+```go
+func TestSupervisorStopsChildAfterTerminate(t *testing.T)
+func TestSupervisorKillsChildAfterGraceTimeout(t *testing.T)
+func TestSupervisorPropagatesKillError(t *testing.T)
+func TestSupervisorCancellationWaitsForChildCleanup(t *testing.T)
+```
+
+用可注入 waiter/短测试 timeout 触发事件，不通过大幅缩短生产常量制造竞态。
+
+- [ ] **Step 3: 验证 race**
+
+```console
+go test -count=1 ./internal/supervisor
+go test -count=20 -race ./internal/supervisor
+```
+
+Expected: 20 次无 flaky、无竞态。
+
+- [ ] **Step 4: Commit（仅用户明确要求时）**
+
+```console
+git add internal/supervisor/supervisor.go internal/supervisor/supervisor_test.go
+git commit -s -m "test(supervisor): 覆盖子进程强制终止生命周期"
+```
+
+### Task 5: Native Platform Tests Without Side Effects
+
+**Files:**
+- Modify: `internal/platform/paths_test.go`
+- Create as applicable: `internal/platform/relaunch_windows_test.go`
+- Create as applicable: `internal/platform/relaunch_unix_test.go`
+- Modify: `internal/service/service_test.go`
+- Modify: `internal/sysproxy/*_test.go`
+- Modify: `internal/elevate/elevate_test.go`
+
+**Interfaces:**
+- Consumes: 现有 command/backend/checker 注入点与 build-tagged helpers。
+- Produces: 三平台各自能运行、但不改变系统状态的原生测试集合。
+
+- [ ] **Step 1: 盘点当前平台覆盖**
+
+```console
+go test -count=1 -coverprofile=platform-before.out ./internal/platform ./internal/service ./internal/sysproxy ./internal/elevate
+go tool cover -func=platform-before.out
+```
+
+- [ ] **Step 2: 补纯逻辑与注入边界**
+
+覆盖路径 override、service status/error mapping、sysproxy owned/foreign/off、elevation checker 恢复。测试使用 `t.Setenv`、`t.TempDir`、`t.Cleanup`，不调用平台真实写操作。
+
+- [ ] **Step 3: 补 build-tagged relaunch/command tests**
+
+若现代码无法观察命令构造，引入包内 `commandFactory` 函数变量并在 `t.Cleanup` 恢复；Windows 断言隐藏窗口/控制台继承语义，Unix 断言参数与环境继承。禁止实际替换当前进程。
+
+- [ ] **Step 4: 当前平台验证与交叉编译**
+
+```console
+go test -count=1 ./internal/platform ./internal/service ./internal/sysproxy ./internal/elevate ./internal/supervisor
+$env:CGO_ENABLED='0'; $env:GOOS='windows'; $env:GOARCH='amd64'; go test -c -o "$env:TEMP\mihari-platform-windows-amd64.test.exe" ./internal/platform
+$env:GOOS='linux'; $env:GOARCH='amd64'; go test -c -o "$env:TEMP\mihari-platform-linux-amd64.test" ./internal/platform
+$env:GOOS='darwin'; $env:GOARCH='arm64'; go test -c -o "$env:TEMP\mihari-platform-darwin-arm64.test" ./internal/platform
+```
+
+Expected: 当前平台测试通过，三个目标测试包可编译；生成的测试二进制放到临时目录且不提交。
+
+- [ ] **Step 5: 全阶段验证**
+
+```console
+go test -count=1 ./internal/app ./internal/runtime ./internal/supervisor ./internal/platform ./internal/service ./internal/sysproxy ./internal/elevate
+go test -count=1 -race ./...
+go vet ./...
+gofmt -l internal
+```
+
+- [ ] **Step 6: Commit（仅用户明确要求时）**
+
+```console
+git add internal/platform internal/service internal/sysproxy internal/elevate
+git commit -s -m "test(platform): 补齐无副作用的原生生命周期测试"
+```

--- a/docs/superpowers/plans/2026-08-12-test-governance-phase-c-ci-coverage.md
+++ b/docs/superpowers/plans/2026-08-12-test-governance-phase-c-ci-coverage.md
@@ -1,0 +1,220 @@
+# Phase C CI and Coverage Governance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在三平台原生运行默认测试，生成统一跨包覆盖报告，并在观察期后用同环境 base/HEAD 比较阻止无说明退化。
+
+**Architecture:** CI 将原 `test` job 拆为 OS matrix、Windows race、vet-format 与 Linux coverage。一个无第三方依赖的 Go CLI 解析 coverprofile，按总仓和固定关键包集合聚合语句覆盖，并比较两个 profile；观察期只输出 summary，门禁激活通过显式 workflow 参数完成。
+
+**Tech Stack:** GitHub Actions、Go coverprofile、Go 标准库、JSON/text summary。
+
+## Global Constraints
+
+- 遵守总路线图 Global Constraints 与 Governance Gate。
+- coverage 的可比口径固定为 `ubuntu-latest`、相同 Go toolchain、`-covermode=atomic -coverpkg=./...`。
+- 第一轮只观察至少 10 个成功 `main` run；不得在同一提交中直接启用百分比失败门禁。
+- coverage artifact 位于 runner 临时目录，不写入或提交仓库。
+- 六目标 `CGO_ENABLED=0` cross-build 保持不变。
+
+---
+
+### Task 1: Coverage Profile Parser Tests
+
+**Files:**
+- Create: `scripts/coverage-gate/main.go`
+- Create: `scripts/coverage-gate/main_test.go`
+
+**Interfaces:**
+- Produces: `parseProfile(io.Reader) (report, error)`、`compare(base, head report, policy) result`。
+- Consumers: Task 3/4 coverage job。
+
+- [ ] **Step 1: 写 parser 失败测试**
+
+在 `main_test.go` 用内存 profile 覆盖：mode header、覆盖/未覆盖 block、同包多文件、Windows 风格路径、格式错误和零语句。Expected: FAIL，因为类型和函数尚不存在。
+
+```go
+func TestParseProfileAggregatesTotalAndCriticalPackages(t *testing.T) {
+    input := `mode: atomic
+github.com/mihari-proxy/mihari/internal/runtime/a.go:1.1,2.1 4 1
+github.com/mihari-proxy/mihari/internal/runtime/b.go:3.1,4.1 6 0
+`
+    got, err := parseProfile(strings.NewReader(input))
+    // assert total 4/10 and internal/runtime 4/10
+}
+```
+
+- [ ] **Step 2: 写 comparison 失败测试**
+
+覆盖总覆盖下降 0.5pp 边界、关键包下降 1.0pp 边界、改善、base 中不存在的新包、head 缺包以及 deterministic 排序。
+
+- [ ] **Step 3: 运行 Red**
+
+```console
+go test -count=1 ./scripts/coverage-gate
+```
+
+Expected: FAIL，缺少 parser/comparison 实现。
+
+### Task 2: Coverage Gate CLI Implementation
+
+**Files:**
+- Modify: `scripts/coverage-gate/main.go`
+- Modify: `scripts/coverage-gate/main_test.go`
+
+**Interfaces:**
+- CLI: `coverage-gate report -profile <path>`。
+- CLI: `coverage-gate compare -base <path> -head <path> -total-drop 0.5 -critical-drop 1.0`。
+- Output: Markdown summary to stdout; compare violation exits non-zero。
+
+- [ ] **Step 1: 实现 profile parser**
+
+定义明确类型：
+
+```go
+type coverage struct { Covered, Statements uint64 }
+type report struct { Total coverage; Packages map[string]coverage }
+type policy struct { TotalDrop, CriticalDrop float64; Critical []string }
+type result struct { TotalDelta float64; PackageDeltas map[string]float64; Violations []string }
+```
+
+用 `bufio.Scanner`、`strings.Fields`、`strconv` 解析 profile；package 从 module path 到最后一个 `/` 之间提取。拒绝 malformed、负数、count 非法和重复 mode header。
+
+- [ ] **Step 2: 实现比较与 CLI**
+
+百分比只在展示/比较时计算；分母为零时显式输出 `n/a`。关键包列表硬编码为规格中的十个包，避免 workflow 与工具产生两份配置。
+
+- [ ] **Step 3: 运行 Green 与命令烟测**
+
+```console
+go test -count=1 ./scripts/coverage-gate
+go test -count=1 -covermode=atomic -coverpkg=./... -coverprofile="$env:TEMP\mihari-coverage.out" ./...
+go run ./scripts/coverage-gate report -profile "$env:TEMP\mihari-coverage.out"
+```
+
+Expected: parser/comparison 测试通过；对有效 profile 输出 total 与关键包表。
+
+- [ ] **Step 4: Commit（仅用户明确要求时）**
+
+```console
+git add scripts/coverage-gate
+git commit -s -m "test(tooling): 增加跨包覆盖率比较工具"
+```
+
+### Task 3: Native OS Matrix and Coverage Observability
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+**Interfaces:**
+- Consumes: Task 2 `coverage-gate report`。
+- Produces: `unit (windows|linux|macos)`、`race`、`vet-format`、`coverage` job。
+
+- [ ] **Step 1: 重构 test jobs**
+
+将默认测试改为 `matrix.os: [windows-latest, ubuntu-latest, macos-latest]`，每项运行：
+
+```yaml
+- name: Test
+  run: go test -count=1 ./...
+```
+
+保留独立 `race` 在 `windows-latest`，命令为 `go test -count=1 -race ./...`；vet/format 独立执行，避免某平台失败掩盖其他结果。
+
+- [ ] **Step 2: 增加只观察 coverage job**
+
+在 `ubuntu-latest`、bash 中执行：
+
+```bash
+profile="$RUNNER_TEMP/mihari-coverage.out"
+go test -count=1 -covermode=atomic -coverpkg=./... -coverprofile="$profile" ./...
+go run ./scripts/coverage-gate report -profile "$profile" | tee -a "$GITHUB_STEP_SUMMARY"
+```
+
+上传 profile，artifact retention 使用明确短周期；该 job 此时只因测试或 parser 错误失败，不因百分比失败。
+
+- [ ] **Step 3: 本地等价验证**
+
+```console
+go test -count=1 ./scripts/coverage-gate
+go test -count=1 ./...
+go test -count=1 -race ./...
+go vet ./...
+```
+
+- [ ] **Step 4: workflow 审核**
+
+检查 job 名不会破坏当前 branch protection 的 `cross-build`；确认 matrix 不调用真实系统服务；确认 coverage profile 仅位于 `$RUNNER_TEMP`。
+
+- [ ] **Step 5: Commit（仅用户明确要求时）**
+
+```console
+git add .github/workflows/ci.yml
+git commit -s -m "ci: 增加三平台测试与覆盖率报告"
+```
+
+### Task 4: Relative Coverage Regression Gate
+
+**Prerequisite:** coverage job 已在 `main` 上连续成功至少 10 次，且审查确认自然波动不超过设计容差。
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+- Modify if observations require: `scripts/coverage-gate/main_test.go`
+- Update: `docs/superpowers/specs/2026-08-12-test-coverage-governance-design.md`（记录观察样本与最终批准阈值）
+
+**Interfaces:**
+- Consumes: Task 2 `coverage-gate compare`。
+- Produces: PR merge-base 与 HEAD 同环境相对门禁。
+
+- [ ] **Step 1: 记录观察结果并请求阈值批准**
+
+在规格中记录 10 次 run 的 total/关键包最小、最大和波动。若数据支持原设计，请用户批准 total drop 0.5pp、critical drop 1.0pp；否则提出有证据的新阈值。未经批准不继续。
+
+- [ ] **Step 2: 在临时 git worktree 计算 base profile**
+
+workflow fetch PR base SHA，在 `$RUNNER_TEMP/base-worktree` 创建 detached worktree，使用同一 Go 版本和相同命令生成 base profile；用 `if: always()` 清理 worktree。不得覆盖 PR 工作区。
+
+- [ ] **Step 3: 比较 HEAD**
+
+```bash
+go run ./scripts/coverage-gate compare \
+  -base "$RUNNER_TEMP/base.out" \
+  -head "$RUNNER_TEMP/head.out" \
+  -total-drop 0.5 -critical-drop 1.0 | tee -a "$GITHUB_STEP_SUMMARY"
+```
+
+Expected: 超过任一批准容差时非零退出；改善或容差内波动通过。
+
+- [ ] **Step 4: 验证 gate 自身**
+
+在测试 fixture 中交换 base/head，证明下降会失败、改善会通过；在 draft PR 或专用分支验证 summary、artifact 和 worktree cleanup。
+
+- [ ] **Step 5: Commit（仅用户明确要求时）**
+
+```console
+git add .github/workflows/ci.yml scripts/coverage-gate/main_test.go docs/superpowers/specs/2026-08-12-test-coverage-governance-design.md
+git commit -s -m "ci: 启用覆盖率相对基线门禁"
+```
+
+### Task 5: Phase Verification
+
+**Files:** no new files.
+
+- [ ] **Step 1: 完整本地验证**
+
+```console
+go test -count=1 ./scripts/coverage-gate
+go test -count=1 ./...
+go test -count=1 -race ./...
+go vet ./...
+gofmt -l scripts
+git diff --check
+```
+
+- [ ] **Step 2: 检查产物与 diff**
+
+```console
+git status --short
+git diff --stat
+```
+
+Expected: 不含 `coverage.out`、测试二进制、临时 worktree 或无关文件。

--- a/docs/superpowers/plans/2026-08-12-test-governance-phase-d-fuzz.md
+++ b/docs/superpowers/plans/2026-08-12-test-governance-phase-d-fuzz.md
@@ -1,0 +1,211 @@
+# Phase D Bounded Fuzz Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为四类不可信输入边界增加可复现 seed corpus 和有界 nightly fuzz，不影响默认测试的隔离性。
+
+**Architecture:** fuzz target 与被测包相邻，复用现有 fixture 作为 seed；每个 target 断言“不 panic + 明确安全不变量”，发现 crash 后先固化最小输入再修复。独立 workflow 顺序运行 target，每项 60 秒并设置 job timeout。
+
+**Tech Stack:** Go native fuzzing、`testing.F`、`httptest`、`archive/zip`、GitHub Actions。
+
+## Global Constraints
+
+- 遵守总路线图 Global Constraints 与 Governance Gate。
+- fuzz 输入只使用合成数据，不含真实 URL、凭据或用户文件。
+- fuzz target 不访问公网，不写 `t.TempDir()` 之外路径。
+- 默认 `go test ./...` 只运行 seed corpus；持续 fuzz 只在 nightly/手动 workflow。
+- crash corpus 经人工确认无敏感数据后才允许提交。
+
+---
+
+### Task 1: Subscription Document Parser Fuzzing
+
+**Files:**
+- Modify: `internal/subscription/document_test.go`
+- Modify only on proven defect: `internal/subscription/document.go`
+
+**Interfaces:**
+- Consumes: `ParseDocument([]byte) (Document, error)`。
+- Produces: `FuzzParseDocument`。
+
+- [ ] **Step 1: 增加 seed corpus**
+
+加入有效 proxies、有效 proxy-providers、空输入、多 YAML 文档、错误 proxies 类型、未知 tag、嵌套 alias 和接近大小边界的小型代表输入。
+
+- [ ] **Step 2: 写 fuzz 不变量**
+
+```go
+func FuzzParseDocument(f *testing.F) {
+    for _, seed := range documentSeeds { f.Add([]byte(seed)) }
+    f.Fuzz(func(t *testing.T, input []byte) {
+        document, err := ParseDocument(input)
+        if err == nil && document == nil { t.Fatal("nil document without error") }
+        if err == nil {
+            _, proxies := document["proxies"]
+            _, providers := document["proxy-providers"]
+            if !proxies && !providers { t.Fatal("accepted non-subscription") }
+        }
+    })
+}
+```
+
+- [ ] **Step 3: 验证 seed 与短 fuzz**
+
+```console
+go test -count=1 ./internal/subscription
+go test -run '^$' -fuzz '^FuzzParseDocument$' -fuzztime=10s ./internal/subscription
+```
+
+- [ ] **Step 4: Commit（仅用户明确要求时）**
+
+```console
+git add internal/subscription/document.go internal/subscription/document_test.go
+git commit -s -m "test(fuzz): 覆盖订阅文档解析边界"
+```
+
+### Task 2: Archive Path Fuzzing
+
+**Files:**
+- Modify: `internal/panel/archive/zip_test.go`
+- Modify only on proven defect: `internal/panel/archive/zip.go`
+
+**Interfaces:**
+- Consumes: `SafeName(string) bool`、包内 `resolveTarget(string, string)`。
+- Produces: `FuzzSafeArchivePath`。
+
+- [ ] **Step 1: 增加路径 seed**
+
+包含正常嵌套路径、`.`、`..`、绝对 Unix/Windows 路径、UNC、混合分隔符、NUL、空名、Unicode normalization 和超长 segment。
+
+- [ ] **Step 2: 写安全不变量**
+
+在 `t.TempDir()` 下调用 `resolveTarget`；若接受，使用 `filepath.Rel` 断言结果不是 `..`、不以 `..+separator` 开头且仍位于目标根。`SafeName` 拒绝时不得要求 `resolveTarget` 接受。
+
+- [ ] **Step 3: 验证**
+
+```console
+go test -count=1 ./internal/panel/archive
+go test -run '^$' -fuzz '^FuzzSafeArchivePath$' -fuzztime=10s ./internal/panel/archive
+```
+
+- [ ] **Step 4: Commit（仅用户明确要求时）**
+
+```console
+git add internal/panel/archive/zip.go internal/panel/archive/zip_test.go
+git commit -s -m "test(fuzz): 覆盖面板归档路径边界"
+```
+
+### Task 3: Control JSON Decoder Fuzzing
+
+**Files:**
+- Modify: `internal/control/server/runtime_test.go`
+- Modify only on proven defect: `internal/control/server/runtime.go:432`
+
+**Interfaces:**
+- Consumes: 包内 `decodeControlJSON(http.ResponseWriter, *http.Request, any) bool`。
+- Produces: `FuzzDecodeControlJSON`。
+
+- [ ] **Step 1: 增加 DTO seed**
+
+使用 `MutationRequest`、`SubscriptionUpdateRequest`、未知字段、重复对象、尾随 JSON、畸形 UTF-8 和超过 `maxControlBodySize` 的代表输入。
+
+- [ ] **Step 2: 写 fuzz harness**
+
+每次创建 `httptest.NewRequest` 和 recorder，轮流解码到两个明确 DTO。断言：成功只返回 2xx 前置状态且 body 恰好一个对象；失败状态为 400，envelope 可解码为 `CodeInvalidArgument`，响应不回显原输入。
+
+- [ ] **Step 3: 验证**
+
+```console
+go test -count=1 ./internal/control/server
+go test -run '^$' -fuzz '^FuzzDecodeControlJSON$' -fuzztime=10s ./internal/control/server
+```
+
+- [ ] **Step 4: Commit（仅用户明确要求时）**
+
+```console
+git add internal/control/server/runtime.go internal/control/server/runtime_test.go
+git commit -s -m "test(fuzz): 覆盖控制请求 JSON 解码边界"
+```
+
+### Task 4: Subscription Userinfo Fuzzing
+
+**Files:**
+- Modify: `internal/subscription/userinfo_test.go`
+- Modify only on proven defect: `internal/subscription/userinfo.go`
+
+**Interfaces:**
+- Consumes: `ParseUserInfo(string) (UserInfo, bool)`、`UserInfo.Used()`。
+- Produces: `FuzzParseUserInfo`。
+
+- [ ] **Step 1: 增加 seed**
+
+包含正常 header、大小写/空白、重复 key、负值、`MaxInt64`、溢出、乱码、未知 key 和空输入。
+
+- [ ] **Step 2: 写不变量**
+
+断言所有返回字段非负；`ok=false` 时结构为零值；`Used()` 永不为负。若 upload/download 求和溢出导致 `Used()` 错误归零，先添加明确回归测试，再决定采用饱和还是安全归零语义并请求审查，不在 fuzz 修复中暗改公开展示语义。
+
+- [ ] **Step 3: 验证**
+
+```console
+go test -count=1 ./internal/subscription
+go test -run '^$' -fuzz '^FuzzParseUserInfo$' -fuzztime=10s ./internal/subscription
+```
+
+- [ ] **Step 4: Commit（仅用户明确要求时）**
+
+```console
+git add internal/subscription/userinfo.go internal/subscription/userinfo_test.go
+git commit -s -m "test(fuzz): 覆盖订阅配额头解析边界"
+```
+
+### Task 5: Bounded Fuzz Workflow
+
+**Files:**
+- Create: `.github/workflows/fuzz.yml`
+
+**Interfaces:**
+- Consumes: Tasks 1–4 fuzz target names。
+- Produces: nightly + `workflow_dispatch` 有界 fuzz job。
+
+- [ ] **Step 1: 创建 workflow**
+
+触发器使用每日 cron 和手动触发；runner 为 `ubuntu-latest`；job `timeout-minutes: 10`。顺序执行：
+
+```console
+go test -run '^$' -fuzz '^FuzzParseDocument$' -fuzztime=60s ./internal/subscription
+go test -run '^$' -fuzz '^FuzzSafeArchivePath$' -fuzztime=60s ./internal/panel/archive
+go test -run '^$' -fuzz '^FuzzDecodeControlJSON$' -fuzztime=60s ./internal/control/server
+go test -run '^$' -fuzz '^FuzzParseUserInfo$' -fuzztime=60s ./internal/subscription
+```
+
+- [ ] **Step 2: 失败产物策略**
+
+仅在失败时上传对应包 `testdata/fuzz/<Target>` 与测试日志，artifact retention 设为 7 天。上传前拒绝大于 1 MiB 的单文件，并运行 `rg -a -n '(https?://|Bearer |token=|secret=)' <corpus-dir>`；命中时只上传日志，不上传 corpus。
+
+- [ ] **Step 3: 默认与 bounded 验证**
+
+```console
+go test -count=1 ./...
+go test -run '^$' -fuzz '^FuzzParseDocument$' -fuzztime=10s ./internal/subscription
+go test -run '^$' -fuzz '^FuzzSafeArchivePath$' -fuzztime=10s ./internal/panel/archive
+go test -run '^$' -fuzz '^FuzzDecodeControlJSON$' -fuzztime=10s ./internal/control/server
+go test -run '^$' -fuzz '^FuzzParseUserInfo$' -fuzztime=10s ./internal/subscription
+go test -count=1 -race ./...
+go vet ./...
+```
+
+- [ ] **Step 4: 检查 crash corpus**
+
+```console
+git status --short
+```
+
+Expected: 没有未经审核的 `testdata/fuzz` crash 文件或其他临时产物。
+
+- [ ] **Step 5: Commit（仅用户明确要求时）**
+
+```console
+git add .github/workflows/fuzz.yml
+git commit -s -m "ci: 增加有界 fuzz 工作流"
+```

--- a/docs/superpowers/plans/2026-08-12-test-governance-roadmap.md
+++ b/docs/superpowers/plans/2026-08-12-test-governance-roadmap.md
@@ -1,0 +1,61 @@
+# Mihari Test Governance Implementation Roadmap
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 分阶段补齐 Mihari 高风险测试盲区，并建立跨平台、覆盖率与 fuzz 的持续治理能力。
+
+**Architecture:** 路线按四个可独立交付的子计划执行。先保护稳定契约与 WebSocket，再覆盖 mutation 和平台生命周期；随后增加 CI 可观测性与相对基线门禁；最后引入 bounded fuzz。每个阶段都能独立通过现有默认测试，不依赖后续阶段。
+
+**Tech Stack:** Go 1.26.5、`testing`、`httptest`、`github.com/coder/websocket`、GitHub Actions、Go coverage profile、Go native fuzzing。
+
+## Global Constraints
+
+- 实施前必须获得用户对相应阶段的明确授权，并更新根 `AGENTS.md` 当前“不新增或修改测试代码、CI、Git hooks”的治理限制。
+- 不修改 `/v1` DTO、错误码、JSON envelope、CLI 退出码或持久化格式。
+- 不新增第三方测试、mock、覆盖率或 fuzz 依赖。
+- 默认测试不访问公网、真实订阅、真实用户目录、真实 mihomo 或系统服务。
+- 所有网络、文件、listener、goroutine 与子进程均由测试拥有并清理。
+- 行为变更使用 Red–Green–Refactor；覆盖既有行为时先记录目标函数的 0% 覆盖基线，不制造虚假失败断言。
+- 所有 Go 修改执行 `gofmt`；验证从目标包扩大到 `go test -race ./...`、`go vet ./...`。
+- 只在非 `main` 分支实施；仅在用户明确要求时创建 commit。
+
+---
+
+## Execution Order
+
+1. [阶段 A：控制协议与 WebSocket](2026-08-12-test-governance-phase-a-control-websocket.md)
+2. [阶段 B：Mutation 与平台生命周期](2026-08-12-test-governance-phase-b-mutation-platform.md)
+3. [阶段 C：CI 与覆盖率治理](2026-08-12-test-governance-phase-c-ci-coverage.md)
+4. [阶段 D：Bounded Fuzz](2026-08-12-test-governance-phase-d-fuzz.md)
+
+阶段 A、B 修改测试和少量可测试性边界；阶段 C 修改 CI 并新增无依赖覆盖率工具；阶段 D 新增 fuzz target 与独立 workflow。每个阶段单独审核、单独授权、单独交付。
+
+## Governance Gate
+
+- [ ] **Step 1: 获得阶段实施授权**
+
+记录用户明确批准的阶段，不把设计文档批准解释为代码或 CI 修改授权。
+
+- [ ] **Step 2: 更新根治理状态**
+
+修改 `AGENTS.md` 第 10 节，将绝对禁止测试/CI 修改改为与获批阶段一致的限定授权，同时保留“不迁移目录、不新增 Git hooks、不预设固定总覆盖率”的约束。
+
+- [ ] **Step 3: 检查独立分支与工作区**
+
+```console
+git branch --show-current
+git status --short
+```
+
+Expected: 当前分支不是 `main`，不存在会被本阶段覆盖的用户改动。
+
+- [ ] **Step 4: 建立干净基线**
+
+```console
+go test -count=1 ./...
+go test -count=1 -race ./...
+go vet ./...
+```
+
+Expected: 全部通过；若失败，停止实施并报告基线问题。
+

--- a/docs/superpowers/specs/2026-08-12-test-coverage-governance-design.md
+++ b/docs/superpowers/specs/2026-08-12-test-coverage-governance-design.md
@@ -1,0 +1,383 @@
+# Mihari 测试覆盖完善与治理设计
+
+日期：2026-08-12  
+状态：已批准；Phase A–D、计划内 CI、提交、推送与 PR 均已授权实施  
+目标分支：`docs/test-coverage-governance-design`
+
+## 1. 背景
+
+本设计基于 2026-08-12 对仓库当前测试状态的审计。审计在 Windows amd64、Go 1.26.5 环境中完成，实际执行了默认测试、原子覆盖率、跨包覆盖率、race detector 与 vet。
+
+当前基线如下：
+
+| 指标 | 基线 |
+|---|---:|
+| Go package | 46 |
+| 生产 Go 文件 | 190 |
+| 测试 Go 文件 | 149 |
+| 顶层 `TestXxx` | 778 |
+| 常规包内语句覆盖率 | 72.0% |
+| `-coverpkg=./...` 跨包语句覆盖率 | 74.6% |
+| 跨包口径零覆盖函数 | 159 |
+| 关键架构包零覆盖函数 | 54 |
+| fuzz target | 0 |
+| benchmark | 0 |
+
+以下验证通过：
+
+```console
+go test -count=1 -covermode=atomic -coverpkg=./... ./...
+go test -count=1 -race ./...
+go vet ./...
+```
+
+现有测试已经较好保护以下架构不变量：
+
+- 配置原子替换失败时保留上一份有效文件；
+- mutation coordinator 串行提交并拒绝陈旧 revision；
+- 下载期间删除订阅后，迟到结果不能重建已删除对象；
+- reload 失败时回滚订阅激活和运行时配置；
+- Web gateway 对未知写操作默认拒绝；
+- Web credential 与 mihomo controller secret 相互隔离；
+- supervisor 的崩溃退避、健康检查失败、显式重启和取消退出；
+- 本地控制协议的主要 DTO 与错误 envelope。
+
+主要缺口不是测试数量不足，而是稳定契约和高风险边界的覆盖不对称：订阅 `/v1` 只有部分端点被直接验证，WebSocket 成功代理链未覆盖，部分 app/runtime/panel mutation 只在单层测试中出现，平台生命周期测试偏弱，CI 也没有持续记录覆盖基线。
+
+## 2. 目标
+
+本设计建立一套风险优先、渐进收紧的测试治理体系：
+
+1. 补齐稳定 `/v1` 控制协议的端点、客户端和错误映射矩阵。
+2. 直接验证 WebSocket 认证、secret 注入、双向转发和关闭行为。
+3. 覆盖所有公开 mutation 的 coordinator、revision、operation ID、失败回滚和敏感信息清理语义。
+4. 在 Windows、Linux 和 macOS 原生运行与平台相关的测试，而不只做交叉编译。
+5. 让 CI 持续生成可比较的跨包覆盖报告，并阻止无理由退化。
+6. 对不可信输入边界增加 bounded fuzz，使解析器和解码器持续接受异常输入检验。
+7. 保留真实 mihomo、真实订阅、系统服务和权限场景为显式授权的 testenv 验证。
+
+完成后，测试结果应能回答“关键契约是否被验证、失败能否安全回滚、平台资源是否正确关闭”，而不仅是给出一个总覆盖率数字。
+
+用户已明确授权完整实施 Phase A–D、计划内 CI、必要的最小生产修复、提交、推送与 PR，并要求修复 Actions 直到全部必需检查通过。各阶段仍保持独立实现与评审切分。Git hooks、testenv、固定覆盖率门槛及计划外治理仍须单独授权；相对覆盖率门禁须等待设计规定的观察期数据。
+
+## 3. 非目标
+
+- 不以提升总覆盖率百分比为目的给简单 getter、生成代码或不可达平台分支堆叠低价值测试。
+- 第一阶段不设置武断的全仓固定百分比，也不要求每个包达到相同门槛。
+- 不修改 `/v1` DTO、错误码、JSON envelope、CLI 退出码或持久化格式。
+- 不为测试引入第三方 assertion、mock、覆盖率 SaaS 或 fuzz 框架；优先使用 Go 标准库和 GitHub Actions 原生能力。
+- 不在默认测试中访问公网、真实订阅、真实用户目录、真实 mihomo 或系统服务管理器。
+- 不借测试完善重构无关业务代码。只有无法建立确定性测试边界时，才允许引入最小注入点。
+- benchmark 不在本轮治理范围内；只有出现明确性能预算后再单独设计。
+
+## 4. 治理原则
+
+### 4.1 风险矩阵优先于总覆盖率
+
+总覆盖率用于发现趋势，不能替代关键行为断言。高风险路径即使所在包已超过 80%，只要没有直接验证，仍视为未完成。低风险包装函数即使为 0%，也不自动成为最高优先级。
+
+### 4.2 每个稳定契约需要双侧测试
+
+本地控制协议的每个公开端点至少包含：
+
+- server handler 测试：HTTP 方法、路径、认证、输入限制、DTO 和错误码；
+- typed client 测试：请求方法与路径、授权头、请求 JSON、成功响应和 API error 解码；
+- 对关键跨包行为再增加 IPC 集成测试，而不是给所有端点重复第三层测试。
+
+### 4.3 失败路径与成功路径同等重要
+
+涉及文件、网络、进程和 mutation 的测试必须同时考虑：
+
+- 准备阶段失败；
+- revision 在准备后变陈旧；
+- 提交或 reload 失败；
+- context 取消；
+- 部分成功后的资源清理；
+- 错误文本不泄露 token、secret 或完整订阅 URL。
+
+### 4.4 确定性优先
+
+并发测试使用 channel、fake clock、waiter 或明确事件同步，不依赖固定 `time.Sleep`。端口使用临时 listener，文件使用 `t.TempDir()`，HTTP 使用 `httptest.Server`，所有 goroutine、listener、response body 和子进程都由测试拥有并在 `t.Cleanup` 中回收。
+
+## 5. 测试层级与职责
+
+### 5.1 单元测试
+
+单元测试与实现放在同包相邻的 `*_test.go` 中，负责一个包内的输入、输出、错误分类和资源所有权。新增测试优先扩展现有 fake，而不是建立全仓 mock 框架。
+
+主要目标包：
+
+- `internal/control/server`
+- `internal/control/client`
+- `internal/runtime`
+- `internal/app`
+- `internal/web`
+- `internal/subscription`
+- `internal/supervisor`
+- `internal/platform`、`internal/service`、`internal/sysproxy`、`internal/elevate`
+
+### 5.2 开发集成测试
+
+`internal/integration` 只验证跨包外部可观察行为和架构不变量：IPC 生命周期、daemon 单写入者、完整 mutation 链、Web gateway 与 fake mihomo。它不重复每个 handler 的表驱动输入校验。
+
+集成测试覆盖到其他包的语句必须通过 `-coverpkg=./...` 计入治理报告。普通 `go test ./...` 的逐包百分比仍保留用于本地定位，但不作为仓库总覆盖率口径。
+
+### 5.3 testenv
+
+以下场景不进入默认测试：
+
+- 真实 mihomo 二进制与 controller；
+- 真实订阅 URL；
+- Windows SCM、systemd、launchd 的安装和卸载；
+- 真实系统代理、TUN 和权限提升；
+- 真实 GitHub Release 下载与自更新。
+
+未来 testenv 必须使用显式 build tag 或独立命令、隔离数据目录、测试凭据和可执行回滚步骤。没有用户授权时，Agent 和 CI 均不得运行。
+
+## 6. 风险覆盖矩阵
+
+### 6.1 P0：稳定控制协议
+
+第一批补齐订阅 `/v1` 的对称矩阵。
+
+| 能力 | Server | Client | IPC 集成 | 必须断言 |
+|---|---|---|---|---|
+| list | 补齐 | 已有/核对 | 不要求 | URL 不出现在响应中、revision 正确 |
+| show | 补齐 | 补齐 | 不要求 | not found 映射、secret-free DTO |
+| add | 已有 | 已有/核对 | 保留现有链路 | operation ID、proxy mode、URL 仅进入请求 |
+| refresh | 补齐 | 已有/核对 | 保留现有链路 | revision、运行时错误映射 |
+| use | 补齐 | 已有/核对 | 已有运行时集成 | reload 失败回滚 |
+| enable | 补齐 | 补齐 | 不要求 | 显式 `false`、stale revision |
+| update | 已有部分 | 补齐 | 不要求 | pointer 字段保留显式空值与 `false` |
+| remove | 补齐 | 补齐 | 增加一条跨 IPC 场景 | 删除后迟到 refresh 不得复活对象 |
+
+同一方法还应覆盖以下公共 handler 行为：错误或超大 JSON、未知字段、缺失 operation ID、错误认证、runtime capability 缺失，以及底层错误到稳定协议错误码的映射。
+
+### 6.2 P0：WebSocket gateway
+
+为 `internal/web.Server.proxyWebSocket` 增加真实的本地双向 WebSocket 测试：
+
+1. 启动 `httptest.Server` 作为 fake controller，并校验收到的 `Authorization: Bearer <controller-secret>`。
+2. 启动 Mihari Web gateway，浏览器侧只提交 Web credential，不得接触 controller secret。
+3. 浏览器发送文本或二进制帧，fake controller 回显，断言两个方向内容和消息类型保持一致。
+4. 上游主动关闭时，gateway 退出复制循环并关闭客户端连接。
+5. 客户端主动关闭或 context 取消时，上游连接和两个复制 goroutine 可回收。
+6. 上游握手返回 401/500 或无法连接时，gateway 返回安全错误，不反射 secret 和上游响应体。
+
+测试不得依赖公网、固定端口或固定 sleep。每条测试结束后检查 listener 和 handler goroutine 均已退出。
+
+### 6.3 P1：mutation 完整性
+
+本节所述 panel runtime/coordinator、revision、回滚与 mutation 语义属于阶段 B。阶段 A Task 2 仅提前补齐 panel typed client wrapper 的传输契约测试，范围限于方法、路径、认证、请求 JSON 和响应解码；这些 wrapper 测试不代表 runtime mutation 语义已经覆盖。
+
+为公开 mutation 建立统一清单，至少覆盖以下当前薄弱路径：
+
+- app：选择代理、关闭单个/全部连接、配置 patch；
+- runtime：panel update/uninstall/reinstall、subscription enable、连接关闭；
+- control client：panel update/activate/rollback/uninstall/reinstall 的 wrapper 契约在 Phase A 覆盖，runtime mutation 语义在 Phase B 覆盖；
+- web mutation：允许的写操作、拒绝的未知写操作和稳定错误响应。
+
+每项 mutation 按适用性验证：
+
+- operation ID 在同一 coordinator 中幂等；
+- `IfRevision` 在慢 IO 前后均不允许陈旧提交；
+- 下载、校验、解压等慢 IO 在提交锁外；
+- mutation 的唯一写入者是 daemon runtime；
+- reload/发布失败恢复上一份有效状态；
+- 返回的 revision 是提交后的 revision；
+- API、日志和测试错误不含敏感值。
+
+不要求所有 mutation 都做端到端测试。一个路径只有在跨越 IPC、coordinator、文件或 fake mihomo 三个以上边界时才进入 `internal/integration`。
+
+### 6.4 P1：平台与生命周期
+
+平台测试分为可注入逻辑和真实 OS 原生实现两类。
+
+可注入逻辑在所有平台运行：
+
+- service 状态与错误映射；
+- sysproxy owned/foreign/off 分类；
+- supervisor 启动、终止、kill fallback 和 wait；
+- endpoint/path 选择与权限意图；
+- context 取消后的资源清理。
+
+原生实现只在对应 runner 运行：
+
+- Windows named pipe、job object/child termination、WinINET 数据映射的非破坏性部分；
+- Linux Unix socket、路径和权限位、进程组终止；
+- macOS Unix socket、路径和 `networksetup` 命令构造。
+
+默认 CI 不安装服务、不修改系统代理。涉及系统状态的实现通过 command runner、registry/backend 或 filesystem 接口注入 fake，原生测试只验证不产生外部持久副作用的行为。
+
+### 6.5 P2：输入边界 fuzz
+
+第一批 fuzz target 限定为纯函数或完全内存边界：
+
+| Target | 种子来源 | 不变量 |
+|---|---|---|
+| 订阅 YAML/节点解析 | 现有有效与无效 fixture | 不 panic；多文档、异常 tag 和超深结构安全失败 |
+| panel archive entry/path 校验 | 正常路径、绝对路径、`..`、链接名称 | 不允许目录穿越、绝对路径或链接逃逸 |
+| control JSON request 解码 | 现有 DTO JSON、未知字段、重复字段、超长 token | 不 panic；遵守大小上限与 unknown-field 策略 |
+| subscription-userinfo 解析 | 正常 header、溢出、负值、乱码 | 不 panic；非法值不产生错误配额 |
+
+fuzz 输入全部为合成数据，不包含真实 URL、凭据或用户文件。默认 `go test ./...` 只运行 seed corpus；持续 fuzz 放在定时或手动 workflow，每个 target 使用明确时间预算。
+
+## 7. CI 设计
+
+### 7.1 PR 必需门禁
+
+保留现有 lint 和六目标 CGO-free cross-build，并把测试拆为以下职责：
+
+| Job | Runner | 命令 | 目的 |
+|---|---|---|---|
+| unit-windows | `windows-latest` | `go test -count=1 ./...` | Windows 原生行为与 named pipe |
+| unit-linux | `ubuntu-latest` | `go test -count=1 ./...` | Linux 原生行为与 Unix socket |
+| unit-macos | `macos-latest` | `go test -count=1 ./...` | macOS 原生行为与 Unix socket |
+| race | `windows-latest` | `go test -count=1 -race ./...` | 并发与生命周期，并保持与当前 CI 基线一致 |
+| vet-format | 现有 runner | `go vet ./...`、`gofmt -l .` | 静态与格式检查 |
+| coverage | `ubuntu-latest` | 跨包 atomic coverage | 可比较的仓库总口径 |
+
+原生测试矩阵与 cross-build 的职责不同：前者执行对应 build tag 的测试，后者证明 `CGO_ENABLED=0` 的六种发布构建仍成立。
+
+### 7.2 覆盖率采集
+
+coverage job 使用 Linux/bash，避免不同 PowerShell 原生参数解析影响报告路径：
+
+```console
+go test -count=1 -covermode=atomic -coverpkg=./... \
+  -coverprofile="$RUNNER_TEMP/mihari-coverage.out" ./...
+go tool cover -func="$RUNNER_TEMP/mihari-coverage.out"
+```
+
+CI 将 profile 和逐函数文本报告保存为短期 artifact，并把总覆盖率写入 job summary。覆盖文件不写入仓库，也不提交。
+
+### 7.3 渐进门禁
+
+门禁分三步启用：
+
+1. **观察期**：连续至少 10 个成功的 `main` workflow 只采集报告，不因百分比失败，用于确认波动范围。
+2. **防退化期**：PR 同时计算 merge base 与 HEAD 的相同口径覆盖率。总覆盖率下降超过 0.5 个百分点时失败；关键包下降超过 1.0 个百分点时失败。阈值吸收生成代码、平台 build tag 和小规模结构调整的正常波动。
+3. **收紧期**：当关键矩阵全部完成后，才讨论是否为关键包设置最低值。任何固定阈值都必须基于至少 30 次 `main` 数据另行审核，不能在本设计实施时直接写死。
+
+关键包集合固定为：
+
+```text
+internal/config
+internal/control/client
+internal/control/protocol
+internal/control/server
+internal/daemon
+internal/runtime
+internal/state
+internal/subscription
+internal/supervisor
+internal/web
+```
+
+覆盖率下降不自动等同于缺陷。若语义等价重构导致下降但风险矩阵未退化，PR 可以通过显式说明和审查更新基线；不得用空断言测试恢复数字。
+
+### 7.4 Fuzz workflow
+
+fuzz 不进入每个 PR 的必需门禁。新增 nightly 和 `workflow_dispatch` 任务：
+
+- 每个 target 独立执行，初始预算 60 秒；
+- 设置 job timeout，防止 runner 无界占用；
+- 失败时上传最小化输入和测试日志；
+- crash corpus 经确认不含敏感数据后才能提交；
+- fuzz 失败按测试失败处理，不自动修改 corpus 或生产代码。
+
+## 8. 实施阶段
+
+### 阶段 A：P0 契约与 WebSocket
+
+交付订阅 server/client 对称矩阵、仅限传输层的 panel typed client wrapper 契约，以及 WebSocket 成功/失败/关闭测试。panel runtime 的 coordinator、revision、回滚和 mutation 语义留在阶段 B；该阶段不修改 CI 门槛，避免基础缺口与治理工具同时变化。
+
+验收：目标 P0 行为全部有直接断言；相关包、集成测试、全仓 race 与 vet 通过。
+
+### 阶段 B：P1 mutation 与平台生命周期
+
+按包逐项补齐 mutation 风险清单，并增加 Windows/Linux/macOS 原生 unit job。必要的注入点与对应测试放在同一小提交中，不先建立通用 mock 层。
+
+验收：所有公开 mutation 都能在清单中映射到测试；三平台原生默认测试通过；默认测试不产生系统持久副作用。
+
+### 阶段 C：覆盖可观测性与防退化
+
+增加 coverage job、artifact 和 summary，完成观察期后再启用相对基线比较。观察期数据与阈值启用应分别提交，便于独立回滚。
+
+验收：PR 能看到跨包总覆盖和关键包变化；允许范围外的下降会阻断 CI；仓库内没有 coverage 临时产物。
+
+### 阶段 D：P2 fuzz
+
+每次只引入一个 fuzz target，先以固定 seed 回归测试证明目标不变量，再加入 bounded nightly fuzz。fuzz 发现的缺陷必须先固化为最小回归输入，再修复实现。
+
+验收：四类目标均能在默认测试中运行 seed corpus，在定时 workflow 中按预算完成；失败输入可复现且不含敏感数据。
+
+### 阶段 E：testenv 设计
+
+真实环境验证是独立后续设计，不与 A–D 混合实施。该阶段需要用户明确授权测试平台、凭据、服务状态变更和回滚方案。
+
+## 9. 提交与评审切分
+
+测试完善按可独立审查的意图拆分，不创建“全仓补覆盖”巨型提交。建议顺序：
+
+1. `test(control): 补齐订阅服务端契约矩阵`
+2. `test(control): 补齐订阅与面板客户端契约`
+3. `test(web): 覆盖 WebSocket 双向代理生命周期`
+4. `test(runtime): 补齐 mutation 回滚与 revision 路径`
+5. `test(platform): 补齐平台生命周期边界`
+6. `ci: 增加三平台原生测试矩阵`
+7. `ci: 记录跨包覆盖率基线`
+8. `ci: 启用覆盖率防退化门禁`
+9. 按 target 分开的 `test(fuzz): ...`
+
+每个行为变更遵循 Red–Green–Refactor。纯 CI 报告或文档变更不要求先制造失败测试，但必须在分支上验证 workflow 语法和本地等价命令。
+
+## 10. 风险与缓解
+
+### 10.1 CI 时间增长
+
+三平台测试、race、双份覆盖比较会增加 runner 时间。先并行运行三平台 unit；coverage merge-base 比较只在 PR 执行；fuzz 放到 nightly。若耗时仍不可接受，应基于 job 数据调整，而不是删除平台覆盖。
+
+### 10.2 平台测试不稳定
+
+端口、进程和 socket 测试最容易产生时序波动。测试必须依靠事件同步、临时资源与有界 context。出现 flaky test 时先定位所有权和退出条件，禁止简单增加 sleep 或无条件 retry。
+
+### 10.3 覆盖率指标被游戏化
+
+风险矩阵是完成条件，覆盖率只是退化告警。评审拒绝无断言测试、只调用 getter 的测试和为了数字排除生产文件的做法。
+
+### 10.4 `-coverpkg=./...` 与平台 build tag 差异
+
+仓库总口径固定在 Linux coverage job，保证 PR 间可比。Windows/macOS 的覆盖率只用于诊断，不与 Linux 百分比混合。平台关键行为由原生测试矩阵和显式风险清单保护。
+
+### 10.5 测试为了可注入性扩大生产接口
+
+接口定义在使用方附近并保持最小。优先注入函数或现有小接口；只有真实 OS/IO 边界需要替换时才新增接口，不创建通用 `utils` 或全局 service locator。
+
+## 11. 完成定义
+
+本治理路线完成需要同时满足：
+
+- P0/P1 风险矩阵中的每一项都能指向具体测试名称；
+- 订阅 `/v1` server/client 契约对称，错误映射与敏感字段规则有直接断言；
+- WebSocket 成功代理、认证、secret 注入、上下游关闭和 context 取消均有确定性测试；
+- 公开 mutation 的 coordinator、revision、幂等和回滚语义按适用性覆盖；
+- Windows、Linux、macOS 原生默认测试进入 CI，六目标 CGO-free 构建保持通过；
+- CI 生成统一跨包覆盖报告，并在观察期后阻止超出容差的无说明退化；
+- 四类 fuzz target 具备 seed corpus 和有界定时执行；
+- `go test ./...` 不访问公网、不使用真实用户目录、不依赖真实 mihomo 或系统服务；
+- `go test -race ./...`、`go vet ./...` 与 `gofmt -l .` 通过；
+- 没有提交 coverage profile、测试二进制、fuzz 临时产物或敏感输入。
+
+总覆盖率不是单独的完成条件。完成定义以稳定契约、事务回滚、安全边界、平台生命周期和持续防退化能力为准。
+
+## 12. 已选方案与否决方案
+
+采用“风险优先 + 渐进门禁”：先补高风险盲区，再建立跨平台和覆盖率治理，最后引入 bounded fuzz。
+
+未采用：
+
+1. **立即设置统一全仓最低覆盖率**：不能反映包风险差异，容易诱导低价值测试，也与仓库当前渐进门槛原则冲突。
+2. **只补当前 0% 函数**：函数覆盖不等于行为覆盖，且会把平台包装器、简单 getter 与稳定协议端点错误地视为同一优先级。
+3. **只做审计发现的短期缺口**：不能阻止后续退化，也不能解决当前只有 Windows 原生测试和没有 fuzz 的治理空白。
+4. **默认测试连接真实环境**：破坏隔离性、可重复性和安全边界，且违反仓库 testenv 授权规则。

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -243,9 +243,17 @@ func BuildRuntimeWithOptions(paths platform.Paths, settings config.Settings, dae
 	return &RuntimeAssembly{Manager: manager, Store: store, Web: webGateway}, nil
 }
 
+type webMutationRuntime interface {
+	SelectProxy(context.Context, runtimeapi.Operation, string, string) error
+	CloseConnection(context.Context, runtimeapi.Operation, string) error
+	CloseAllConnections(context.Context, runtimeapi.Operation) error
+	EnableTun(context.Context, runtimeapi.Operation) (protocol.TunStatus, error)
+	DisableTun(context.Context, runtimeapi.Operation) (protocol.TunStatus, error)
+}
+
 // webMutator routes browser mutations through the daemon coordinator.
 type webMutator struct {
-	manager *runtimeapi.Manager
+	manager webMutationRuntime
 }
 
 func (m webMutator) SelectProxy(ctx context.Context, group, name string) error {

--- a/internal/app/runtime_test.go
+++ b/internal/app/runtime_test.go
@@ -13,7 +13,141 @@ import (
 	"github.com/mihari-proxy/mihari/internal/config"
 	"github.com/mihari-proxy/mihari/internal/control/protocol"
 	"github.com/mihari-proxy/mihari/internal/platform"
+	runtimeapi "github.com/mihari-proxy/mihari/internal/runtime"
 )
+
+type webProxySelectionCall struct {
+	operation runtimeapi.Operation
+	group     string
+	name      string
+}
+
+type webConnectionCloseCall struct {
+	operation runtimeapi.Operation
+	id        string
+}
+
+type recordingWebMutationRuntime struct {
+	selectCalls        []webProxySelectionCall
+	closeCalls         []webConnectionCloseCall
+	closeAllOperations []runtimeapi.Operation
+	enableOperations   []runtimeapi.Operation
+	disableOperations  []runtimeapi.Operation
+}
+
+func (r *recordingWebMutationRuntime) SelectProxy(_ context.Context, operation runtimeapi.Operation, group, name string) error {
+	r.selectCalls = append(r.selectCalls, webProxySelectionCall{operation: operation, group: group, name: name})
+	return nil
+}
+
+func (r *recordingWebMutationRuntime) CloseConnection(_ context.Context, operation runtimeapi.Operation, id string) error {
+	r.closeCalls = append(r.closeCalls, webConnectionCloseCall{operation: operation, id: id})
+	return nil
+}
+
+func (r *recordingWebMutationRuntime) CloseAllConnections(_ context.Context, operation runtimeapi.Operation) error {
+	r.closeAllOperations = append(r.closeAllOperations, operation)
+	return nil
+}
+
+func (r *recordingWebMutationRuntime) EnableTun(_ context.Context, operation runtimeapi.Operation) (protocol.TunStatus, error) {
+	r.enableOperations = append(r.enableOperations, operation)
+	return protocol.TunStatus{}, nil
+}
+
+func (r *recordingWebMutationRuntime) DisableTun(_ context.Context, operation runtimeapi.Operation) (protocol.TunStatus, error) {
+	r.disableOperations = append(r.disableOperations, operation)
+	return protocol.TunStatus{}, nil
+}
+
+func TestWebMutatorRoutesOperationsThroughRuntime(t *testing.T) {
+	runtime := &recordingWebMutationRuntime{}
+	mutator := webMutator{manager: runtime}
+	ctx := context.Background()
+
+	if err := mutator.SelectProxy(ctx, "Proxy Group", "selected-proxy"); err != nil {
+		t.Fatal(err)
+	}
+	if err := mutator.CloseConnection(ctx, "connection-id"); err != nil {
+		t.Fatal(err)
+	}
+	if err := mutator.CloseAllConnections(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(runtime.selectCalls) != 1 {
+		t.Fatalf("select calls=%d", len(runtime.selectCalls))
+	}
+	selectCall := runtime.selectCalls[0]
+	if selectCall.group != "Proxy Group" || selectCall.name != "selected-proxy" {
+		t.Fatalf("select call=%#v", selectCall)
+	}
+	assertWebOperation(t, selectCall.operation, "web-select-")
+
+	if len(runtime.closeCalls) != 1 {
+		t.Fatalf("close calls=%d", len(runtime.closeCalls))
+	}
+	closeCall := runtime.closeCalls[0]
+	if closeCall.id != "connection-id" {
+		t.Fatalf("close call=%#v", closeCall)
+	}
+	assertWebOperation(t, closeCall.operation, "web-close-")
+
+	if len(runtime.closeAllOperations) != 1 {
+		t.Fatalf("close all calls=%d", len(runtime.closeAllOperations))
+	}
+	assertWebOperation(t, runtime.closeAllOperations[0], "web-close-all-")
+}
+
+func TestWebMutatorConfigPatchAllowlist(t *testing.T) {
+	runtime := &recordingWebMutationRuntime{}
+	mutator := webMutator{manager: runtime}
+	ctx := context.Background()
+
+	if err := mutator.ApplyConfigPatch(ctx, map[string]any{"tun": map[string]any{"enable": true}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := mutator.ApplyConfigPatch(ctx, map[string]any{"tun": map[string]any{"enable": false}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(runtime.enableOperations) != 1 {
+		t.Fatalf("enable calls=%d", len(runtime.enableOperations))
+	}
+	assertWebOperation(t, runtime.enableOperations[0], "web-tun-")
+	if len(runtime.disableOperations) != 1 {
+		t.Fatalf("disable calls=%d", len(runtime.disableOperations))
+	}
+	assertWebOperation(t, runtime.disableOperations[0], "web-tun-")
+
+	for _, test := range []struct {
+		name  string
+		patch map[string]any
+		code  protocol.ErrorCode
+	}{
+		{name: "missing tun", patch: map[string]any{}, code: protocol.CodeUnsupportedMutation},
+		{name: "non object tun", patch: map[string]any{"tun": "enabled"}, code: protocol.CodeInvalidArgument},
+		{name: "non boolean enable", patch: map[string]any{"tun": map[string]any{"enable": "true"}}, code: protocol.CodeInvalidArgument},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := mutator.ApplyConfigPatch(ctx, test.patch)
+			var apiError protocol.APIError
+			if !errors.As(err, &apiError) || apiError.Code != test.code {
+				t.Fatalf("err=%v, code=%q", err, apiError.Code)
+			}
+		})
+	}
+}
+
+func assertWebOperation(t *testing.T, operation runtimeapi.Operation, prefix string) {
+	t.Helper()
+	if operation.Source != "web" {
+		t.Fatalf("operation source=%q", operation.Source)
+	}
+	if operation.ID == "" || !strings.HasPrefix(operation.ID, prefix) {
+		t.Fatalf("operation ID=%q, prefix=%q", operation.ID, prefix)
+	}
+}
 
 func TestBuildRuntimeCreatesBootstrapAndSharedState(t *testing.T) {
 	paths := platform.NewPaths(filepath.Join(t.TempDir(), "data"))

--- a/internal/control/client/runtime_test.go
+++ b/internal/control/client/runtime_test.go
@@ -3,9 +3,12 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -123,8 +126,18 @@ func TestRuntimeClientFiniteEndpoints(t *testing.T) {
 				_, err := client.UpdateOnboarding(ctx, protocol.OnboardingUpdateRequest{OperationID: "setup-1", IfRevision: &revision, Complete: &complete, WebAddr: &webAddr})
 				return err
 			}},
-		{"subscriptions", http.MethodGet, "/v1/subscriptions", "", `{"schema":"mihari/v1","revision":1,"global_interval":"12h","subscriptions":[]}`,
-			func(ctx context.Context, client *Client) error { _, err := client.Subscriptions(ctx); return err }},
+		{"subscriptions", http.MethodGet, "/v1/subscriptions", "", `{"schema":"mihari/v1","revision":11,"active_id":"listed-one","global_interval":"9h","subscriptions":[{"id":"listed-one","name":"listed","enabled":true,"auto_refresh":false,"interval":"3h","cached":true,"generation":4,"proxy_mode":"auto"}]}`,
+			func(ctx context.Context, client *Client) error {
+				result, err := client.Subscriptions(ctx)
+				if err != nil {
+					return err
+				}
+				wantSubscription := protocol.Subscription{ID: "listed-one", Name: "listed", Enabled: true, AutoRefresh: false, Interval: "3h", Cached: true, Generation: 4, ProxyMode: "auto"}
+				if result.Schema != "mihari/v1" || result.Revision != 11 || result.ActiveID != "listed-one" || result.GlobalInterval != "9h" || len(result.Subscriptions) != 1 || result.Subscriptions[0] != wantSubscription {
+					return fmt.Errorf("subscription list=%#v", result)
+				}
+				return nil
+			}},
 		{"TUI preferences", http.MethodGet, "/v1/preferences/tui", "", `{"schema":"mihari/v1","revision":1,"connections_columns":["host","chain"]}`,
 			func(ctx context.Context, client *Client) error { _, err := client.TUIPreferences(ctx); return err }},
 		{"update TUI preferences", http.MethodPatch, "/v1/preferences/tui", `{"operation_id":"columns-1","if_revision":1,"connections_columns":["source","traffic"]}`, `{"schema":"mihari/v1","revision":2,"connections_columns":["source","traffic"]}`,
@@ -135,28 +148,114 @@ func TestRuntimeClientFiniteEndpoints(t *testing.T) {
 				})
 				return err
 			}},
-		{"subscription add", http.MethodPost, "/v1/subscriptions", `{"operation_id":"op","name":"main","url":"https://example.test/sub"}`, `{"schema":"mihari/v1","revision":2,"subscription":{"id":"one","name":"main","enabled":true,"auto_refresh":true,"interval":"","cached":false,"generation":0}}`,
+		{"subscription add", http.MethodPost, "/v1/subscriptions", `{"operation_id":"add-1","if_revision":11,"name":"added","url":"https://example.test/sub","proxy_mode":"proxy"}`, `{"schema":"mihari/v1","operation_id":"add-1","revision":12,"subscription":{"id":"added-one","name":"added","enabled":true,"auto_refresh":true,"interval":"6h","cached":false,"generation":0,"proxy_mode":"proxy"}}`,
 			func(ctx context.Context, client *Client) error {
-				_, err := client.AddSubscription(ctx, protocol.SubscriptionAddRequest{OperationID: "op", Name: "main", URL: "https://example.test/sub"})
-				return err
+				revision := uint64(11)
+				result, err := client.AddSubscription(ctx, protocol.SubscriptionAddRequest{OperationID: "add-1", IfRevision: &revision, Name: "added", URL: "https://example.test/sub", ProxyMode: "proxy"})
+				if err != nil {
+					return err
+				}
+				return assertSubscriptionResult(result, protocol.SubscriptionResult{
+					Schema: "mihari/v1", OperationID: "add-1", Revision: 12,
+					Subscription: protocol.Subscription{ID: "added-one", Name: "added", Enabled: true, AutoRefresh: true, Interval: "6h", Cached: false, Generation: 0, ProxyMode: "proxy"},
+				})
 			}},
-		{"subscription refresh", http.MethodPost, "/v1/subscriptions/id%2Fone/refresh", `{"operation_id":"op"}`, `{"schema":"mihari/v1","revision":2,"subscription":{"id":"one","name":"main","enabled":true,"auto_refresh":true,"interval":"","cached":true,"generation":1}}`,
+		{"subscription refresh", http.MethodPost, "/v1/subscriptions/id%2Fone/refresh", `{"operation_id":"refresh-1","if_revision":12}`, `{"schema":"mihari/v1","operation_id":"refresh-1","revision":13,"subscription":{"id":"id/one","name":"refreshed","enabled":true,"auto_refresh":true,"interval":"2h","cached":true,"generation":8,"proxy_mode":"auto"}}`,
 			func(ctx context.Context, client *Client) error {
-				_, err := client.RefreshSubscription(ctx, "id/one", protocol.MutationRequest{OperationID: "op"})
-				return err
+				revision := uint64(12)
+				result, err := client.RefreshSubscription(ctx, "id/one", protocol.MutationRequest{OperationID: "refresh-1", IfRevision: &revision})
+				if err != nil {
+					return err
+				}
+				return assertSubscriptionResult(result, protocol.SubscriptionResult{
+					Schema: "mihari/v1", OperationID: "refresh-1", Revision: 13,
+					Subscription: protocol.Subscription{ID: "id/one", Name: "refreshed", Enabled: true, AutoRefresh: true, Interval: "2h", Cached: true, Generation: 8, ProxyMode: "auto"},
+				})
+			}},
+		{"subscription show", http.MethodGet, "/v1/subscriptions/id%2Fone", "", `{"schema":"mihari/v1","revision":14,"subscription":{"id":"id/one","name":"shown","enabled":true,"auto_refresh":false,"interval":"1h","cached":true,"generation":5}}`,
+			func(ctx context.Context, client *Client) error {
+				result, err := client.Subscription(ctx, "id/one")
+				if err != nil {
+					return err
+				}
+				return assertSubscriptionResult(result, protocol.SubscriptionResult{
+					Schema: "mihari/v1", Revision: 14,
+					Subscription: protocol.Subscription{ID: "id/one", Name: "shown", Enabled: true, AutoRefresh: false, Interval: "1h", Cached: true, Generation: 5},
+				})
+			}},
+		{"subscription use", http.MethodPut, "/v1/subscriptions/id%2Fone/active", `{"operation_id":"use-1","if_revision":14}`, `{"schema":"mihari/v1","operation_id":"use-1","revision":15,"subscription":{"id":"id/one","name":"active","enabled":true,"auto_refresh":true,"interval":"4h","cached":true,"generation":6}}`,
+			func(ctx context.Context, client *Client) error {
+				revision := uint64(14)
+				result, err := client.UseSubscription(ctx, "id/one", protocol.MutationRequest{OperationID: "use-1", IfRevision: &revision})
+				if err != nil {
+					return err
+				}
+				return assertSubscriptionResult(result, protocol.SubscriptionResult{
+					Schema: "mihari/v1", OperationID: "use-1", Revision: 15,
+					Subscription: protocol.Subscription{ID: "id/one", Name: "active", Enabled: true, AutoRefresh: true, Interval: "4h", Cached: true, Generation: 6},
+				})
+			}},
+		{"subscription enable", http.MethodPut, "/v1/subscriptions/id%2Fone/enabled", `{"operation_id":"enable-1","if_revision":15,"enabled":false}`, `{"schema":"mihari/v1","operation_id":"enable-1","revision":16,"subscription":{"id":"id/one","name":"disabled","enabled":false,"auto_refresh":false,"interval":"5h","cached":true,"generation":6}}`,
+			func(ctx context.Context, client *Client) error {
+				revision := uint64(15)
+				result, err := client.SetSubscriptionEnabled(ctx, "id/one", protocol.SubscriptionEnabledRequest{OperationID: "enable-1", IfRevision: &revision, Enabled: false})
+				if err != nil {
+					return err
+				}
+				return assertSubscriptionResult(result, protocol.SubscriptionResult{
+					Schema: "mihari/v1", OperationID: "enable-1", Revision: 16,
+					Subscription: protocol.Subscription{ID: "id/one", Name: "disabled", Enabled: false, AutoRefresh: false, Interval: "5h", Cached: true, Generation: 6},
+				})
+			}},
+		{"subscription update", http.MethodPatch, "/v1/subscriptions/id%2Fone", `{"operation_id":"update-1","if_revision":16,"interval":"","auto_refresh":false}`, `{"schema":"mihari/v1","operation_id":"update-1","revision":17,"subscription":{"id":"id/one","name":"updated","enabled":true,"auto_refresh":false,"interval":"","cached":true,"generation":7,"proxy_mode":"proxy"}}`,
+			func(ctx context.Context, client *Client) error {
+				revision := uint64(16)
+				interval := ""
+				autoRefresh := false
+				result, err := client.UpdateSubscription(ctx, "id/one", protocol.SubscriptionUpdateRequest{
+					OperationID: "update-1", IfRevision: &revision, Interval: &interval, AutoRefresh: &autoRefresh,
+				})
+				if err != nil {
+					return err
+				}
+				return assertSubscriptionResult(result, protocol.SubscriptionResult{
+					Schema: "mihari/v1", OperationID: "update-1", Revision: 17,
+					Subscription: protocol.Subscription{ID: "id/one", Name: "updated", Enabled: true, AutoRefresh: false, Interval: "", Cached: true, Generation: 7, ProxyMode: "proxy"},
+				})
+			}},
+		{"subscription remove", http.MethodDelete, "/v1/subscriptions/id%2Fone", `{"operation_id":"remove-1","if_revision":17}`, `{"schema":"mihari/v1","operation_id":"remove-1","revision":18}`,
+			func(ctx context.Context, client *Client) error {
+				revision := uint64(17)
+				result, err := client.RemoveSubscription(ctx, "id/one", protocol.MutationRequest{OperationID: "remove-1", IfRevision: &revision})
+				if err != nil {
+					return err
+				}
+				if result.Schema != "mihari/v1" || result.OperationID != "remove-1" || result.Revision != 18 {
+					return fmt.Errorf("remove result=%#v", result)
+				}
+				return nil
 			}},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			var requestCount atomic.Int32
 			server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+				requestCount.Add(1)
 				if request.Method != test.method || request.URL.EscapedPath() != test.path || request.Header.Get("Authorization") != "Bearer token" {
 					t.Errorf("request=%s %s auth=%q", request.Method, request.URL.EscapedPath(), request.Header.Get("Authorization"))
 				}
-				if test.body != "" {
-					raw, _ := io.ReadAll(request.Body)
+				raw, readErr := io.ReadAll(request.Body)
+				if readErr != nil {
+					t.Errorf("read request body: %v", readErr)
+				} else if test.body != "" {
+					if request.Header.Get("Content-Type") != "application/json" {
+						t.Errorf("content type=%q", request.Header.Get("Content-Type"))
+					}
 					if !sameJSON(raw, []byte(test.body)) {
 						t.Errorf("body=%s want=%s", raw, test.body)
 					}
+				} else if len(raw) != 0 {
+					t.Errorf("unexpected body=%s", raw)
 				}
 				_, _ = io.WriteString(response, test.response)
 			}))
@@ -164,7 +263,54 @@ func TestRuntimeClientFiniteEndpoints(t *testing.T) {
 			if err := test.invoke(context.Background(), NewHTTP(server.URL, "token", server.Client())); err != nil {
 				t.Fatal(err)
 			}
+			if got := requestCount.Load(); got != 1 {
+				t.Fatalf("request count=%d, want 1", got)
+			}
 		})
+	}
+}
+
+func assertSubscriptionResult(result, want protocol.SubscriptionResult) error {
+	if result != want {
+		return fmt.Errorf("subscription result=%#v want=%#v", result, want)
+	}
+	return nil
+}
+
+func TestClientSetSubscriptionEnabledDecodesRevisionConflict(t *testing.T) {
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requestCount.Add(1)
+		if request.Method != http.MethodPut || request.URL.EscapedPath() != "/v1/subscriptions/id%2Fone/enabled" || request.Header.Get("Authorization") != "Bearer token" {
+			t.Errorf("request=%s %s auth=%q", request.Method, request.URL.EscapedPath(), request.Header.Get("Authorization"))
+		}
+		raw, readErr := io.ReadAll(request.Body)
+		if readErr != nil || !sameJSON(raw, []byte(`{"operation_id":"enable-stale","if_revision":7,"enabled":false}`)) {
+			t.Errorf("body=%s err=%v", raw, readErr)
+		}
+		response.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(response).Encode(protocol.NewError(protocol.CodeRevisionConflict, "subscription revision changed", map[string]any{
+			"expected_revision": 7,
+			"actual_revision":   8,
+		}))
+	}))
+	defer server.Close()
+
+	revision := uint64(7)
+	_, err := NewHTTP(server.URL, "token", server.Client()).SetSubscriptionEnabled(context.Background(), "id/one", protocol.SubscriptionEnabledRequest{
+		OperationID: "enable-stale",
+		IfRevision:  &revision,
+		Enabled:     false,
+	})
+	var apiErr protocol.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected APIError, got %T: %v", err, err)
+	}
+	if apiErr.Code != protocol.CodeRevisionConflict || apiErr.Details["expected_revision"] != float64(7) || apiErr.Details["actual_revision"] != float64(8) {
+		t.Fatalf("api error=%#v", apiErr)
+	}
+	if got := requestCount.Load(); got != 1 {
+		t.Fatalf("request count=%d, want 1", got)
 	}
 }
 

--- a/internal/control/client/webgui_test.go
+++ b/internal/control/client/webgui_test.go
@@ -74,6 +74,104 @@ func TestClientWebGUIRoundTrip(t *testing.T) {
 	}
 }
 
+func TestClientPanelMutationContracts(t *testing.T) {
+	revision := uint64(5)
+	tests := []struct {
+		name        string
+		method      string
+		path        string
+		body        string
+		operationID string
+		invoke      func(context.Context, *Client) (protocol.MutationResult, error)
+	}{
+		{
+			name:        "install",
+			method:      http.MethodPost,
+			path:        "/v1/panels/id%2Fone/install",
+			body:        `{"operation_id":"install-1","if_revision":5,"build":"v1.2.3"}`,
+			operationID: "install-1",
+			invoke: func(ctx context.Context, client *Client) (protocol.MutationResult, error) {
+				return client.InstallPanel(ctx, "id/one", protocol.PanelInstallRequest{OperationID: "install-1", IfRevision: &revision, Build: "v1.2.3"})
+			},
+		},
+		{
+			name:        "update",
+			method:      http.MethodPost,
+			path:        "/v1/panels/id%2Fone/update",
+			body:        `{"operation_id":"update-1","if_revision":5}`,
+			operationID: "update-1",
+			invoke: func(ctx context.Context, client *Client) (protocol.MutationResult, error) {
+				return client.UpdatePanel(ctx, "id/one", protocol.MutationRequest{OperationID: "update-1", IfRevision: &revision})
+			},
+		},
+		{
+			name:        "activate",
+			method:      http.MethodPut,
+			path:        "/v1/panels/id%2Fone/active",
+			body:        `{"operation_id":"activate-1","if_revision":5}`,
+			operationID: "activate-1",
+			invoke: func(ctx context.Context, client *Client) (protocol.MutationResult, error) {
+				return client.ActivatePanel(ctx, "id/one", protocol.MutationRequest{OperationID: "activate-1", IfRevision: &revision})
+			},
+		},
+		{
+			name:        "rollback",
+			method:      http.MethodPost,
+			path:        "/v1/panels/id%2Fone/rollback",
+			body:        `{"operation_id":"rollback-1","if_revision":5}`,
+			operationID: "rollback-1",
+			invoke: func(ctx context.Context, client *Client) (protocol.MutationResult, error) {
+				return client.RollbackPanel(ctx, "id/one", protocol.MutationRequest{OperationID: "rollback-1", IfRevision: &revision})
+			},
+		},
+		{
+			name:        "uninstall",
+			method:      http.MethodPost,
+			path:        "/v1/panels/id%2Fone/uninstall",
+			body:        `{"operation_id":"uninstall-1","if_revision":5}`,
+			operationID: "uninstall-1",
+			invoke: func(ctx context.Context, client *Client) (protocol.MutationResult, error) {
+				return client.UninstallPanel(ctx, "id/one", protocol.MutationRequest{OperationID: "uninstall-1", IfRevision: &revision})
+			},
+		},
+		{
+			name:        "reinstall",
+			method:      http.MethodPost,
+			path:        "/v1/panels/id%2Fone/reinstall",
+			body:        `{"operation_id":"reinstall-1","if_revision":5}`,
+			operationID: "reinstall-1",
+			invoke: func(ctx context.Context, client *Client) (protocol.MutationResult, error) {
+				return client.ReinstallPanel(ctx, "id/one", protocol.MutationRequest{OperationID: "reinstall-1", IfRevision: &revision})
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+				if request.Method != test.method || request.URL.EscapedPath() != test.path || request.Header.Get("Authorization") != "Bearer tok" {
+					t.Errorf("request=%s %s auth=%q", request.Method, request.URL.EscapedPath(), request.Header.Get("Authorization"))
+				}
+				var body any
+				if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+					t.Errorf("decode request body: %v", err)
+					return
+				}
+				if raw, err := json.Marshal(body); err != nil || !sameJSON(raw, []byte(test.body)) {
+					t.Errorf("body=%s want=%s", raw, test.body)
+				}
+				_ = json.NewEncoder(response).Encode(protocol.MutationResult{Schema: "mihari/v1", OperationID: test.operationID, Revision: 6})
+			}))
+
+			result, err := test.invoke(context.Background(), NewHTTP(server.URL, "tok", server.Client()))
+			server.Close()
+			if err != nil || result.Schema != "mihari/v1" || result.OperationID != test.operationID || result.Revision != 6 {
+				t.Fatalf("result=%#v err=%v", result, err)
+			}
+		})
+	}
+}
+
 func TestClientWebGUIOpenRequiresAuth(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)

--- a/internal/control/server/runtime_test.go
+++ b/internal/control/server/runtime_test.go
@@ -619,3 +619,46 @@ func TestInstallCoreThreadsRequestSource(t *testing.T) {
 		})
 	}
 }
+
+func FuzzDecodeControlJSON(f *testing.F) {
+	seeds := [][]byte{
+		[]byte(`{"operation_id":"op-1"}`),
+		[]byte(`{"operation_id":"op-2","if_revision":3,"source":"control"}`),
+		[]byte(`{"operation_id":"op","name":"sub","url":"https://example.invalid/x"}`),
+		[]byte(`{"operation_id":"op","unknown":true}`),
+		[]byte(`{"operation_id":"op"}{"extra":1}`),
+		[]byte(`{"operation_id":"op",`),
+		[]byte("\xff\xfe\x00not-json"),
+		[]byte(`{"operation_id":"` + strings.Repeat("x", 1024) + `"}`),
+		[]byte(`{"operation_id":"` + strings.Repeat("y", 8192) + `"}`),
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, body []byte) {
+		for _, target := range []any{&protocol.MutationRequest{}, &protocol.SubscriptionUpdateRequest{}} {
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodPost, "/v1/fuzz", bytes.NewReader(body))
+			ok := decodeControlJSON(recorder, request, target)
+			if ok {
+				if recorder.Body.Len() != 0 {
+					t.Fatalf("success wrote body: %s", recorder.Body.String())
+				}
+				continue
+			}
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("failure status=%d body=%s", recorder.Code, recorder.Body.String())
+			}
+			var envelope protocol.ErrorEnvelope
+			if err := json.Unmarshal(recorder.Body.Bytes(), &envelope); err != nil {
+				t.Fatalf("invalid error envelope: %v body=%s", err, recorder.Body.String())
+			}
+			if envelope.Error.Code != protocol.CodeInvalidArgument {
+				t.Fatalf("code=%q body=%s", envelope.Error.Code, recorder.Body.String())
+			}
+			if len(body) > 8 && bytes.Contains(recorder.Body.Bytes(), body) {
+				t.Fatalf("error body echoed raw input")
+			}
+		}
+	})
+}

--- a/internal/control/server/subscription_test.go
+++ b/internal/control/server/subscription_test.go
@@ -1,68 +1,115 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mihari-proxy/mihari/internal/control/protocol"
 	runtimeapi "github.com/mihari-proxy/mihari/internal/runtime"
+	"github.com/mihari-proxy/mihari/internal/state"
 	"github.com/mihari-proxy/mihari/internal/subscription"
 )
 
 type fakeSubscriptionRuntime struct {
 	*fakeRuntime
-	added    runtimeapi.AddSubscriptionInput
-	setInput runtimeapi.SetSubscriptionInput
+	catalog   subscription.PublicCatalog
+	operation runtimeapi.Operation
+	profileID string
+	enabled   bool
+	err       error
+	added     runtimeapi.AddSubscriptionInput
+	setInput  runtimeapi.SetSubscriptionInput
 }
 
 func (f *fakeSubscriptionRuntime) Subscriptions() subscription.PublicCatalog {
-	return subscription.PublicCatalog{Profiles: []subscription.PublicProfile{}}
+	return f.catalog
 }
-func (f *fakeSubscriptionRuntime) AddSubscription(_ context.Context, _ runtimeapi.Operation, input runtimeapi.AddSubscriptionInput) (subscription.PublicProfile, error) {
+
+func (f *fakeSubscriptionRuntime) AddSubscription(_ context.Context, operation runtimeapi.Operation, input runtimeapi.AddSubscriptionInput) (subscription.PublicProfile, error) {
+	f.operation = operation
 	f.added = input
-	return subscription.PublicProfile{ID: "one", Name: input.Name, ProxyMode: input.ProxyMode}, nil
+	return subscription.PublicProfile{ID: "one", Name: input.Name, ProxyMode: input.ProxyMode}, f.err
 }
-func (f *fakeSubscriptionRuntime) RefreshSubscription(context.Context, runtimeapi.Operation, string) (subscription.PublicProfile, error) {
-	return subscription.PublicProfile{}, nil
+
+func (f *fakeSubscriptionRuntime) RefreshSubscription(_ context.Context, operation runtimeapi.Operation, profileID string) (subscription.PublicProfile, error) {
+	f.operation = operation
+	f.profileID = profileID
+	return f.mutatedProfile(), f.err
 }
-func (f *fakeSubscriptionRuntime) UseSubscription(context.Context, runtimeapi.Operation, string) (subscription.PublicProfile, error) {
-	return subscription.PublicProfile{}, nil
+
+func (f *fakeSubscriptionRuntime) UseSubscription(_ context.Context, operation runtimeapi.Operation, profileID string) (subscription.PublicProfile, error) {
+	f.operation = operation
+	f.profileID = profileID
+	return f.mutatedProfile(), f.err
 }
-func (f *fakeSubscriptionRuntime) SetSubscriptionEnabled(context.Context, runtimeapi.Operation, string, bool) (subscription.PublicProfile, error) {
-	return subscription.PublicProfile{}, nil
+
+func (f *fakeSubscriptionRuntime) SetSubscriptionEnabled(_ context.Context, operation runtimeapi.Operation, profileID string, enabled bool) (subscription.PublicProfile, error) {
+	f.operation = operation
+	f.profileID = profileID
+	f.enabled = enabled
+	profile := f.mutatedProfile()
+	profile.Enabled = enabled
+	return profile, f.err
 }
-func (f *fakeSubscriptionRuntime) SetSubscription(_ context.Context, _ runtimeapi.Operation, _ string, input runtimeapi.SetSubscriptionInput) (subscription.PublicProfile, error) {
+
+func (f *fakeSubscriptionRuntime) SetSubscription(_ context.Context, operation runtimeapi.Operation, profileID string, input runtimeapi.SetSubscriptionInput) (subscription.PublicProfile, error) {
+	f.operation = operation
+	f.profileID = profileID
 	f.setInput = input
-	profile := subscription.PublicProfile{ID: "one"}
+	profile := subscription.PublicProfile{ID: profileID}
+	if input.Name != nil {
+		profile.Name = *input.Name
+	}
+	if input.Interval != nil {
+		profile.Interval = *input.Interval
+	}
+	if input.AutoRefresh != nil {
+		profile.AutoRefresh = *input.AutoRefresh
+	}
 	if input.ProxyMode != nil {
 		profile.ProxyMode = *input.ProxyMode
 	}
-	return profile, nil
+	return profile, f.err
 }
-func (f *fakeSubscriptionRuntime) RemoveSubscription(context.Context, runtimeapi.Operation, string) error {
-	return nil
+
+func (f *fakeSubscriptionRuntime) RemoveSubscription(_ context.Context, operation runtimeapi.Operation, profileID string) error {
+	f.operation = operation
+	f.profileID = profileID
+	return f.err
+}
+
+func (f *fakeSubscriptionRuntime) mutatedProfile() subscription.PublicProfile {
+	return subscription.PublicProfile{ID: f.profileID, Name: "updated", Enabled: f.enabled, ProxyMode: subscription.ProxyModeAuto}
 }
 
 func TestSubscriptionAddRouteAcceptsURLButDoesNotReturnIt(t *testing.T) {
-	runtime := &fakeSubscriptionRuntime{fakeRuntime: &fakeRuntime{}}
+	runtime := &fakeSubscriptionRuntime{fakeRuntime: &fakeRuntime{snapshot: state.Snapshot{Revision: 9}}}
 	server := New(Options{Token: "token", Runtime: runtime})
-	request := httptest.NewRequest(http.MethodPost, "/v1/subscriptions", strings.NewReader(`{"operation_id":"op","name":"main","url":"https://example.test/?token=secret"}`))
+	request := httptest.NewRequest(http.MethodPost, "/v1/subscriptions", strings.NewReader(`{"operation_id":"add-url-1","if_revision":7,"name":"main","url":"https://example.test/?token=secret"}`))
 	request.Header.Set("Authorization", "Bearer token")
 	recorder := httptest.NewRecorder()
 	server.Handler().ServeHTTP(recorder, request)
-	if recorder.Code != http.StatusCreated || runtime.added.URL == "" {
+	if recorder.Code != http.StatusCreated || runtime.added.Name != "main" || runtime.added.URL != "https://example.test/?token=secret" {
 		t.Fatalf("status=%d body=%s input=%#v", recorder.Code, recorder.Body.String(), runtime.added)
+	}
+	if runtime.operation.ID != "add-url-1" || runtime.operation.Source != "control" || runtime.operation.IfRevision == nil || *runtime.operation.IfRevision != 7 {
+		t.Fatalf("operation=%#v", runtime.operation)
 	}
 	if strings.Contains(recorder.Body.String(), "example.test") || strings.Contains(recorder.Body.String(), "secret") {
 		t.Fatalf("response leaked URL: %s", recorder.Body.String())
 	}
 	var result protocol.SubscriptionResult
-	if err := json.Unmarshal(recorder.Body.Bytes(), &result); err != nil || result.Subscription.ID != "one" {
+	if err := json.Unmarshal(recorder.Body.Bytes(), &result); err != nil {
 		t.Fatal(err)
+	}
+	if result.Schema != "mihari/v1" || result.OperationID != "add-url-1" || result.Revision != 9 || result.Subscription.ID != "one" || result.Subscription.Name != "main" {
+		t.Fatalf("result=%#v", result)
 	}
 }
 
@@ -89,10 +136,10 @@ func TestSubscriptionAddRouteForwardsProxyMode(t *testing.T) {
 	}
 }
 
-func TestSubscriptionUpdateRouteForwardsProxyMode(t *testing.T) {
-	runtime := &fakeSubscriptionRuntime{fakeRuntime: &fakeRuntime{}}
+func TestSubscriptionUpdateRouteForwardsAllFieldsAndOperation(t *testing.T) {
+	runtime := &fakeSubscriptionRuntime{fakeRuntime: &fakeRuntime{snapshot: state.Snapshot{Revision: 21}}}
 	server := New(Options{Token: "token", Runtime: runtime})
-	body := `{"operation_id":"op","proxy_mode":"proxy"}`
+	body := `{"operation_id":"update-1","if_revision":20,"name":"renamed","url":"https://example.test/new?token=private","interval":"","auto_refresh":false,"global_interval":"24h","proxy_mode":"proxy"}`
 	request := httptest.NewRequest(http.MethodPatch, "/v1/subscriptions/one", strings.NewReader(body))
 	request.Header.Set("Authorization", "Bearer token")
 	recorder := httptest.NewRecorder()
@@ -100,7 +147,218 @@ func TestSubscriptionUpdateRouteForwardsProxyMode(t *testing.T) {
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
 	}
-	if runtime.setInput.ProxyMode == nil || *runtime.setInput.ProxyMode != "proxy" {
-		t.Fatalf("update did not forward proxy mode: %#v", runtime.setInput)
+	if runtime.operation.ID != "update-1" || runtime.operation.Source != "control" || runtime.operation.IfRevision == nil || *runtime.operation.IfRevision != 20 || runtime.profileID != "one" {
+		t.Fatalf("operation=%#v profileID=%q", runtime.operation, runtime.profileID)
+	}
+	input := runtime.setInput
+	if input.Name == nil || *input.Name != "renamed" ||
+		input.URL == nil || *input.URL != "https://example.test/new?token=private" ||
+		input.Interval == nil || *input.Interval != "" ||
+		input.AutoRefresh == nil || *input.AutoRefresh ||
+		input.GlobalPeriod == nil || *input.GlobalPeriod != "24h" ||
+		input.ProxyMode == nil || *input.ProxyMode != "proxy" {
+		t.Fatalf("update input=%#v", input)
+	}
+	if strings.Contains(recorder.Body.String(), "example.test") || strings.Contains(recorder.Body.String(), "private") {
+		t.Fatalf("response leaked URL: %s", recorder.Body.String())
+	}
+	var result protocol.SubscriptionResult
+	if err := json.Unmarshal(recorder.Body.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Schema != "mihari/v1" || result.OperationID != "update-1" || result.Revision != 21 ||
+		result.Subscription.ID != "one" || result.Subscription.Name != "renamed" || result.Subscription.Interval != "" ||
+		result.Subscription.AutoRefresh || result.Subscription.ProxyMode != "proxy" {
+		t.Fatalf("result=%#v", result)
 	}
 }
+
+func TestSubscriptionListAndShowRoutesReturnSecretFreeDTOs(t *testing.T) {
+	updatedAt := time.Date(2026, time.August, 12, 9, 30, 0, 0, time.UTC)
+	runtime := &fakeSubscriptionRuntime{
+		fakeRuntime: &fakeRuntime{snapshot: state.Snapshot{Revision: 8}},
+		catalog: subscription.PublicCatalog{
+			ActiveID:       "one",
+			GlobalInterval: "12h",
+			Profiles: []subscription.PublicProfile{{
+				ID: "one", Name: "primary", Enabled: true, AutoRefresh: true, Interval: "6h", Cached: true,
+				Generation: 3, UpdatedAt: updatedAt, LastError: "temporary upstream error", Upload: 11, Download: 22, Total: 33, Expire: 44,
+				ProxyMode: subscription.ProxyModeAuto,
+			}},
+		},
+	}
+	server := New(Options{Token: "token", Runtime: runtime})
+
+	list := httptest.NewRecorder()
+	server.Handler().ServeHTTP(list, authorizedRequest(http.MethodGet, "/v1/subscriptions", nil))
+	if list.Code != http.StatusOK {
+		t.Fatalf("list status=%d body=%s", list.Code, list.Body.String())
+	}
+	var rawList map[string]json.RawMessage
+	if err := json.Unmarshal(list.Body.Bytes(), &rawList); err != nil {
+		t.Fatal(err)
+	}
+	var rawSubscriptions []json.RawMessage
+	if err := json.Unmarshal(rawList["subscriptions"], &rawSubscriptions); err != nil || len(rawSubscriptions) != 1 {
+		t.Fatalf("raw subscriptions=%q err=%v", rawList["subscriptions"], err)
+	}
+	assertSubscriptionDTOHasNoSourceURL(t, rawSubscriptions[0])
+	var catalog protocol.SubscriptionList
+	if err := json.Unmarshal(list.Body.Bytes(), &catalog); err != nil {
+		t.Fatal(err)
+	}
+	if catalog.Schema != "mihari/v1" || catalog.Revision != 8 || catalog.ActiveID != "one" || catalog.GlobalInterval != "12h" || len(catalog.Subscriptions) != 1 {
+		t.Fatalf("list=%#v", catalog)
+	}
+	profile := catalog.Subscriptions[0]
+	if profile.ID != "one" || profile.Name != "primary" || !profile.Enabled || !profile.AutoRefresh || profile.Interval != "6h" || !profile.Cached || profile.Generation != 3 || !profile.UpdatedAt.Equal(updatedAt) || profile.LastError != "temporary upstream error" || profile.Upload != 11 || profile.Download != 22 || profile.Total != 33 || profile.Expire != 44 || profile.ProxyMode != subscription.ProxyModeAuto {
+		t.Fatalf("list profile=%#v", profile)
+	}
+
+	show := httptest.NewRecorder()
+	server.Handler().ServeHTTP(show, authorizedRequest(http.MethodGet, "/v1/subscriptions/one", nil))
+	if show.Code != http.StatusOK {
+		t.Fatalf("show status=%d body=%s", show.Code, show.Body.String())
+	}
+	var rawShow map[string]json.RawMessage
+	if err := json.Unmarshal(show.Body.Bytes(), &rawShow); err != nil {
+		t.Fatal(err)
+	}
+	assertSubscriptionDTOHasNoSourceURL(t, rawShow["subscription"])
+	var result protocol.SubscriptionResult
+	if err := json.Unmarshal(show.Body.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Schema != "mihari/v1" || result.Revision != 8 || result.OperationID != "" || result.Subscription != profile {
+		t.Fatalf("show=%#v want profile=%#v", result, profile)
+	}
+}
+
+func assertSubscriptionDTOHasNoSourceURL(t *testing.T, raw json.RawMessage) {
+	t.Helper()
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &object); err != nil {
+		t.Fatalf("subscription JSON=%q err=%v", raw, err)
+	}
+	for _, field := range []string{"url", "source_url", "subscription_url"} {
+		if _, found := object[field]; found {
+			t.Fatalf("subscription DTO leaked forbidden %q field: %s", field, raw)
+		}
+	}
+}
+
+func TestSubscriptionShowRouteMapsNotFound(t *testing.T) {
+	runtime := &fakeSubscriptionRuntime{fakeRuntime: &fakeRuntime{}, catalog: subscription.PublicCatalog{Profiles: []subscription.PublicProfile{}}}
+	server := New(Options{Token: "token", Runtime: runtime})
+	recorder := httptest.NewRecorder()
+	server.Handler().ServeHTTP(recorder, authorizedRequest(http.MethodGet, "/v1/subscriptions/missing", nil))
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	var envelope protocol.ErrorEnvelope
+	if err := json.Unmarshal(recorder.Body.Bytes(), &envelope); err != nil || envelope.Error.Code != protocol.CodeInvalidArgument {
+		t.Fatalf("envelope=%#v err=%v", envelope, err)
+	}
+}
+
+func TestSubscriptionProfileMutationRoutesForwardOperation(t *testing.T) {
+	tests := []struct {
+		name, method, path, body string
+		operationID              string
+		wantEnabled              *bool
+	}{
+		{name: "refresh", method: http.MethodPost, path: "/v1/subscriptions/one/refresh", body: `{"operation_id":"refresh-1","if_revision":7}`, operationID: "refresh-1"},
+		{name: "use", method: http.MethodPut, path: "/v1/subscriptions/one/active", body: `{"operation_id":"use-1","if_revision":7}`, operationID: "use-1"},
+		{name: "enable false", method: http.MethodPut, path: "/v1/subscriptions/one/enabled", body: `{"operation_id":"enable-1","if_revision":7,"enabled":false}`, operationID: "enable-1", wantEnabled: boolPtr(false)},
+		{name: "remove", method: http.MethodDelete, path: "/v1/subscriptions/one", body: `{"operation_id":"remove-1","if_revision":7}`, operationID: "remove-1"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runtime := &fakeSubscriptionRuntime{fakeRuntime: &fakeRuntime{snapshot: state.Snapshot{Revision: 8}}}
+			server := New(Options{Token: "token", Runtime: runtime})
+			recorder := httptest.NewRecorder()
+			server.Handler().ServeHTTP(recorder, authorizedRequest(test.method, test.path, strings.NewReader(test.body)))
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+			}
+			var operationID string
+			var subscription protocol.Subscription
+			if test.name == "remove" {
+				var result protocol.MutationResult
+				if err := json.Unmarshal(recorder.Body.Bytes(), &result); err != nil || result.Schema != "mihari/v1" || result.Revision != 8 {
+					t.Fatalf("result=%#v err=%v", result, err)
+				}
+				operationID = result.OperationID
+			} else {
+				var result protocol.SubscriptionResult
+				if err := json.Unmarshal(recorder.Body.Bytes(), &result); err != nil || result.Schema != "mihari/v1" || result.Revision != 8 || result.Subscription.ID != "one" {
+					t.Fatalf("result=%#v err=%v", result, err)
+				}
+				operationID = result.OperationID
+				subscription = result.Subscription
+			}
+			if operationID != test.operationID || runtime.operation.ID != test.operationID || runtime.operation.Source != "control" || runtime.operation.IfRevision == nil || *runtime.operation.IfRevision != 7 || runtime.profileID != "one" {
+				t.Fatalf("response operation=%q runtime operation=%#v profileID=%q", operationID, runtime.operation, runtime.profileID)
+			}
+			if test.wantEnabled != nil && (runtime.enabled != *test.wantEnabled || subscription.Enabled != *test.wantEnabled) {
+				t.Fatalf("runtime enabled=%v response enabled=%v want %v", runtime.enabled, subscription.Enabled, *test.wantEnabled)
+			}
+		})
+	}
+}
+
+func TestSubscriptionRoutesRejectInvalidBodiesAndUnavailableRuntime(t *testing.T) {
+	invalidBodies := []struct {
+		name string
+		body string
+	}{
+		{name: "unknown field", body: `{"operation_id":"one","unexpected":true}`},
+		{name: "multiple JSON objects", body: `{"operation_id":"one"}{"operation_id":"two"}`},
+		{name: "missing operation ID", body: `{}`},
+		{name: "oversized body", body: `{"operation_id":"one","padding":"` + strings.Repeat("x", maxControlBodySize) + `"}`},
+	}
+	for _, test := range invalidBodies {
+		t.Run(test.name, func(t *testing.T) {
+			server := New(Options{Token: "token", Runtime: &fakeSubscriptionRuntime{fakeRuntime: &fakeRuntime{}}})
+			recorder := httptest.NewRecorder()
+			server.Handler().ServeHTTP(recorder, authorizedRequest(http.MethodPost, "/v1/subscriptions/one/refresh", strings.NewReader(test.body)))
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+			}
+			var envelope protocol.ErrorEnvelope
+			if err := json.Unmarshal(recorder.Body.Bytes(), &envelope); err != nil || envelope.Error.Code != protocol.CodeInvalidArgument {
+				t.Fatalf("envelope=%#v err=%v", envelope, err)
+			}
+		})
+	}
+
+	t.Run("runtime capability unavailable", func(t *testing.T) {
+		server := New(Options{Token: "token", Runtime: strippedRuntime{&fakeRuntime{}}})
+		recorder := httptest.NewRecorder()
+		server.Handler().ServeHTTP(recorder, authorizedRequest(http.MethodGet, "/v1/subscriptions", nil))
+		if recorder.Code != http.StatusConflict {
+			t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+		}
+		var envelope protocol.ErrorEnvelope
+		if err := json.Unmarshal(recorder.Body.Bytes(), &envelope); err != nil || envelope.Error.Code != protocol.CodeInvalidState {
+			t.Fatalf("envelope=%#v err=%v", envelope, err)
+		}
+	})
+
+	t.Run("runtime API error", func(t *testing.T) {
+		runtime := &fakeSubscriptionRuntime{fakeRuntime: &fakeRuntime{}, err: protocol.APIError{Code: protocol.CodePermissionDenied, Message: "subscription access denied"}}
+		server := New(Options{Token: "token", Runtime: runtime})
+		recorder := httptest.NewRecorder()
+		server.Handler().ServeHTTP(recorder, authorizedRequest(http.MethodPost, "/v1/subscriptions/one/refresh", bytes.NewBufferString(`{"operation_id":"one"}`)))
+		if recorder.Code != http.StatusForbidden {
+			t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+		}
+		var envelope protocol.ErrorEnvelope
+		if err := json.Unmarshal(recorder.Body.Bytes(), &envelope); err != nil || envelope.Error.Code != protocol.CodePermissionDenied || envelope.Error.Message != "subscription access denied" {
+			t.Fatalf("envelope=%#v err=%v", envelope, err)
+		}
+	})
+}
+
+func boolPtr(value bool) *bool { return &value }

--- a/internal/control/transport/testutil/testutil.go
+++ b/internal/control/transport/testutil/testutil.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -17,5 +18,12 @@ func Endpoint(t testing.TB) string {
 		}
 		return `\\.\pipe\mihari-test-` + hex.EncodeToString(suffix[:])
 	}
-	return filepath.Join(t.TempDir(), "control.sock")
+	// Darwin (and some other Unixes) cap AF_UNIX path length near 104 bytes.
+	// t.TempDir() under /var/folders/... is often too long for control.sock.
+	dir, err := os.MkdirTemp("/tmp", "mh-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, "c.sock")
 }

--- a/internal/elevate/elevate_test.go
+++ b/internal/elevate/elevate_test.go
@@ -39,3 +39,17 @@ func TestIsElevatedUsesChecker(t *testing.T) {
 		t.Fatal("expected not elevated")
 	}
 }
+
+func TestSetCheckerNilRestoresPlatformProbe(t *testing.T) {
+	prev := Check
+	t.Cleanup(func() { Check = prev })
+	SetChecker(func() bool { return true })
+	if !IsElevated() {
+		t.Fatal("expected injected elevated checker")
+	}
+	SetChecker(nil)
+	// platformElevated is OS-specific; only assert the hook restored a non-nil function.
+	if Check == nil {
+		t.Fatal("Check is nil after SetChecker(nil)")
+	}
+}

--- a/internal/integration/control_test.go
+++ b/internal/integration/control_test.go
@@ -4,17 +4,151 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/mihari-proxy/mihari/internal/cli"
+	"github.com/mihari-proxy/mihari/internal/config"
 	controlclient "github.com/mihari-proxy/mihari/internal/control/client"
 	"github.com/mihari-proxy/mihari/internal/control/protocol"
 	transporttest "github.com/mihari-proxy/mihari/internal/control/transport/testutil"
 	"github.com/mihari-proxy/mihari/internal/daemon"
+	runtimeapi "github.com/mihari-proxy/mihari/internal/runtime"
+	"github.com/mihari-proxy/mihari/internal/state"
+	"github.com/mihari-proxy/mihari/internal/subscription"
 )
+
+type controlledSubscriptionFetcher struct {
+	entered     chan struct{}
+	enteredOnce sync.Once
+	release     chan struct{}
+	releaseOnce sync.Once
+}
+
+func newControlledSubscriptionFetcher() *controlledSubscriptionFetcher {
+	return &controlledSubscriptionFetcher{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (f *controlledSubscriptionFetcher) Fetch(ctx context.Context, _ subscription.FetchRequest) (subscription.FetchResult, error) {
+	f.enteredOnce.Do(func() { close(f.entered) })
+	select {
+	case <-f.release:
+		return subscription.FetchResult{Content: []byte("proxies: []\n")}, nil
+	case <-ctx.Done():
+		return subscription.FetchResult{}, ctx.Err()
+	}
+}
+
+func (f *controlledSubscriptionFetcher) releaseFetch() {
+	f.releaseOnce.Do(func() { close(f.release) })
+}
+
+type subscriptionControlFixture struct {
+	client    *controlclient.Client
+	fetcher   *controlledSubscriptionFetcher
+	profileID string
+	cancel    context.CancelFunc
+	done      chan struct{}
+	daemonErr error
+}
+
+func newSubscriptionControlFixture(t *testing.T) *subscriptionControlFixture {
+	t.Helper()
+	root := t.TempDir()
+	fetcher := newControlledSubscriptionFetcher()
+	service, err := subscription.Open(subscription.ServiceOptions{
+		CatalogPath: filepath.Join(root, "subscriptions", "catalog.yaml"),
+		CacheDir:    filepath.Join(root, "subscriptions", "cache"),
+		Downloader:  fetcher,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile, err := service.Add("controlled", "https://example.test/subscription", subscription.ProxyModeDirect)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtimeConfig := filepath.Join(root, "runtime", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(runtimeConfig), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(runtimeConfig, []byte("proxies: []\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := state.NewStore(state.Snapshot{
+		Version:   "integration",
+		StartedAt: time.Now().UTC(),
+		Health:    "ok",
+	})
+	settings := config.Defaults()
+	settings.ControllerSecret = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	manager := runtimeapi.New(runtimeapi.Options{
+		Store:          store,
+		Coordinator:    state.NewCoordinator(store),
+		Subscriptions:  service,
+		Settings:       settings,
+		RuntimeConfig:  runtimeConfig,
+		StagingDir:     filepath.Join(root, "staging"),
+		ValidateConfig: func(context.Context, string) error { return nil },
+	})
+
+	endpoint := transporttest.Endpoint(t)
+	const token = "subscription-integration-token"
+	ctx, cancel := context.WithCancel(context.Background())
+	ready := make(chan struct{})
+	fixture := &subscriptionControlFixture{
+		client:    controlclient.New(endpoint, token),
+		fetcher:   fetcher,
+		profileID: profile.ID,
+		cancel:    cancel,
+		done:      make(chan struct{}),
+	}
+	go func() {
+		defer close(fixture.done)
+		fixture.daemonErr = daemon.Run(ctx, daemon.Options{
+			Endpoint: endpoint,
+			Token:    token,
+			Version:  "integration",
+			Ready:    ready,
+			Store:    store,
+			Runtime:  manager,
+		})
+	}()
+	t.Cleanup(func() {
+		fetcher.releaseFetch()
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 8*time.Second)
+		defer shutdownCancel()
+		if err := fixture.stop(shutdownCtx); err != nil {
+			t.Errorf("daemon cleanup: %v", err)
+		}
+	})
+	select {
+	case <-ready:
+	case <-fixture.done:
+		t.Fatalf("daemon exited before becoming ready: %v", fixture.daemonErr)
+	case <-time.After(3 * time.Second):
+		t.Fatal("daemon did not become ready")
+	}
+	return fixture
+}
+
+func (f *subscriptionControlFixture) stop(ctx context.Context) error {
+	f.cancel()
+	select {
+	case <-f.done:
+		return f.daemonErr
+	case <-ctx.Done():
+		return fmt.Errorf("daemon did not stop: %w", ctx.Err())
+	}
+}
 
 func TestControlPlaneLifecycleAndConcurrentStatus(t *testing.T) {
 	endpoint := transporttest.Endpoint(t)
@@ -102,5 +236,61 @@ func TestControlPlaneLifecycleAndConcurrentStatus(t *testing.T) {
 	}
 	if envelope.Error.Code != protocol.CodeDaemonUnavailable {
 		t.Fatalf("post-shutdown error=%#v", envelope.Error)
+	}
+}
+
+func TestSubscriptionRemoveOverIPCRejectsLateRefreshCommit(t *testing.T) {
+	fixture := newSubscriptionControlFixture(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	refreshDone := make(chan error, 1)
+	go func() {
+		defer close(refreshDone)
+		_, refreshErr := fixture.client.RefreshSubscription(ctx, fixture.profileID, protocol.MutationRequest{OperationID: "subscription-refresh"})
+		refreshDone <- refreshErr
+	}()
+	t.Cleanup(func() {
+		fixture.fetcher.releaseFetch()
+		select {
+		case <-refreshDone:
+		case <-time.After(8 * time.Second):
+			t.Error("refresh goroutine did not stop")
+		}
+	})
+	select {
+	case <-fixture.fetcher.entered:
+	case err := <-refreshDone:
+		t.Fatalf("refresh finished before entering fetch: %v", err)
+	case <-ctx.Done():
+		t.Fatalf("refresh did not enter fetch: %v", ctx.Err())
+	}
+
+	if _, err := fixture.client.RemoveSubscription(ctx, fixture.profileID, protocol.MutationRequest{OperationID: "subscription-remove"}); err != nil {
+		t.Fatal(err)
+	}
+	fixture.fetcher.releaseFetch()
+
+	select {
+	case err := <-refreshDone:
+		var apiError protocol.APIError
+		if !errors.As(err, &apiError) || (apiError.Code != protocol.CodeRevisionConflict && apiError.Code != protocol.CodeInvalidArgument) {
+			t.Fatalf("refresh error=%v", err)
+		}
+	case <-ctx.Done():
+		t.Fatalf("refresh did not finish: %v", ctx.Err())
+	}
+
+	list, err := fixture.client.Subscriptions(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, profile := range list.Subscriptions {
+		if profile.ID == fixture.profileID {
+			t.Fatalf("deleted subscription was recreated: %#v", profile)
+		}
+	}
+	if err := fixture.stop(ctx); err != nil {
+		t.Fatalf("stop daemon: %v", err)
 	}
 }

--- a/internal/panel/archive/zip_test.go
+++ b/internal/panel/archive/zip_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -146,4 +147,48 @@ func addZipFile(t *testing.T, writer *zip.Writer, name, content string) {
 	if _, err := entry.Write([]byte(content)); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func FuzzSafeArchivePath(f *testing.F) {
+	seeds := []string{
+		"index.html",
+		"assets/app.js",
+		".",
+		"..",
+		"../evil",
+		"nested/../../evil",
+		"/tmp/abs",
+		"C:/Windows/system32",
+		`\\unc\share\file`,
+		"a\\b/c",
+		"name\x00evil",
+		"",
+		"café/index.html",
+		strings.Repeat("a", 300) + "/b",
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, name string) {
+		root := t.TempDir()
+		safe := SafeName(name)
+		target, err := resolveTarget(root, name)
+		if !safe {
+			if err == nil {
+				t.Fatalf("SafeName rejected %q but resolveTarget accepted %q", name, target)
+			}
+			return
+		}
+		if err != nil {
+			// SafeName may accept names that Join still rejects on this platform.
+			return
+		}
+		rel, relErr := filepath.Rel(root, target)
+		if relErr != nil {
+			t.Fatalf("Rel(%q,%q): %v", root, target, relErr)
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+			t.Fatalf("resolved outside root: name=%q target=%q rel=%q", name, target, rel)
+		}
+	})
 }

--- a/internal/panel/install.go
+++ b/internal/panel/install.go
@@ -27,20 +27,28 @@ func PanelBuildDir(webRoot, panelID, build string) string {
 // InstallFromZip extracts a validated panel archive into staging, then atomically
 // promotes it to web/{panelID}/{build}/. The caller must supply a unique build id.
 func InstallFromZip(request InstallRequest) (string, error) {
+	stagingDir, err := prepareInstallCandidate(request)
+	if err != nil {
+		return "", err
+	}
+	finalDir := PanelBuildDir(request.WebRoot, request.PanelID, request.Build)
+	if err := promoteInstallCandidate(stagingDir, finalDir); err != nil {
+		_ = os.RemoveAll(stagingDir)
+		return "", err
+	}
+	return finalDir, nil
+}
+
+func prepareInstallCandidate(request InstallRequest) (string, error) {
 	if err := validateInstallRequest(request); err != nil {
 		return "", err
 	}
 	if err := os.MkdirAll(request.StagingDir, 0o700); err != nil {
 		return "", fmt.Errorf("create panel staging directory: %w", err)
 	}
-	if err := os.MkdirAll(request.WebRoot, 0o700); err != nil {
-		return "", fmt.Errorf("create web root: %w", err)
-	}
 
-	stagingName := request.PanelID + "-" + sanitizeBuild(request.Build)
-	stagingDir := filepath.Join(request.StagingDir, stagingName)
-	_ = os.RemoveAll(stagingDir)
-	if err := os.MkdirAll(stagingDir, 0o700); err != nil {
+	stagingDir, err := os.MkdirTemp(request.StagingDir, request.PanelID+"-"+sanitizeBuild(request.Build)+"-")
+	if err != nil {
 		return "", fmt.Errorf("create panel staging candidate: %w", err)
 	}
 
@@ -55,22 +63,23 @@ func InstallFromZip(request InstallRequest) (string, error) {
 		return "", fmt.Errorf("normalize panel archive root: %w", err)
 	}
 
-	finalDir := PanelBuildDir(request.WebRoot, request.PanelID, request.Build)
+	return stagingDir, nil
+}
+
+func promoteInstallCandidate(stagingDir, finalDir string) error {
 	if err := os.MkdirAll(filepath.Dir(finalDir), 0o700); err != nil {
-		_ = os.RemoveAll(stagingDir)
-		return "", fmt.Errorf("create panel install directory: %w", err)
+		return fmt.Errorf("create panel install directory: %w", err)
 	}
 	// Replace any previous incomplete install of the same build.
 	_ = os.RemoveAll(finalDir)
 	if err := os.Rename(stagingDir, finalDir); err != nil {
 		// Cross-device rename fallback: copy is not implemented; fail closed.
-		_ = os.RemoveAll(stagingDir)
-		return "", protocol.APIError{
+		return protocol.APIError{
 			Code:    protocol.CodeDataFailure,
 			Message: "promote panel install candidate",
 		}
 	}
-	return finalDir, nil
+	return nil
 }
 
 func validateInstallRequest(request InstallRequest) error {

--- a/internal/panel/service.go
+++ b/internal/panel/service.go
@@ -2,6 +2,7 @@ package panel
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -39,6 +40,14 @@ type PanelInfo struct {
 	LatestBuild    string
 	RollbackBuild  string
 	Health         string
+}
+
+// PreparedMutation is a validated panel candidate whose filesystem mutation is deferred until Commit.
+type PreparedMutation interface {
+	Identity() string
+	Valid() bool
+	Commit() error
+	Cleanup()
 }
 
 // Service owns panel install trees under web/ and the active.json pointer.
@@ -222,23 +231,36 @@ func (s *Service) Install(ctx context.Context, panelID, pinBuild string) error {
 
 // Update installs the latest build when it differs from the current installed build for panelID.
 func (s *Service) Update(ctx context.Context, panelID string) error {
-	adapter, err := s.adapter(panelID)
+	prepared, err := s.PrepareUpdate(ctx, panelID)
 	if err != nil {
 		return err
 	}
+	defer prepared.Cleanup()
+	return prepared.Commit()
+}
+
+// PrepareUpdate downloads and validates the latest build without changing the installed tree.
+func (s *Service) PrepareUpdate(ctx context.Context, panelID string) (PreparedMutation, error) {
+	adapter, err := s.adapter(panelID)
+	if err != nil {
+		return nil, err
+	}
 	build, assetURL, err := adapter.ResolveLatest(ctx)
 	if err != nil {
-		return err
+		return nil, err
+	}
+	if build == "" || assetURL == "" {
+		return nil, protocol.APIError{Code: protocol.CodeDataFailure, Message: "panel adapter returned empty build"}
 	}
 	s.mu.Lock()
 	builds := s.listBuildsLocked(panelID)
 	s.mu.Unlock()
 	if len(builds) > 0 && builds[0] == build {
 		if s.buildReady(panelID, build) {
-			return nil
+			return &preparedPanelMutation{service: s, panelID: panelID, build: build, noOp: true}, nil
 		}
 	}
-	return s.installBuild(ctx, panelID, build, assetURL)
+	return s.prepareBuild(ctx, panelID, build, assetURL, false)
 }
 
 // Activate sets active.json to the newest complete installed build for panelID.
@@ -369,23 +391,28 @@ func (s *Service) Uninstall(ctx context.Context, panelID string) error {
 // Reinstall uninstalls panelID then installs the latest build.
 // When the panel was the default active panel, it is re-activated after install.
 func (s *Service) Reinstall(ctx context.Context, panelID string) error {
-	if err := ctx.Err(); err != nil {
+	prepared, err := s.PrepareReinstall(ctx, panelID)
+	if err != nil {
 		return err
 	}
-	wasDefault := false
-	if active, err := s.Active(); err == nil && active.Panel == panelID && active.Panel != "" {
-		wasDefault = true
+	defer prepared.Cleanup()
+	return prepared.Commit()
+}
+
+// PrepareReinstall downloads and validates a replacement without deleting the installed tree.
+func (s *Service) PrepareReinstall(ctx context.Context, panelID string) (PreparedMutation, error) {
+	adapter, err := s.adapter(panelID)
+	if err != nil {
+		return nil, err
 	}
-	if err := s.Uninstall(ctx, panelID); err != nil {
-		return err
+	build, assetURL, err := adapter.ResolveLatest(ctx)
+	if err != nil {
+		return nil, err
 	}
-	if err := s.Install(ctx, panelID, ""); err != nil {
-		return err
+	if build == "" || assetURL == "" {
+		return nil, protocol.APIError{Code: protocol.CodeDataFailure, Message: "panel adapter returned empty build"}
 	}
-	if wasDefault {
-		return s.Activate(ctx, panelID)
-	}
-	return nil
+	return s.prepareBuild(ctx, panelID, build, assetURL, true)
 }
 
 func (s *Service) installBuild(ctx context.Context, panelID, build, assetURL string) error {
@@ -410,6 +437,206 @@ func (s *Service) installBuild(ctx context.Context, panelID, build, assetURL str
 		StagingDir: s.stagingDir, WebRoot: s.webRoot,
 	})
 	return err
+}
+
+func (s *Service) prepareBuild(ctx context.Context, panelID, build, assetURL string, reinstall bool) (PreparedMutation, error) {
+	if err := validateDownloadURL(assetURL, s.allowHTTP); err != nil {
+		return nil, err
+	}
+	zipPath, err := s.download(ctx, panelID, build, assetURL)
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(zipPath)
+	candidateDir, err := prepareInstallCandidate(InstallRequest{
+		PanelID: panelID, Build: build, Archive: zipPath,
+		StagingDir: s.stagingDir, WebRoot: s.webRoot,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &preparedPanelMutation{
+		service: s, panelID: panelID, build: build, candidateDir: candidateDir, reinstall: reinstall,
+	}, nil
+}
+
+type preparedPanelMutation struct {
+	mu           sync.Mutex
+	service      *Service
+	panelID      string
+	build        string
+	candidateDir string
+	cleanupDirs  []string
+	reinstall    bool
+	noOp         bool
+	committed    bool
+	cleaned      bool
+}
+
+func (p *preparedPanelMutation) Valid() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.validLocked()
+}
+
+func (p *preparedPanelMutation) Identity() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.panelID + "\x00" + p.build
+}
+
+func (p *preparedPanelMutation) validLocked() bool {
+	if p.cleaned || p.service == nil || p.panelID == "" || p.build == "" {
+		return false
+	}
+	if p.noOp || p.committed {
+		return true
+	}
+	return candidateReady(p.candidateDir)
+}
+
+func (p *preparedPanelMutation) Commit() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.committed {
+		return nil
+	}
+	if !p.validLocked() {
+		return protocol.APIError{Code: protocol.CodeDataFailure, Message: "panel update candidate changed before commit"}
+	}
+	if p.noOp {
+		p.committed = true
+		return nil
+	}
+	p.service.mu.Lock()
+	defer p.service.mu.Unlock()
+	var err error
+	if p.reinstall {
+		err = p.commitReinstallLocked()
+	} else {
+		err = p.commitUpdateLocked()
+	}
+	if err != nil {
+		return err
+	}
+	p.committed = true
+	p.candidateDir = ""
+	return nil
+}
+
+func (p *preparedPanelMutation) Cleanup() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.candidateDir != "" {
+		// Cleanup cannot change the committed result; removal is best-effort because the interface has no error return.
+		_ = os.RemoveAll(p.candidateDir)
+		p.candidateDir = ""
+	}
+	for _, dir := range p.cleanupDirs {
+		// Committed backups are no longer live state; remove them after the coordinator lock is released.
+		_ = os.RemoveAll(dir)
+	}
+	p.cleanupDirs = nil
+	p.cleaned = true
+}
+
+func (p *preparedPanelMutation) commitUpdateLocked() error {
+	finalDir := PanelBuildDir(p.service.webRoot, p.panelID, p.build)
+	backupDir, hadPrevious, err := moveAside(finalDir, p.candidateDir+"-previous")
+	if err != nil {
+		return err
+	}
+	if err := promoteInstallCandidate(p.candidateDir, finalDir); err != nil {
+		if hadPrevious {
+			if restoreErr := os.Rename(backupDir, finalDir); restoreErr != nil {
+				return errors.Join(err, fmt.Errorf("restore previous panel build: %w", restoreErr))
+			}
+		}
+		return err
+	}
+	if hadPrevious {
+		p.cleanupDirs = append(p.cleanupDirs, backupDir)
+	}
+	return nil
+}
+
+func (p *preparedPanelMutation) commitReinstallLocked() error {
+	current, err := LoadActive(p.service.webActive)
+	if err != nil {
+		return err
+	}
+	panelDir := filepath.Join(p.service.webRoot, p.panelID)
+	backupDir, hadPrevious, err := moveAside(panelDir, p.candidateDir+"-previous-panel")
+	if err != nil {
+		return err
+	}
+	finalDir := PanelBuildDir(p.service.webRoot, p.panelID, p.build)
+	if err := promoteInstallCandidate(p.candidateDir, finalDir); err != nil {
+		if hadPrevious {
+			if restoreErr := os.Rename(backupDir, panelDir); restoreErr != nil {
+				return errors.Join(err, fmt.Errorf("restore previous panel install: %w", restoreErr))
+			}
+		}
+		return err
+	}
+	previous := clonePrevious(current.Previous)
+	delete(previous, p.panelID)
+	next := Active{Panel: current.Panel, Build: current.Build, Previous: previous}
+	if current.Panel == p.panelID {
+		next.Panel = p.panelID
+		next.Build = p.build
+	}
+	if err := SaveActive(p.service.webActive, next); err != nil {
+		if removeErr := os.RemoveAll(panelDir); removeErr != nil {
+			return errors.Join(err, fmt.Errorf("remove uncommitted panel install: %w", removeErr))
+		}
+		if hadPrevious {
+			if restoreErr := os.Rename(backupDir, panelDir); restoreErr != nil {
+				return errors.Join(err, fmt.Errorf("restore previous panel install: %w", restoreErr))
+			}
+		}
+		return err
+	}
+	if hadPrevious {
+		p.cleanupDirs = append(p.cleanupDirs, backupDir)
+	}
+	return nil
+}
+
+func moveAside(path, backup string) (string, bool, error) {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return backup, false, nil
+		}
+		return backup, false, err
+	}
+	// Backup names are candidate-unique; a leftover is cleanup debris and a failed removal makes Rename fail closed.
+	_ = os.RemoveAll(backup)
+	if err := os.Rename(path, backup); err != nil {
+		return backup, false, fmt.Errorf("retain previous panel install: %w", err)
+	}
+	return backup, true, nil
+}
+
+func candidateReady(root string) bool {
+	if root == "" {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(root, "index.html")); err == nil {
+		return true
+	}
+	var found bool
+	_ = filepath.WalkDir(root, func(_ string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		if strings.EqualFold(d.Name(), "index.html") {
+			found = true
+			return io.EOF
+		}
+		return nil
+	})
+	return found
 }
 
 func (s *Service) download(ctx context.Context, panelID, build, assetURL string) (string, error) {

--- a/internal/panel/service_test.go
+++ b/internal/panel/service_test.go
@@ -189,6 +189,130 @@ func TestServiceReinstallReplacesTreeAndRestoresDefault(t *testing.T) {
 	}
 }
 
+func TestServicePrepareUpdateDoesNotPromoteUntilCommit(t *testing.T) {
+	paths, server, _, _ := panelFixture(t)
+	defer server.Close()
+	service, err := Open(ServiceOptions{
+		WebRoot: paths.WebRoot, WebActive: paths.WebActive, StagingDir: paths.PanelStaging,
+		HTTPClient: server.Client(), AllowHTTP: true,
+		Adapters: []Adapter{
+			fixtureAdapter{id: IDZashboard, name: "Zashboard", build: "v2.0.0", asset: server.URL + "/v2.zip"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prepared, err := service.PrepareUpdate(context.Background(), IDZashboard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer prepared.Cleanup()
+	if !prepared.Valid() {
+		t.Fatal("prepared update candidate is not valid")
+	}
+	buildDir := filepath.Join(paths.WebRoot, IDZashboard, "v2.0.0")
+	if _, err := os.Stat(buildDir); !os.IsNotExist(err) {
+		t.Fatalf("prepared update promoted before commit: %v", err)
+	}
+	if err := prepared.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(buildDir, "index.html")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestServicePreparedUpdateCleanupRemovesStagingCandidate(t *testing.T) {
+	paths, server, _, _ := panelFixture(t)
+	defer server.Close()
+	service, err := Open(ServiceOptions{
+		WebRoot: paths.WebRoot, WebActive: paths.WebActive, StagingDir: paths.PanelStaging,
+		HTTPClient: server.Client(), AllowHTTP: true,
+		Adapters: []Adapter{
+			fixtureAdapter{id: IDZashboard, name: "Zashboard", build: "v2.0.0", asset: server.URL + "/v2.zip"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := service.PrepareUpdate(context.Background(), IDZashboard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared.Cleanup()
+	entries, err := os.ReadDir(paths.PanelStaging)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("staging entries after cleanup=%v", entries)
+	}
+	if _, err := os.Stat(filepath.Join(paths.WebRoot, IDZashboard, "v2.0.0")); !os.IsNotExist(err) {
+		t.Fatalf("cleaned candidate promoted into web root: %v", err)
+	}
+}
+
+func TestServicePrepareReinstallDoesNotMutateUntilCommit(t *testing.T) {
+	paths, server, _, _ := panelFixture(t)
+	defer server.Close()
+	service, err := Open(ServiceOptions{
+		WebRoot: paths.WebRoot, WebActive: paths.WebActive, StagingDir: paths.PanelStaging,
+		HTTPClient: server.Client(), AllowHTTP: true,
+		Adapters: []Adapter{
+			fixtureAdapter{id: IDZashboard, name: "Zashboard", build: "v1.0.0", asset: server.URL + "/v1.zip"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := service.Install(context.Background(), IDZashboard, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := service.Activate(context.Background(), IDZashboard); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(paths.WebRoot, IDZashboard, "v1.0.0", "stale.txt")
+	if err := os.WriteFile(marker, []byte("stale"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	prepared, err := service.PrepareReinstall(context.Background(), IDZashboard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer prepared.Cleanup()
+	if !prepared.Valid() {
+		t.Fatal("prepared reinstall candidate is not valid")
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("reinstall mutated existing tree during prepare: %v", err)
+	}
+	active, err := service.Active()
+	if err != nil || active.Panel != IDZashboard || active.Build != "v1.0.0" {
+		t.Fatalf("active changed during prepare: %#v err=%v", active, err)
+	}
+
+	if err := prepared.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("stale marker survived reinstall commit: %v", err)
+	}
+	active, err = service.Active()
+	if err != nil || active.Panel != IDZashboard || active.Build != "v1.0.0" {
+		t.Fatalf("active not restored after reinstall commit: %#v err=%v", active, err)
+	}
+	prepared.Cleanup()
+	entries, err := os.ReadDir(paths.PanelStaging)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("staging entries after reinstall cleanup=%v", entries)
+	}
+}
+
 func TestServiceUninstallUnknownPanel(t *testing.T) {
 	paths, server, _, _ := panelFixture(t)
 	defer server.Close()

--- a/internal/platform/paths_test.go
+++ b/internal/platform/paths_test.go
@@ -126,3 +126,34 @@ func TestAbsoluteDataRootResolvesRelativeAndAbsolute(t *testing.T) {
 		t.Fatalf("got=%q want=%q", got, wantAbs)
 	}
 }
+
+func TestEnsureDirsCreatesDurableLayout(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "ensure-root")
+	paths := NewPaths(root)
+	if err := paths.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{
+		paths.Root,
+		paths.Bin,
+		filepath.Dir(paths.RuntimeConfig),
+		filepath.Dir(paths.Log),
+		paths.Staging,
+		paths.Subscriptions,
+		paths.SubscriptionCache,
+		paths.SubscriptionStaging,
+		filepath.Dir(paths.TUIPreferences),
+		filepath.Dir(paths.GeoIPCountry),
+		paths.GeoIPStaging,
+		paths.WebRoot,
+		paths.PanelStaging,
+	} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("missing %s: %v", path, err)
+		}
+		if !info.IsDir() {
+			t.Fatalf("%s is not a directory", path)
+		}
+	}
+}

--- a/internal/platform/relaunch_unix.go
+++ b/internal/platform/relaunch_unix.go
@@ -8,12 +8,15 @@ import (
 	"syscall"
 )
 
+// execProcess replaces the current process and is replaced in tests to avoid real exec.
+var execProcess = syscall.Exec
+
 // Relaunch replaces the current process with the updated Mihari binary.
 func Relaunch(binary string, args, env []string) error {
 	if strings.TrimSpace(binary) == "" || len(args) == 0 {
 		return fmt.Errorf("relaunch Mihari: binary and arguments are required")
 	}
-	if err := syscall.Exec(binary, args, env); err != nil {
+	if err := execProcess(binary, args, env); err != nil {
 		return fmt.Errorf("exec updated Mihari: %w", err)
 	}
 	return nil

--- a/internal/platform/relaunch_unix_test.go
+++ b/internal/platform/relaunch_unix_test.go
@@ -1,0 +1,57 @@
+//go:build unix
+
+package platform
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRelaunchRequiresBinaryAndArgs(t *testing.T) {
+	prev := execProcess
+	t.Cleanup(func() { execProcess = prev })
+	execProcess = func(string, []string, []string) error {
+		t.Fatal("execProcess should not run for invalid input")
+		return nil
+	}
+
+	if err := Relaunch("", []string{"mihari"}, nil); err == nil || !strings.Contains(err.Error(), "required") {
+		t.Fatalf("empty binary err=%v", err)
+	}
+	if err := Relaunch("/usr/local/bin/mihari", nil, nil); err == nil || !strings.Contains(err.Error(), "required") {
+		t.Fatalf("empty args err=%v", err)
+	}
+}
+
+func TestRelaunchExecPassesBinaryArgsAndEnv(t *testing.T) {
+	prev := execProcess
+	t.Cleanup(func() { execProcess = prev })
+
+	var (
+		gotBinary string
+		gotArgs   []string
+		gotEnv    []string
+	)
+	execProcess = func(argv0 string, argv []string, envv []string) error {
+		gotBinary = argv0
+		gotArgs = append([]string(nil), argv...)
+		gotEnv = append([]string(nil), envv...)
+		return errors.New("injected exec failure")
+	}
+
+	env := []string{"MIHARI_DATA=/tmp/mihari", "PATH=/usr/bin"}
+	err := Relaunch("/opt/mihari/mihari", []string{"/opt/mihari/mihari", "daemon"}, env)
+	if err == nil || !strings.Contains(err.Error(), "exec updated Mihari") {
+		t.Fatalf("err=%v", err)
+	}
+	if gotBinary != "/opt/mihari/mihari" {
+		t.Fatalf("binary=%q", gotBinary)
+	}
+	if len(gotArgs) != 2 || gotArgs[1] != "daemon" {
+		t.Fatalf("args=%v", gotArgs)
+	}
+	if len(gotEnv) != 2 || gotEnv[0] != env[0] {
+		t.Fatalf("env=%v", gotEnv)
+	}
+}

--- a/internal/platform/relaunch_windows.go
+++ b/internal/platform/relaunch_windows.go
@@ -8,12 +8,15 @@ import (
 	"strings"
 )
 
+// startProcess starts a process and is replaced in tests to avoid spawning binaries.
+var startProcess = os.StartProcess
+
 // Relaunch starts the replacement Mihari binary attached to the current console.
 func Relaunch(binary string, args, env []string) error {
 	if strings.TrimSpace(binary) == "" || len(args) == 0 {
 		return fmt.Errorf("relaunch Mihari: binary and arguments are required")
 	}
-	process, err := os.StartProcess(binary, args, &os.ProcAttr{
+	process, err := startProcess(binary, args, &os.ProcAttr{
 		Env:   env,
 		Files: []*os.File{os.Stdin, os.Stdout, os.Stderr},
 	})

--- a/internal/platform/relaunch_windows_test.go
+++ b/internal/platform/relaunch_windows_test.go
@@ -1,0 +1,67 @@
+//go:build windows
+
+package platform
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestRelaunchRequiresBinaryAndArgs(t *testing.T) {
+	prev := startProcess
+	t.Cleanup(func() { startProcess = prev })
+	startProcess = func(string, []string, *os.ProcAttr) (*os.Process, error) {
+		t.Fatal("startProcess should not run for invalid input")
+		return nil, nil
+	}
+
+	if err := Relaunch("", []string{"mihari"}, nil); err == nil || !strings.Contains(err.Error(), "required") {
+		t.Fatalf("empty binary err=%v", err)
+	}
+	if err := Relaunch("C:\\mihari.exe", nil, nil); err == nil || !strings.Contains(err.Error(), "required") {
+		t.Fatalf("empty args err=%v", err)
+	}
+}
+
+func TestRelaunchStartsWithConsoleInheritedFiles(t *testing.T) {
+	prev := startProcess
+	t.Cleanup(func() { startProcess = prev })
+
+	var (
+		gotName string
+		gotArgs []string
+		gotAttr *os.ProcAttr
+	)
+	startProcess = func(name string, argv []string, attr *os.ProcAttr) (*os.Process, error) {
+		gotName = name
+		gotArgs = append([]string(nil), argv...)
+		gotAttr = attr
+		// Process with Pid 0 cannot Release successfully on Windows; return a
+		// synthetic error path is not needed because we only inspect attr construction.
+		// Returning an error after capturing args proves no real process spawn.
+		return nil, errors.New("injected start failure")
+	}
+
+	env := []string{"MIHARI_DATA=C:\\data", "PATH=C:\\Windows"}
+	err := Relaunch(`C:\Program Files\mihari\mihari.exe`, []string{`C:\Program Files\mihari\mihari.exe`, "daemon"}, env)
+	if err == nil || !strings.Contains(err.Error(), "start updated Mihari") {
+		t.Fatalf("err=%v", err)
+	}
+	if gotName != `C:\Program Files\mihari\mihari.exe` {
+		t.Fatalf("name=%q", gotName)
+	}
+	if len(gotArgs) != 2 || gotArgs[1] != "daemon" {
+		t.Fatalf("args=%v", gotArgs)
+	}
+	if gotAttr == nil {
+		t.Fatal("missing ProcAttr")
+	}
+	if len(gotAttr.Env) != 2 || gotAttr.Env[0] != env[0] {
+		t.Fatalf("env=%v", gotAttr.Env)
+	}
+	if len(gotAttr.Files) != 3 || gotAttr.Files[0] != os.Stdin || gotAttr.Files[1] != os.Stdout || gotAttr.Files[2] != os.Stderr {
+		t.Fatalf("files=%v want stdin/stdout/stderr inheritance", gotAttr.Files)
+	}
+}

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -481,7 +481,7 @@ func (m *Manager) SelectProxy(ctx context.Context, operation Operation, group, n
 		if m.controller == nil {
 			return nil, protocol.APIError{Code: protocol.CodeInvalidState, Message: "mihomo controller is unavailable"}
 		}
-		if err := m.withMaintenance(ctx, func() error { return m.controller.SelectProxy(ctx, group, name) }); err != nil {
+		if err := m.withControllerMutation(ctx, operation, func() error { return m.controller.SelectProxy(ctx, group, name) }); err != nil {
 			return nil, err
 		}
 		return struct{}{}, nil
@@ -494,7 +494,7 @@ func (m *Manager) CloseConnection(ctx context.Context, operation Operation, id s
 		if m.controller == nil {
 			return nil, protocol.APIError{Code: protocol.CodeInvalidState, Message: "mihomo controller is unavailable"}
 		}
-		if err := m.withMaintenance(ctx, func() error { return m.controller.CloseConnection(ctx, id) }); err != nil {
+		if err := m.withControllerMutation(ctx, operation, func() error { return m.controller.CloseConnection(ctx, id) }); err != nil {
 			return nil, err
 		}
 		return struct{}{}, nil
@@ -507,12 +507,41 @@ func (m *Manager) CloseAllConnections(ctx context.Context, operation Operation) 
 		if m.controller == nil {
 			return nil, protocol.APIError{Code: protocol.CodeInvalidState, Message: "mihomo controller is unavailable"}
 		}
-		if err := m.withMaintenance(ctx, func() error { return m.controller.CloseAllConnections(ctx) }); err != nil {
+		if err := m.withControllerMutation(ctx, operation, func() error { return m.controller.CloseAllConnections(ctx) }); err != nil {
 			return nil, err
 		}
 		return struct{}{}, nil
 	})
 	return err
+}
+
+func (m *Manager) withControllerMutation(ctx context.Context, operation Operation, mutation func() error) error {
+	return m.withMaintenance(ctx, func() error {
+		if operation.IfRevision != nil {
+			current := m.store.Load().Revision
+			if *operation.IfRevision != current {
+				return protocol.APIError{
+					Code:    protocol.CodeRevisionConflict,
+					Message: "state revision changed",
+					Details: map[string]any{
+						"expected_revision": *operation.IfRevision,
+						"current_revision":  current,
+					},
+				}
+			}
+		}
+		if err := mutation(); err != nil {
+			return err
+		}
+		_, err := m.coordinator.Do(ctx, state.CommandMeta{
+			ID:         operation.ID,
+			Source:     operation.Source,
+			IfRevision: operation.IfRevision,
+		}, func(snapshot state.Snapshot) (state.Snapshot, error) {
+			return snapshot, nil
+		})
+		return err
+	})
 }
 
 func (m *Manager) withMaintenance(ctx context.Context, operation func() error) error {

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -252,17 +253,14 @@ func TestInstallCommitAndRestartCannotOverlap(t *testing.T) {
 func TestRuntimeMutationWaitsForRestart(t *testing.T) {
 	restartEntered := make(chan struct{})
 	releaseRestart := make(chan struct{})
-	selectCalled := make(chan struct{})
+	selectEntered := make(chan struct{}, 1)
 	manager := newTestManager(Options{
 		Supervisor: &fakeSupervisor{restart: func(context.Context) error {
 			close(restartEntered)
 			<-releaseRestart
 			return nil
 		}},
-		Controller: &fakeController{selectProxy: func(context.Context, string, string) error {
-			close(selectCalled)
-			return nil
-		}},
+		Controller: &fakeController{entered: selectEntered},
 	})
 	restartDone := make(chan error, 1)
 	go func() { restartDone <- manager.Restart(context.Background(), Operation{ID: "restart", Source: "test"}) }()
@@ -271,21 +269,245 @@ func TestRuntimeMutationWaitsForRestart(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatal("restart did not begin")
 	}
+	mutationCtx := &doneObservedContext{Context: context.Background(), observed: make(chan struct{})}
 	selectDone := make(chan error, 1)
 	go func() {
-		selectDone <- manager.SelectProxy(context.Background(), Operation{ID: "select", Source: "test"}, "GLOBAL", "DIRECT")
+		selectDone <- manager.SelectProxy(mutationCtx, Operation{ID: "select", Source: "test"}, "GLOBAL", "DIRECT")
 	}()
 	select {
-	case <-selectCalled:
+	case <-mutationCtx.observed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("proxy selection did not wait on the maintenance gate")
+	}
+	select {
+	case <-selectEntered:
 		t.Fatal("proxy selection overlapped restart")
-	case <-time.After(30 * time.Millisecond):
+	default:
 	}
 	close(releaseRestart)
 	if err := <-restartDone; err != nil {
 		t.Fatal(err)
 	}
+	select {
+	case <-selectEntered:
+	case <-time.After(3 * time.Second):
+		t.Fatal("proxy selection did not enter controller after restart")
+	}
 	if err := <-selectDone; err != nil {
 		t.Fatal(err)
+	}
+}
+
+type doneObservedContext struct {
+	context.Context
+	once     sync.Once
+	observed chan struct{}
+}
+
+func (c *doneObservedContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.observed) })
+	return c.Context.Done()
+}
+
+type controllerMutationContextKey struct{}
+
+func TestControllerMutationsCommitRevisionAndPropagateErrors(t *testing.T) {
+	controllerErr := errors.New("controller mutation failed")
+	tests := []struct {
+		name     string
+		kind     string
+		wantArgs []string
+		setError func(*fakeController, error)
+		invoke   func(context.Context, *Manager, Operation) error
+	}{
+		{
+			name:     "select proxy",
+			kind:     "select",
+			wantArgs: []string{"GLOBAL", "DIRECT"},
+			setError: func(controller *fakeController, err error) { controller.selectProxyErr = err },
+			invoke: func(ctx context.Context, manager *Manager, operation Operation) error {
+				return manager.SelectProxy(ctx, operation, "GLOBAL", "DIRECT")
+			},
+		},
+		{
+			name:     "close connection",
+			kind:     "close",
+			wantArgs: []string{"connection-1"},
+			setError: func(controller *fakeController, err error) { controller.closeConnectionErr = err },
+			invoke: func(ctx context.Context, manager *Manager, operation Operation) error {
+				return manager.CloseConnection(ctx, operation, "connection-1")
+			},
+		},
+		{
+			name:     "close all connections",
+			kind:     "close-all",
+			wantArgs: nil,
+			setError: func(controller *fakeController, err error) { controller.closeAllConnectionsErr = err },
+			invoke: func(ctx context.Context, manager *Manager, operation Operation) error {
+				return manager.CloseAllConnections(ctx, operation)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name+" success", func(t *testing.T) {
+			controller := &fakeController{}
+			manager := newTestManager(Options{Controller: controller})
+			ctx := context.WithValue(context.Background(), controllerMutationContextKey{}, test.name)
+
+			if err := test.invoke(ctx, manager, Operation{ID: "success", Source: "test"}); err != nil {
+				t.Fatal(err)
+			}
+			if revision := manager.Snapshot().Revision; revision != 1 {
+				t.Fatalf("revision=%d want=1", revision)
+			}
+			requireControllerCall(t, controller, test.kind, ctx, test.wantArgs)
+		})
+
+		t.Run(test.name+" error", func(t *testing.T) {
+			controller := &fakeController{}
+			test.setError(controller, controllerErr)
+			manager := newTestManager(Options{Controller: controller})
+			ctx := context.WithValue(context.Background(), controllerMutationContextKey{}, test.name)
+
+			err := test.invoke(ctx, manager, Operation{ID: "error", Source: "test"})
+			if !errors.Is(err, controllerErr) {
+				t.Fatalf("err=%v want controller error", err)
+			}
+			if revision := manager.Snapshot().Revision; revision != 0 {
+				t.Fatalf("revision=%d want=0", revision)
+			}
+			requireControllerCall(t, controller, test.kind, ctx, test.wantArgs)
+		})
+	}
+}
+
+func TestControllerMutationsRunControllerIOOutsideCoordinatorLock(t *testing.T) {
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	controller := &fakeController{entered: entered, release: release}
+	manager := newTestManager(Options{Controller: controller})
+	current := uint64(0)
+	mutationDone := make(chan error, 1)
+	go func() {
+		mutationDone <- manager.SelectProxy(context.Background(), Operation{
+			ID: "select-with-concurrent-state", Source: "test", IfRevision: &current,
+		}, "GLOBAL", "DIRECT")
+	}()
+	select {
+	case <-entered:
+	case <-time.After(3 * time.Second):
+		t.Fatal("controller mutation did not begin")
+	}
+
+	coordinatorStarted := make(chan struct{})
+	coordinatorDone := make(chan error, 1)
+	go func() {
+		close(coordinatorStarted)
+		_, err := manager.coordinator.Do(context.Background(), state.CommandMeta{Source: "concurrent-test"}, func(snapshot state.Snapshot) (state.Snapshot, error) {
+			return snapshot, nil
+		})
+		coordinatorDone <- err
+	}()
+	<-coordinatorStarted
+	select {
+	case err := <-coordinatorDone:
+		if err != nil {
+			close(release)
+			<-mutationDone
+			t.Fatalf("concurrent coordinator mutation: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		close(release)
+		<-mutationDone
+		<-coordinatorDone
+		t.Fatal("coordinator mutation remained blocked while controller I/O was in progress")
+	}
+
+	close(release)
+	err := <-mutationDone
+	var apiError protocol.APIError
+	if !errors.As(err, &apiError) || apiError.Code != protocol.CodeRevisionConflict {
+		t.Fatalf("err=%v want revision conflict", err)
+	}
+	if revision := manager.Snapshot().Revision; revision != 1 {
+		t.Fatalf("revision=%d want=1", revision)
+	}
+}
+
+func TestControllerMutationsRejectStaleRevisionBeforeControllerIO(t *testing.T) {
+	controller := &fakeController{}
+	manager := newTestManager(Options{Controller: controller})
+	manager.store.Store(state.Snapshot{Revision: 2})
+	stale := uint64(1)
+
+	err := manager.CloseAllConnections(context.Background(), Operation{
+		ID: "stale-close-all", Source: "test", IfRevision: &stale,
+	})
+	var apiError protocol.APIError
+	if !errors.As(err, &apiError) || apiError.Code != protocol.CodeRevisionConflict {
+		t.Fatalf("err=%v want revision conflict", err)
+	}
+	if calls := controller.callsFor("close-all"); len(calls) != 0 {
+		t.Fatalf("close-all calls=%d want=0", len(calls))
+	}
+	if revision := manager.Snapshot().Revision; revision != 2 {
+		t.Fatalf("revision=%d want=2", revision)
+	}
+}
+
+func TestControllerMutationsDeduplicateConcurrentOperationID(t *testing.T) {
+	entered := make(chan struct{}, 2)
+	release := make(chan struct{})
+	controller := &fakeController{entered: entered, release: release}
+	manager := newTestManager(Options{Controller: controller})
+	operation := Operation{ID: "same-select", Source: "test"}
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- manager.SelectProxy(context.Background(), operation, "GLOBAL", "DIRECT")
+	}()
+	select {
+	case <-entered:
+	case <-time.After(3 * time.Second):
+		t.Fatal("controller mutation did not begin")
+	}
+
+	secondCtx := &doneObservedContext{Context: context.Background(), observed: make(chan struct{})}
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- manager.SelectProxy(secondCtx, operation, "GLOBAL", "DIRECT")
+	}()
+	select {
+	case <-secondCtx.observed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("duplicate mutation did not enter existing-operation wait")
+	}
+	close(release)
+	if err := <-firstDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-secondDone; err != nil {
+		t.Fatal(err)
+	}
+	if calls := controller.callsFor("select"); len(calls) != 1 {
+		t.Fatalf("select calls=%d want=1", len(calls))
+	}
+	if revision := manager.Snapshot().Revision; revision != 1 {
+		t.Fatalf("revision=%d want=1", revision)
+	}
+}
+
+func requireControllerCall(t *testing.T, controller *fakeController, kind string, wantContext context.Context, wantArgs []string) {
+	t.Helper()
+	calls := controller.callsFor(kind)
+	if len(calls) != 1 {
+		t.Fatalf("%s calls=%d want=1", kind, len(calls))
+	}
+	if calls[0].ctx != wantContext {
+		t.Fatalf("%s context was not propagated", kind)
+	}
+	if !reflect.DeepEqual(calls[0].args, wantArgs) {
+		t.Fatalf("%s args=%v want=%v", kind, calls[0].args, wantArgs)
 	}
 }
 
@@ -599,13 +821,50 @@ func (s *fakeSupervisor) Restart(ctx context.Context) error {
 }
 
 type fakeController struct {
-	selectProxy        func(context.Context, string, string) error
-	updateRuleProvider func(context.Context, string) error
-	configs            map[string]any
-	configsErr         error
-	patchConfigs       func(context.Context, map[string]any) error
-	lastPatch          map[string]any
-	patchCalls         int
+	mu                     sync.Mutex
+	calls                  []controllerCall
+	entered                chan<- struct{}
+	release                <-chan struct{}
+	selectProxy            func(context.Context, string, string) error
+	selectProxyErr         error
+	closeConnectionErr     error
+	closeAllConnectionsErr error
+	updateRuleProvider     func(context.Context, string) error
+	configs                map[string]any
+	configsErr             error
+	patchConfigs           func(context.Context, map[string]any) error
+	lastPatch              map[string]any
+	patchCalls             int
+}
+
+type controllerCall struct {
+	kind string
+	ctx  context.Context
+	args []string
+}
+
+func (c *fakeController) recordCall(kind string, ctx context.Context, args ...string) {
+	c.mu.Lock()
+	c.calls = append(c.calls, controllerCall{kind: kind, ctx: ctx, args: append([]string(nil), args...)})
+	c.mu.Unlock()
+	if c.entered != nil {
+		c.entered <- struct{}{}
+	}
+	if c.release != nil {
+		<-c.release
+	}
+}
+
+func (c *fakeController) callsFor(kind string) []controllerCall {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var calls []controllerCall
+	for _, call := range c.calls {
+		if call.kind == kind {
+			calls = append(calls, call)
+		}
+	}
+	return calls
 }
 
 func (c *fakeController) Proxies(context.Context) (mihomo.Proxies, error) {
@@ -613,10 +872,11 @@ func (c *fakeController) Proxies(context.Context) (mihomo.Proxies, error) {
 }
 
 func (c *fakeController) SelectProxy(ctx context.Context, group, name string) error {
+	c.recordCall("select", ctx, group, name)
 	if c.selectProxy != nil {
 		return c.selectProxy(ctx, group, name)
 	}
-	return nil
+	return c.selectProxyErr
 }
 
 func (c *fakeController) DelayGroup(context.Context, string, string, int) (mihomo.Delays, error) {
@@ -631,9 +891,15 @@ func (c *fakeController) Connections(context.Context) (mihomo.Connections, error
 	return mihomo.Connections{}, nil
 }
 
-func (c *fakeController) CloseConnection(context.Context, string) error { return nil }
+func (c *fakeController) CloseConnection(ctx context.Context, id string) error {
+	c.recordCall("close", ctx, id)
+	return c.closeConnectionErr
+}
 
-func (c *fakeController) CloseAllConnections(context.Context) error { return nil }
+func (c *fakeController) CloseAllConnections(ctx context.Context) error {
+	c.recordCall("close-all", ctx)
+	return c.closeAllConnectionsErr
+}
 
 func (c *fakeController) Rules(context.Context) (mihomo.Rules, error) {
 	return mihomo.Rules{}, nil

--- a/internal/runtime/panel.go
+++ b/internal/runtime/panel.go
@@ -15,11 +15,11 @@ type PanelService interface {
 	ActiveDir() (string, error)
 	PanelDir(panelID string) (string, error)
 	Install(ctx context.Context, panelID, pinBuild string) error
-	Update(ctx context.Context, panelID string) error
+	PrepareUpdate(ctx context.Context, panelID string) (panel.PreparedMutation, error)
 	Activate(ctx context.Context, panelID string) error
 	Rollback(ctx context.Context, panelID string) error
 	Uninstall(ctx context.Context, panelID string) error
-	Reinstall(ctx context.Context, panelID string) error
+	PrepareReinstall(ctx context.Context, panelID string) (panel.PreparedMutation, error)
 	SetupPath(gatewayHost string) string
 	SetupPathFor(panelID, gatewayHost string) string
 }
@@ -71,9 +71,15 @@ func (m *Manager) UpdatePanel(ctx context.Context, operation Operation, panelID 
 		if m.panels == nil {
 			return nil, protocol.APIError{Code: protocol.CodeInvalidState, Message: "panel service is unavailable"}
 		}
-		if err := m.panels.Update(ctx, panelID); err != nil {
+		if err := m.preflightPanelMutation(ctx, operation); err != nil {
 			return nil, err
 		}
+		candidate, err := m.panels.PrepareUpdate(ctx, panelID)
+		if err != nil {
+			return nil, err
+		}
+		defer candidate.Cleanup()
+		identity := candidate.Identity()
 		if err := m.lock(ctx); err != nil {
 			return nil, err
 		}
@@ -81,7 +87,16 @@ func (m *Manager) UpdatePanel(ctx context.Context, operation Operation, panelID 
 		if err := m.checkOpen(); err != nil {
 			return nil, err
 		}
-		_, err := m.coordinator.Do(ctx, state.CommandMeta{ID: operation.ID, Source: operation.Source, IfRevision: operation.IfRevision}, func(snapshot state.Snapshot) (state.Snapshot, error) {
+		if identity == "" || candidate.Identity() != identity || !candidate.Valid() {
+			return nil, protocol.APIError{Code: protocol.CodeDataFailure, Message: "panel update candidate changed before commit"}
+		}
+		_, err = m.coordinator.Do(ctx, state.CommandMeta{ID: operation.ID, Source: operation.Source, IfRevision: operation.IfRevision}, func(snapshot state.Snapshot) (state.Snapshot, error) {
+			if candidate.Identity() != identity || !candidate.Valid() {
+				return snapshot, protocol.APIError{Code: protocol.CodeDataFailure, Message: "panel update candidate changed before commit"}
+			}
+			if err := candidate.Commit(); err != nil {
+				return snapshot, err
+			}
 			return snapshot, nil
 		})
 		return struct{}{}, err
@@ -168,10 +183,15 @@ func (m *Manager) ReinstallPanel(ctx context.Context, operation Operation, panel
 		if m.panels == nil {
 			return nil, protocol.APIError{Code: protocol.CodeInvalidState, Message: "panel service is unavailable"}
 		}
-		// Full reinstall owns download; run under the operation path then publish revision.
-		if err := m.panels.Reinstall(ctx, panelID); err != nil {
+		if err := m.preflightPanelMutation(ctx, operation); err != nil {
 			return nil, err
 		}
+		candidate, err := m.panels.PrepareReinstall(ctx, panelID)
+		if err != nil {
+			return nil, err
+		}
+		defer candidate.Cleanup()
+		identity := candidate.Identity()
 		if err := m.lock(ctx); err != nil {
 			return nil, err
 		}
@@ -179,10 +199,39 @@ func (m *Manager) ReinstallPanel(ctx context.Context, operation Operation, panel
 		if err := m.checkOpen(); err != nil {
 			return nil, err
 		}
-		_, err := m.coordinator.Do(ctx, state.CommandMeta{ID: operation.ID, Source: operation.Source, IfRevision: operation.IfRevision}, func(snapshot state.Snapshot) (state.Snapshot, error) {
+		if identity == "" || candidate.Identity() != identity || !candidate.Valid() {
+			return nil, protocol.APIError{Code: protocol.CodeDataFailure, Message: "panel reinstall candidate changed before commit"}
+		}
+		_, err = m.coordinator.Do(ctx, state.CommandMeta{ID: operation.ID, Source: operation.Source, IfRevision: operation.IfRevision}, func(snapshot state.Snapshot) (state.Snapshot, error) {
+			if candidate.Identity() != identity || !candidate.Valid() {
+				return snapshot, protocol.APIError{Code: protocol.CodeDataFailure, Message: "panel reinstall candidate changed before commit"}
+			}
+			if err := candidate.Commit(); err != nil {
+				return snapshot, err
+			}
 			return snapshot, nil
 		})
 		return struct{}{}, err
 	})
 	return err
+}
+
+func (m *Manager) preflightPanelMutation(ctx context.Context, operation Operation) error {
+	return m.withMaintenance(ctx, func() error {
+		if operation.IfRevision == nil {
+			return nil
+		}
+		current := m.store.Load().Revision
+		if *operation.IfRevision == current {
+			return nil
+		}
+		return protocol.APIError{
+			Code:    protocol.CodeRevisionConflict,
+			Message: "state revision changed",
+			Details: map[string]any{
+				"expected_revision": *operation.IfRevision,
+				"current_revision":  current,
+			},
+		}
+	})
 }

--- a/internal/runtime/panel_test.go
+++ b/internal/runtime/panel_test.go
@@ -13,13 +13,20 @@ import (
 )
 
 type fakePanels struct {
-	mu       sync.Mutex
-	active   panel.Active
-	list     []panel.PanelInfo
-	install  func(ctx context.Context, id, pin string) error
-	update   func(ctx context.Context, id string) error
-	activate func(ctx context.Context, id string) error
-	rollback func(ctx context.Context, id string) error
+	mu              sync.Mutex
+	active          panel.Active
+	list            []panel.PanelInfo
+	install         func(ctx context.Context, id, pin string) error
+	update          func(ctx context.Context, id string) error
+	activate        func(ctx context.Context, id string) error
+	rollback        func(ctx context.Context, id string) error
+	uninstall       func(ctx context.Context, id string) error
+	reinstall       func(ctx context.Context, id string) error
+	updateCommit    func() error
+	reinstallCommit func() error
+	updateCalls     []string
+	uninstallCalls  []string
+	reinstallCalls  []string
 }
 
 func (f *fakePanels) List() []panel.PanelInfo {
@@ -50,11 +57,18 @@ func (f *fakePanels) Install(ctx context.Context, id, pin string) error {
 	}
 	return nil
 }
-func (f *fakePanels) Update(ctx context.Context, id string) error {
-	if f.update != nil {
-		return f.update(ctx, id)
+func (f *fakePanels) PrepareUpdate(ctx context.Context, id string) (panel.PreparedMutation, error) {
+	f.mu.Lock()
+	f.updateCalls = append(f.updateCalls, id)
+	update := f.update
+	commit := f.updateCommit
+	f.mu.Unlock()
+	if update != nil {
+		if err := update(ctx, id); err != nil {
+			return nil, err
+		}
 	}
-	return nil
+	return &fakePreparedPanelMutation{commit: commit}, nil
 }
 func (f *fakePanels) Activate(ctx context.Context, id string) error {
 	if f.activate != nil {
@@ -73,17 +87,91 @@ func (f *fakePanels) Rollback(ctx context.Context, id string) error {
 }
 func (f *fakePanels) Uninstall(ctx context.Context, id string) error {
 	f.mu.Lock()
-	defer f.mu.Unlock()
+	f.uninstallCalls = append(f.uninstallCalls, id)
+	uninstall := f.uninstall
+	if uninstall != nil {
+		f.mu.Unlock()
+		return uninstall(ctx, id)
+	}
 	if f.active.Panel == id {
 		f.active = panel.Active{}
 	}
+	f.mu.Unlock()
 	return nil
 }
-func (f *fakePanels) Reinstall(ctx context.Context, id string) error {
+func (f *fakePanels) PrepareReinstall(ctx context.Context, id string) (panel.PreparedMutation, error) {
+	f.mu.Lock()
+	f.reinstallCalls = append(f.reinstallCalls, id)
+	reinstall := f.reinstall
+	commit := f.reinstallCommit
+	if reinstall != nil {
+		f.mu.Unlock()
+		if err := reinstall(ctx, id); err != nil {
+			return nil, err
+		}
+		return &fakePreparedPanelMutation{commit: commit}, nil
+	}
+	f.mu.Unlock()
+	return &fakePreparedPanelMutation{commit: commit}, nil
+}
+
+type fakePreparedPanelMutation struct {
+	mu        sync.Mutex
+	commit    func() error
+	committed bool
+	cleaned   bool
+}
+
+func (p *fakePreparedPanelMutation) Valid() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return !p.cleaned
+}
+
+func (p *fakePreparedPanelMutation) Identity() string { return "fake-panel-candidate" }
+
+func (p *fakePreparedPanelMutation) Commit() error {
+	p.mu.Lock()
+	if p.committed {
+		p.mu.Unlock()
+		return nil
+	}
+	if p.cleaned {
+		p.mu.Unlock()
+		return errors.New("prepared panel candidate was cleaned")
+	}
+	commit := p.commit
+	p.mu.Unlock()
+	if commit != nil {
+		if err := commit(); err != nil {
+			return err
+		}
+	}
+	p.mu.Lock()
+	p.committed = true
+	p.mu.Unlock()
+	return nil
+}
+
+func (p *fakePreparedPanelMutation) Cleanup() {
+	p.mu.Lock()
+	p.cleaned = true
+	p.mu.Unlock()
+}
+
+func (f *fakePanels) mutationCallCount(name string) int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.active = panel.Active{Panel: id, Build: "v1"}
-	return nil
+	switch name {
+	case "update":
+		return len(f.updateCalls)
+	case "uninstall":
+		return len(f.uninstallCalls)
+	case "reinstall":
+		return len(f.reinstallCalls)
+	default:
+		return 0
+	}
 }
 
 func TestActivatePanelCommitsThroughCoordinator(t *testing.T) {
@@ -148,5 +236,245 @@ func TestRollbackPanelRejectsStaleRevision(t *testing.T) {
 	}
 	if panels.active.Panel != "" {
 		t.Fatal("stale rollback mutated panel state")
+	}
+}
+
+type panelMutationTest struct {
+	name    string
+	setHook func(*fakePanels, func(context.Context, string) error)
+	invoke  func(*Manager, context.Context, Operation) error
+}
+
+func TestUpdatePanelCoordinatesRevisionAndServiceFailures(t *testing.T) {
+	testPanelMutationSymmetry(t, panelMutationTest{
+		name: "update",
+		setHook: func(panels *fakePanels, hook func(context.Context, string) error) {
+			panels.update = hook
+		},
+		invoke: func(manager *Manager, ctx context.Context, operation Operation) error {
+			return manager.UpdatePanel(ctx, operation, panel.IDZashboard)
+		},
+	})
+}
+
+func TestUninstallPanelCoordinatesRevisionAndServiceFailures(t *testing.T) {
+	testPanelMutationSymmetry(t, panelMutationTest{
+		name: "uninstall",
+		setHook: func(panels *fakePanels, hook func(context.Context, string) error) {
+			panels.uninstall = hook
+		},
+		invoke: func(manager *Manager, ctx context.Context, operation Operation) error {
+			return manager.UninstallPanel(ctx, operation, panel.IDZashboard)
+		},
+	})
+}
+
+func TestReinstallPanelCoordinatesRevisionAndServiceFailures(t *testing.T) {
+	testPanelMutationSymmetry(t, panelMutationTest{
+		name: "reinstall",
+		setHook: func(panels *fakePanels, hook func(context.Context, string) error) {
+			panels.reinstall = hook
+		},
+		invoke: func(manager *Manager, ctx context.Context, operation Operation) error {
+			return manager.ReinstallPanel(ctx, operation, panel.IDZashboard)
+		},
+	})
+}
+
+func testPanelMutationSymmetry(t *testing.T, mutation panelMutationTest) {
+	t.Helper()
+	serviceErr := errors.New("panel service failed")
+	stale := uint64(6)
+	tests := []struct {
+		name         string
+		ifRevision   *uint64
+		serviceErr   error
+		wantRevision uint64
+		wantCalls    int
+		wantConflict bool
+	}{
+		{name: "success publishes revision", wantRevision: 8, wantCalls: 1},
+		{name: "stale revision skips service", ifRevision: &stale, wantRevision: 7, wantCalls: 0, wantConflict: true},
+		{name: "service error does not publish revision", serviceErr: serviceErr, wantRevision: 7, wantCalls: 1},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			panels := &fakePanels{}
+			mutation.setHook(panels, func(context.Context, string) error {
+				return test.serviceErr
+			})
+			manager := newTestManager(Options{Panels: panels})
+			manager.store.Store(state.Snapshot{Revision: 7})
+
+			err := mutation.invoke(manager, context.Background(), Operation{
+				ID:         mutation.name + "-1",
+				Source:     "test",
+				IfRevision: test.ifRevision,
+			})
+			switch {
+			case test.wantConflict:
+				var apiError protocol.APIError
+				if !errors.As(err, &apiError) || apiError.Code != protocol.CodeRevisionConflict {
+					t.Fatalf("err=%v", err)
+				}
+			case test.serviceErr != nil:
+				if !errors.Is(err, serviceErr) {
+					t.Fatalf("err=%v", err)
+				}
+			case err != nil:
+				t.Fatal(err)
+			}
+			if revision := manager.Snapshot().Revision; revision != test.wantRevision {
+				t.Fatalf("revision=%d, want %d", revision, test.wantRevision)
+			}
+			if calls := panels.mutationCallCount(mutation.name); calls != test.wantCalls {
+				t.Fatalf("%s calls=%d, want %d", mutation.name, calls, test.wantCalls)
+			}
+		})
+	}
+}
+
+func TestUpdatePanelDownloadsOutsideMutationLock(t *testing.T) {
+	updateEntered := make(chan struct{})
+	releaseUpdate := make(chan struct{})
+	activateEntered := make(chan struct{})
+	panels := &fakePanels{
+		update: func(ctx context.Context, _ string) error {
+			close(updateEntered)
+			select {
+			case <-releaseUpdate:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+		activate: func(context.Context, string) error {
+			close(activateEntered)
+			return nil
+		},
+	}
+	manager := newTestManager(Options{Panels: panels})
+	updateDone := make(chan error, 1)
+	go func() {
+		updateDone <- manager.UpdatePanel(context.Background(), Operation{ID: "update-outside-lock", Source: "test"}, panel.IDZashboard)
+	}()
+	select {
+	case <-updateEntered:
+	case err := <-updateDone:
+		t.Fatalf("update returned before download entered: %v", err)
+	}
+
+	activateCtx, cancelActivate := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancelActivate()
+	activateDone := make(chan error, 1)
+	go func() {
+		activateDone <- manager.ActivatePanel(activateCtx, Operation{ID: "activate-during-update", Source: "test"}, panel.IDZashboard)
+	}()
+	select {
+	case <-activateEntered:
+	case err := <-activateDone:
+		close(releaseUpdate)
+		t.Fatalf("activate could not enter while update download was blocked: %v", err)
+	}
+	if err := <-activateDone; err != nil {
+		close(releaseUpdate)
+		t.Fatal(err)
+	}
+	close(releaseUpdate)
+	if err := <-updateDone; err != nil {
+		t.Fatal(err)
+	}
+	if revision := manager.Snapshot().Revision; revision != 2 {
+		t.Fatalf("revision=%d, want 2", revision)
+	}
+}
+
+func TestPreparedPanelMutationDoesNotCommitAfterConcurrentUninstall(t *testing.T) {
+	current := uint64(7)
+	tests := []struct {
+		name      string
+		setHook   func(*fakePanels, func(context.Context, string) error)
+		setCommit func(*fakePanels, func() error)
+		invoke    func(*Manager, context.Context, Operation) error
+	}{
+		{
+			name: "update",
+			setHook: func(panels *fakePanels, hook func(context.Context, string) error) {
+				panels.update = hook
+			},
+			setCommit: func(panels *fakePanels, commit func() error) {
+				panels.updateCommit = commit
+			},
+			invoke: func(manager *Manager, ctx context.Context, operation Operation) error {
+				return manager.UpdatePanel(ctx, operation, panel.IDZashboard)
+			},
+		},
+		{
+			name: "reinstall",
+			setHook: func(panels *fakePanels, hook func(context.Context, string) error) {
+				panels.reinstall = hook
+			},
+			setCommit: func(panels *fakePanels, commit func() error) {
+				panels.reinstallCommit = commit
+			},
+			invoke: func(manager *Manager, ctx context.Context, operation Operation) error {
+				return manager.ReinstallPanel(ctx, operation, panel.IDZashboard)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			serviceEntered := make(chan struct{})
+			releaseService := make(chan struct{})
+			var promoted bool
+			panels := &fakePanels{}
+			test.setHook(panels, func(ctx context.Context, _ string) error {
+				close(serviceEntered)
+				select {
+				case <-releaseService:
+					return nil
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			})
+			test.setCommit(panels, func() error {
+				promoted = true
+				return nil
+			})
+			manager := newTestManager(Options{Panels: panels})
+			manager.store.Store(state.Snapshot{Revision: current})
+			mutationDone := make(chan error, 1)
+			go func() {
+				mutationDone <- test.invoke(manager, context.Background(), Operation{
+					ID: test.name + "-concurrent-uninstall", Source: "test", IfRevision: &current,
+				})
+			}()
+			select {
+			case <-serviceEntered:
+			case err := <-mutationDone:
+				t.Fatalf("%s returned before service entered: %v", test.name, err)
+			}
+
+			if err := manager.UninstallPanel(context.Background(), Operation{
+				ID: "newer-uninstall", Source: "test",
+			}, panel.IDZashboard); err != nil {
+				close(releaseService)
+				t.Fatal(err)
+			}
+			close(releaseService)
+			err := <-mutationDone
+			var apiError protocol.APIError
+			if !errors.As(err, &apiError) || apiError.Code != protocol.CodeRevisionConflict {
+				t.Fatalf("err=%v", err)
+			}
+			if promoted {
+				t.Fatalf("stale %s promoted after the newer uninstall committed", test.name)
+			}
+			if revision := manager.Snapshot().Revision; revision != current+1 {
+				t.Fatalf("revision=%d, want %d", revision, current+1)
+			}
+		})
 	}
 }

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -258,6 +258,34 @@ func TestMapServiceErrorStartTimeout(t *testing.T) {
 	}
 }
 
+func TestMapServiceErrorPermissionAndMarkedForDeletion(t *testing.T) {
+	err := mapServiceError(errors.New("Access is denied."))
+	var api protocol.APIError
+	if !errors.As(err, &api) || api.Code != protocol.CodePermissionDenied {
+		t.Fatalf("permission err=%v", err)
+	}
+
+	err = mapServiceError(errors.New("The specified service has been marked for deletion. (1072)"))
+	if !errors.As(err, &api) || api.Code != protocol.CodeInvalidState {
+		t.Fatalf("marked-for-deletion err=%v", err)
+	}
+	if !strings.Contains(strings.ToLower(api.Message), "marked for deletion") {
+		t.Fatalf("message=%q", api.Message)
+	}
+}
+
+func TestIsIgnorableStopError(t *testing.T) {
+	if !isIgnorableStopError(errors.New("service has not been started")) {
+		t.Fatal("expected not-started to be ignorable")
+	}
+	if !isIgnorableStopError(errors.New("service mihari is not installed")) {
+		t.Fatal("expected not-installed to be ignorable")
+	}
+	if isIgnorableStopError(errors.New("access is denied")) {
+		t.Fatal("permission errors must not be ignored")
+	}
+}
+
 func TestInstallEnvVarsPinsAbsoluteMIHARI_DATA(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "service-data")
 	t.Setenv("MIHARI_DATA", root)

--- a/internal/subscription/document_test.go
+++ b/internal/subscription/document_test.go
@@ -39,3 +39,35 @@ func TestParseDocumentRejectsInvalidNonClashAndMultipleDocuments(t *testing.T) {
 		})
 	}
 }
+
+func FuzzParseDocument(f *testing.F) {
+	seeds := []string{
+		"",
+		"proxies: []\n",
+		"proxy-providers: {}\n",
+		"proxies:\n  - {name: one, type: ss, server: 127.0.0.1, port: 443, cipher: aes-128-gcm, password: x}\n",
+		"proxies: not-a-list\n",
+		"hello: world\n",
+		"proxies: []\n---\nproxies: []\n",
+		"proxies: &a []\nextra: *a\n",
+		"proxies: [" + string(make([]byte, 256)) + "]\n",
+		"!unknown tag\n",
+	}
+	for _, seed := range seeds {
+		f.Add([]byte(seed))
+	}
+	f.Fuzz(func(t *testing.T, input []byte) {
+		document, err := ParseDocument(input)
+		if err == nil && document == nil {
+			t.Fatal("nil document without error")
+		}
+		if err != nil {
+			return
+		}
+		_, proxies := document["proxies"]
+		_, providers := document["proxy-providers"]
+		if !proxies && !providers {
+			t.Fatal("accepted non-subscription document")
+		}
+	})
+}

--- a/internal/subscription/userinfo_test.go
+++ b/internal/subscription/userinfo_test.go
@@ -20,3 +20,35 @@ func TestParseUserInfo(t *testing.T) {
 		t.Fatal("garbage should fail")
 	}
 }
+
+func FuzzParseUserInfo(f *testing.F) {
+	seeds := []string{
+		"",
+		"upload=100; download=200; total=1000; expire=1710000000",
+		"Upload = 1 ; Download = 2",
+		"upload=1; upload=2; download=3",
+		"upload=-1; download=5",
+		"upload=9223372036854775807; download=1",
+		"upload=999999999999999999999",
+		"garbage;;;=;;",
+		"unknown=7; total=9",
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, raw string) {
+		info, ok := ParseUserInfo(raw)
+		if !ok {
+			if info != (UserInfo{}) {
+				t.Fatalf("ok=false with non-zero info: %#v", info)
+			}
+			return
+		}
+		if info.Upload < 0 || info.Download < 0 || info.Total < 0 || info.Expire < 0 {
+			t.Fatalf("negative field: %#v", info)
+		}
+		if info.Used() < 0 {
+			t.Fatalf("Used() negative: %d", info.Used())
+		}
+	})
+}

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -166,6 +166,140 @@ func TestSupervisorStableRuntimeResetsBackoff(t *testing.T) {
 	}
 }
 
+func TestSupervisorStopsChildAfterTerminate(t *testing.T) {
+	starter := newFakeStarter()
+	supervisor := New(Options{
+		Starter:     starter,
+		Waiter:      realWaiter{},
+		Now:         time.Now,
+		StopTimeout: time.Second,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- supervisor.Run(ctx) }()
+
+	child := starter.next(t)
+	cancel()
+	if err := waitDone(t, done); err != nil {
+		t.Fatal(err)
+	}
+	if got := child.terminateCallsCount(); got != 1 {
+		t.Fatalf("terminate calls=%d, want 1", got)
+	}
+	if got := child.killCallsCount(); got != 0 {
+		t.Fatalf("kill calls=%d, want 0", got)
+	}
+	select {
+	case <-child.terminated:
+	default:
+		t.Fatal("terminate was not observed")
+	}
+}
+
+func TestSupervisorKillsChildAfterGraceTimeout(t *testing.T) {
+	starter := newFakeStarter()
+	supervisor := New(Options{
+		Starter:     starter,
+		Waiter:      realWaiter{},
+		Now:         time.Now,
+		StopTimeout: 40 * time.Millisecond,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- supervisor.Run(ctx) }()
+
+	child := starter.next(t)
+	child.setHangOnTerminate(true)
+	cancel()
+	if err := waitDone(t, done); err != nil {
+		t.Fatal(err)
+	}
+	if got := child.terminateCallsCount(); got != 1 {
+		t.Fatalf("terminate calls=%d, want 1", got)
+	}
+	if got := child.killCallsCount(); got != 1 {
+		t.Fatalf("kill calls=%d, want 1", got)
+	}
+	select {
+	case <-child.killed:
+	default:
+		t.Fatal("kill was not observed")
+	}
+}
+
+func TestSupervisorPropagatesKillError(t *testing.T) {
+	starter := newFakeStarter()
+	killErr := errors.New("force kill failed")
+	supervisor := New(Options{
+		Starter:     starter,
+		Waiter:      realWaiter{},
+		Now:         time.Now,
+		StopTimeout: 40 * time.Millisecond,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- supervisor.Run(ctx) }()
+
+	child := starter.next(t)
+	child.setHangOnTerminate(true)
+	child.setKillError(killErr)
+
+	restarted := make(chan error, 1)
+	go func() { restarted <- supervisor.Restart(context.Background()) }()
+	select {
+	case err := <-restarted:
+		if !errors.Is(err, killErr) {
+			t.Fatalf("restart error=%v, want %v", err, killErr)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("restart did not return")
+	}
+
+	// After a failed kill, Wait may remain blocked; cancel must still stop the outer loop.
+	cancel()
+	if err := waitDone(t, done); err != nil {
+		t.Fatal(err)
+	}
+	if got := child.killCallsCount(); got != 1 {
+		t.Fatalf("kill calls=%d, want 1", got)
+	}
+}
+
+func TestSupervisorCancellationWaitsForChildCleanup(t *testing.T) {
+	starter := newFakeStarter()
+	supervisor := New(Options{
+		Starter:     starter,
+		Waiter:      realWaiter{},
+		Now:         time.Now,
+		StopTimeout: 40 * time.Millisecond,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- supervisor.Run(ctx) }()
+
+	child := starter.next(t)
+	// Delay Wait completion until after Kill so cancellation must wait for the full stop path.
+	child.setHangOnTerminate(true)
+	releaseKill := make(chan struct{})
+	child.setKillHook(func() {
+		<-releaseKill
+	})
+
+	cancel()
+	select {
+	case <-done:
+		t.Fatal("supervisor returned before child cleanup finished")
+	case <-time.After(80 * time.Millisecond):
+	}
+	close(releaseKill)
+	if err := waitDone(t, done); err != nil {
+		t.Fatal(err)
+	}
+	if got := child.killCallsCount(); got != 1 {
+		t.Fatalf("kill calls=%d, want 1", got)
+	}
+}
+
 type fakeStarter struct {
 	started chan *fakeChild
 	nextPID atomic.Int64
@@ -180,6 +314,7 @@ func (s *fakeStarter) Start() (Child, error) {
 		pid:        int(s.nextPID.Add(1)),
 		done:       make(chan error, 1),
 		terminated: make(chan struct{}),
+		killed:     make(chan struct{}),
 	}
 	s.started <- child
 	return child, nil
@@ -200,7 +335,18 @@ type fakeChild struct {
 	pid        int
 	done       chan error
 	terminated chan struct{}
+	killed     chan struct{}
 	exitOnce   sync.Once
+	termOnce   sync.Once
+	killOnce   sync.Once
+
+	mu              sync.Mutex
+	hangOnTerminate bool
+	terminateErr    error
+	killErr         error
+	killHook        func()
+	terminateCalls  int
+	killCalls       int
 }
 
 func (c *fakeChild) PID() int { return c.pid }
@@ -208,17 +354,73 @@ func (c *fakeChild) PID() int { return c.pid }
 func (c *fakeChild) Wait() error { return <-c.done }
 
 func (c *fakeChild) Terminate() error {
+	c.mu.Lock()
+	c.terminateCalls++
+	err := c.terminateErr
+	hang := c.hangOnTerminate
+	c.mu.Unlock()
+
+	c.termOnce.Do(func() { close(c.terminated) })
+	if !hang {
+		c.exitOnce.Do(func() {
+			c.done <- errors.New("terminated by supervisor")
+		})
+	}
+	return err
+}
+
+func (c *fakeChild) Kill() error {
+	c.mu.Lock()
+	c.killCalls++
+	err := c.killErr
+	hook := c.killHook
+	c.mu.Unlock()
+
+	c.killOnce.Do(func() { close(c.killed) })
+	if hook != nil {
+		hook()
+	}
+	if err != nil {
+		return err
+	}
 	c.exitOnce.Do(func() {
-		close(c.terminated)
-		c.done <- errors.New("terminated by supervisor")
+		c.done <- errors.New("killed by supervisor")
 	})
 	return nil
 }
 
-func (c *fakeChild) Kill() error { return c.Terminate() }
-
 func (c *fakeChild) exit(err error) {
 	c.exitOnce.Do(func() { c.done <- err })
+}
+
+func (c *fakeChild) setHangOnTerminate(hang bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.hangOnTerminate = hang
+}
+
+func (c *fakeChild) setKillError(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.killErr = err
+}
+
+func (c *fakeChild) setKillHook(hook func()) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.killHook = hook
+}
+
+func (c *fakeChild) terminateCallsCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.terminateCalls
+}
+
+func (c *fakeChild) killCallsCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.killCalls
 }
 
 type waitRequest struct {

--- a/internal/sysproxy/sysproxy_test.go
+++ b/internal/sysproxy/sysproxy_test.go
@@ -72,6 +72,25 @@ func TestEnable_RejectsInvalidPort(t *testing.T) {
 	}
 }
 
+func TestNormalizeEnableArgsDefaultsBlankHost(t *testing.T) {
+	t.Parallel()
+
+	host, port, err := normalizeEnableArgs("  ", 9190)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if host != "127.0.0.1" || port != 9190 {
+		t.Fatalf("host=%q port=%d", host, port)
+	}
+	host, port, err = normalizeEnableArgs("proxy.local", 8080)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if host != "proxy.local" || port != 8080 {
+		t.Fatalf("host=%q port=%d", host, port)
+	}
+}
+
 func TestClassifyOwnedForeign(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -46,6 +46,12 @@ type Mutator interface {
 	ApplyConfigPatch(ctx context.Context, patch map[string]any) error
 }
 
+type webSocketRelayObserver interface {
+	relayStarted()
+	relayFinished()
+	handlerFinished()
+}
+
 // Server is the loopback Web gateway: auth, static panel hosting, and API proxy.
 type Server struct {
 	Addr             string
@@ -60,6 +66,7 @@ type Server struct {
 	listener   net.Listener
 	httpServer *http.Server
 	sessions   atomic.Int64
+	wsObserver webSocketRelayObserver
 	mu         sync.Mutex
 	serving    bool
 }
@@ -683,23 +690,54 @@ func (s *Server) proxyWebSocket(w http.ResponseWriter, r *http.Request) {
 	}
 	defer client.CloseNow()
 
-	errc := make(chan error, 2)
-	copyWS := func(dst, src *websocket.Conn) {
+	observer := s.wsObserver
+	if observer != nil {
+		observer.relayStarted()
+		observer.relayStarted()
+		defer observer.handlerFinished()
+	}
+	relayCtx, cancelRelay := context.WithCancel(r.Context())
+	defer cancelRelay()
+	type relayResult struct {
+		peer *websocket.Conn
+		err  error
+	}
+	results := make(chan relayResult, 2)
+	copyWS := func(dst, src *websocket.Conn) error {
 		for {
-			msgType, data, err := src.Read(r.Context())
+			msgType, data, err := src.Read(relayCtx)
 			if err != nil {
-				errc <- err
-				return
+				return err
 			}
-			if err := dst.Write(r.Context(), msgType, data); err != nil {
-				errc <- err
-				return
+			if err := dst.Write(relayCtx, msgType, data); err != nil {
+				return err
 			}
 		}
 	}
-	go copyWS(upstream, client)
-	go copyWS(client, upstream)
-	<-errc
+	runCopy := func(dst, src *websocket.Conn) {
+		err := copyWS(dst, src)
+		if observer != nil {
+			observer.relayFinished()
+		}
+		results <- relayResult{peer: dst, err: err}
+	}
+	go runCopy(upstream, client)
+	go runCopy(client, upstream)
+	first := <-results
+	cancelRelay()
+	closeWebSocketRelayPeer(first.peer, first.err)
+	upstream.CloseNow()
+	client.CloseNow()
+	<-results
+}
+
+func closeWebSocketRelayPeer(peer *websocket.Conn, relayErr error) {
+	status := websocket.CloseStatus(relayErr)
+	if status == websocket.StatusNormalClosure || status == websocket.StatusGoingAway {
+		_ = peer.Close(status, "")
+		return
+	}
+	peer.CloseNow()
 }
 
 func (s *Server) writeLogin(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1,16 +1,24 @@
 package web
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"io"
+	"net"
 	"net/http"
+	"net/http/cookiejar"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/coder/websocket"
 )
 
 // recordingMutator captures ApplyConfigPatch calls for allowlist tests.
@@ -80,6 +88,778 @@ func (m memoryPanel) SetupPathFor(panelID, host string) string {
 		}
 	}
 	return "/__mihari/panels/" + panelID + "/#/setup?hostname=" + host
+}
+
+func newWebSocketController(t *testing.T, wantSecret, forbiddenWebCredential, responseHeaderSentinel string) *httptest.Server {
+	t.Helper()
+
+	type observedFrame struct {
+		messageType websocket.MessageType
+		data        []byte
+	}
+	var observed struct {
+		sync.Mutex
+		requests int
+		path     string
+		rawQuery string
+		headers  http.Header
+		frames   []observedFrame
+		errors   []string
+	}
+	handlerDone := make(chan struct{})
+	var handlerDoneOnce sync.Once
+
+	controller := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer handlerDoneOnce.Do(func() { close(handlerDone) })
+
+		observed.Lock()
+		observed.requests++
+		observed.path = r.URL.Path
+		observed.rawQuery = r.URL.RawQuery
+		observed.headers = r.Header.Clone()
+		observed.Unlock()
+
+		w.Header().Set("X-Upstream-Response-Sentinel", responseHeaderSentinel)
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			observed.Lock()
+			observed.errors = append(observed.errors, "accept: "+err.Error())
+			observed.Unlock()
+			return
+		}
+		defer conn.CloseNow()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		for range 2 {
+			messageType, data, err := conn.Read(ctx)
+			if err != nil {
+				observed.Lock()
+				observed.errors = append(observed.errors, "read: "+err.Error())
+				observed.Unlock()
+				return
+			}
+			observed.Lock()
+			observed.frames = append(observed.frames, observedFrame{
+				messageType: messageType,
+				data:        append([]byte(nil), data...),
+			})
+			observed.Unlock()
+			if err := conn.Write(ctx, messageType, data); err != nil {
+				observed.Lock()
+				observed.errors = append(observed.errors, "write: "+err.Error())
+				observed.Unlock()
+				return
+			}
+		}
+	}))
+
+	t.Cleanup(func() {
+		controller.CloseClientConnections()
+		controller.Close()
+
+		timer := time.NewTimer(3 * time.Second)
+		defer timer.Stop()
+		select {
+		case <-handlerDone:
+		case <-timer.C:
+			t.Error("WebSocket controller handler did not stop")
+		}
+
+		observed.Lock()
+		defer observed.Unlock()
+		if observed.requests != 1 {
+			t.Errorf("controller requests = %d, want 1", observed.requests)
+		}
+		if observed.path != "/connections" {
+			t.Errorf("controller path = %q, want /connections", observed.path)
+		}
+		if observed.rawQuery != "scope=active&format=full" {
+			t.Errorf("controller query = %q, want scope=active&format=full", observed.rawQuery)
+		}
+		if observed.headers.Get("Authorization") != "Bearer "+wantSecret {
+			t.Errorf("controller authorization was not the injected controller secret")
+		}
+		if cookie := observed.headers.Get("Cookie"); cookie != "" {
+			t.Errorf("controller received browser cookie %q", cookie)
+		}
+		for name, values := range observed.headers {
+			joined := strings.Join(values, "\n")
+			if strings.Contains(joined, forbiddenWebCredential) {
+				t.Errorf("controller header %q leaked browser web credential", name)
+			}
+			if !strings.EqualFold(name, "Authorization") && strings.Contains(joined, wantSecret) {
+				t.Errorf("controller header %q leaked controller secret outside Authorization", name)
+			}
+		}
+		if len(observed.errors) != 0 {
+			t.Errorf("controller relay errors: %v", observed.errors)
+		}
+
+		wantFrames := []observedFrame{
+			{messageType: websocket.MessageText, data: []byte(`{"command":"ping"}`)},
+			{messageType: websocket.MessageBinary, data: []byte{0x00, 0x7f, 0x80, 0xff}},
+		}
+		if len(observed.frames) != len(wantFrames) {
+			t.Errorf("controller frames = %d, want %d", len(observed.frames), len(wantFrames))
+			return
+		}
+		for i, want := range wantFrames {
+			got := observed.frames[i]
+			if got.messageType != want.messageType {
+				t.Errorf("controller frame %d type = %v, want %v", i, got.messageType, want.messageType)
+			}
+			if !bytes.Equal(got.data, want.data) {
+				t.Errorf("controller frame %d data = %v, want %v", i, got.data, want.data)
+			}
+		}
+	})
+
+	return controller
+}
+
+type gatewayServeState struct {
+	done chan struct{}
+	err  error
+}
+
+func waitGatewayServeReady(t *testing.T, gateway *Server, serveState *gatewayServeState) string {
+	t.Helper()
+
+	deadline := time.NewTimer(2 * time.Second)
+	defer deadline.Stop()
+	retry := time.NewTicker(10 * time.Millisecond)
+	defer retry.Stop()
+
+	probe := func() string {
+		addr := gateway.ListenAddr()
+		if addr == "" || addr == "127.0.0.1:0" {
+			return ""
+		}
+		probeCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		conn, err := (&net.Dialer{}).DialContext(probeCtx, "tcp", addr)
+		if err != nil {
+			return ""
+		}
+		if err := conn.Close(); err != nil {
+			t.Errorf("close gateway readiness probe: %v", err)
+		}
+		return "http://" + addr
+	}
+
+	for {
+		if base := probe(); base != "" {
+			return base
+		}
+		select {
+		case <-serveState.done:
+			t.Fatalf("gateway stopped before becoming ready: %v", serveState.err)
+		case <-retry.C:
+		case <-deadline.C:
+			t.Fatal("gateway did not become network-ready")
+		}
+	}
+}
+
+const (
+	task5WebCredential    = "web-token-task5-aaaaaaaaaaaaaaaaaaaaaaaaaa"
+	task5ControllerSecret = "controller-secret-task5-bbbbbbbbbbbbbbbbb"
+)
+
+type task5RoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f task5RoundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+type task5ControllerState struct {
+	started         chan struct{}
+	accepted        chan struct{}
+	done            chan struct{}
+	relayErr        error
+	relayContextErr error
+	cancel          context.CancelFunc
+}
+
+type webSocketRelayJoinObserver struct {
+	active        atomic.Int32
+	handlerResult chan int32
+}
+
+func newWebSocketRelayJoinObserver() *webSocketRelayJoinObserver {
+	return &webSocketRelayJoinObserver{handlerResult: make(chan int32, 1)}
+}
+
+func (o *webSocketRelayJoinObserver) relayStarted() {
+	o.active.Add(1)
+}
+
+func (o *webSocketRelayJoinObserver) relayFinished() {
+	o.active.Add(-1)
+}
+
+func (o *webSocketRelayJoinObserver) handlerFinished() {
+	o.handlerResult <- o.active.Load()
+}
+
+func newTask5WebSocketController(
+	t *testing.T,
+	relay func(context.Context, *websocket.Conn) error,
+) (*httptest.Server, *task5ControllerState) {
+	t.Helper()
+
+	controllerCtx, cancelController := context.WithCancel(context.Background())
+	state := &task5ControllerState{
+		started:  make(chan struct{}),
+		accepted: make(chan struct{}),
+		done:     make(chan struct{}),
+		cancel:   cancelController,
+	}
+	controller := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(state.started)
+		defer close(state.done)
+
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			state.relayErr = err
+			return
+		}
+		defer conn.CloseNow()
+		close(state.accepted)
+
+		relayCtx, cancelRelay := context.WithTimeout(controllerCtx, 3*time.Second)
+		defer cancelRelay()
+		state.relayErr = relay(relayCtx, conn)
+		state.relayContextErr = relayCtx.Err()
+	}))
+	t.Cleanup(controller.Close)
+	t.Cleanup(func() {
+		state.cancel()
+		controller.CloseClientConnections()
+		select {
+		case <-state.started:
+			waitDone(t, state.done, "WebSocket controller handler")
+		default:
+		}
+	})
+	return controller, state
+}
+
+func newTask5Gateway(t *testing.T, controllerURL string, transport http.RoundTripper) *Server {
+	t.Helper()
+
+	gateway, err := New(Options{
+		Addr:             "127.0.0.1:0",
+		Auth:             Authenticator{WebCredential: task5WebCredential, ControllerSecret: task5ControllerSecret},
+		ControllerURL:    controllerURL,
+		ControllerSecret: task5ControllerSecret,
+		Transport:        transport,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return gateway
+}
+
+func serveWebSocketGateway(t *testing.T, gateway *Server) string {
+	t.Helper()
+
+	gatewayCtx, cancelGateway := context.WithCancel(context.Background())
+	serveState := &gatewayServeState{done: make(chan struct{})}
+	go func() {
+		serveState.err = gateway.Serve(gatewayCtx)
+		close(serveState.done)
+	}()
+	t.Cleanup(func() {
+		cancelGateway()
+		waitDone(t, serveState.done, "gateway")
+		if serveState.err != nil {
+			t.Errorf("serve gateway: %v", serveState.err)
+		}
+	})
+	return waitGatewayServeReady(t, gateway, serveState)
+}
+
+func dialTask5GatewayStream(t *testing.T, base string) *websocket.Conn {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	header := http.Header{}
+	header.Set("Authorization", "Bearer "+task5WebCredential)
+	stream, response, err := websocket.Dial(
+		ctx,
+		"ws"+strings.TrimPrefix(base, "http")+"/connections?scope=active",
+		&websocket.DialOptions{HTTPHeader: header},
+	)
+	if err != nil {
+		t.Fatalf("dial gateway WebSocket: %v", err)
+	}
+	if response == nil || response.StatusCode != http.StatusSwitchingProtocols {
+		stream.CloseNow()
+		t.Fatalf("gateway handshake response = %v", response)
+	}
+	t.Cleanup(func() { stream.CloseNow() })
+	return stream
+}
+
+func waitDone(t *testing.T, done <-chan struct{}, label string) {
+	t.Helper()
+
+	timer := time.NewTimer(3 * time.Second)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return
+	case <-timer.C:
+		select {
+		case <-done:
+			return
+		default:
+			t.Fatalf("%s did not stop before its deadline", label)
+		}
+	}
+}
+
+func requireTask5NotDone(t *testing.T, done <-chan struct{}, label string) {
+	t.Helper()
+
+	select {
+	case <-done:
+		t.Fatalf("%s stopped before the shutdown trigger", label)
+	default:
+	}
+}
+
+func requireTask5PeerClose(t *testing.T, state *task5ControllerState) {
+	t.Helper()
+
+	if state.relayContextErr != nil {
+		t.Fatalf("controller relay ended from its context instead of its peer: %v", state.relayContextErr)
+	}
+	if state.relayErr == nil {
+		t.Fatal("controller relay returned no peer-close error")
+	}
+}
+
+func waitTask5SessionCount(t *testing.T, gateway *Server, want int) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if got := gateway.SessionCount(); got == want {
+			return
+		}
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			t.Fatalf("gateway session count = %d, want %d: %v", gateway.SessionCount(), want, ctx.Err())
+		}
+	}
+}
+
+func TestGatewayWebSocketHandlerWaitsForBothRelaysAfterNormalClose(t *testing.T) {
+	closeUpstream := make(chan struct{})
+	controller, controllerState := newTask5WebSocketController(t, func(ctx context.Context, conn *websocket.Conn) error {
+		select {
+		case <-closeUpstream:
+			return conn.Close(websocket.StatusNormalClosure, "")
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	})
+	observer := newWebSocketRelayJoinObserver()
+	gateway := newTask5Gateway(t, controller.URL, nil)
+	gateway.wsObserver = observer
+	base := serveWebSocketGateway(t, gateway)
+	stream := dialTask5GatewayStream(t, base)
+	waitDone(t, controllerState.accepted, "upstream WebSocket acceptance")
+
+	readCtx, cancelRead := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancelRead()
+	readErr := make(chan error, 1)
+	go func() {
+		_, _, err := stream.Read(readCtx)
+		readErr <- err
+	}()
+	close(closeUpstream)
+
+	var activeAtHandlerFinish int32
+	select {
+	case activeAtHandlerFinish = <-observer.handlerResult:
+	case <-readCtx.Done():
+		t.Fatalf("gateway WebSocket handler did not finish: %v", readCtx.Err())
+	}
+	if activeAtHandlerFinish != 0 {
+		t.Fatalf("gateway WebSocket handler finished with %d relay copier still running; want 0", activeAtHandlerFinish)
+	}
+
+	select {
+	case err := <-readErr:
+		if err == nil {
+			t.Fatal("browser WebSocket remained open after normal upstream close")
+		}
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			t.Fatalf("browser read ended from its context instead of upstream close: %v", err)
+		}
+	case <-readCtx.Done():
+		t.Fatalf("browser did not receive graceful close: %v", readCtx.Err())
+	}
+	waitDone(t, controllerState.done, "normal upstream close")
+	if controllerState.relayErr != nil || controllerState.relayContextErr != nil {
+		t.Fatalf("normal upstream close failed: relay=%v context=%v", controllerState.relayErr, controllerState.relayContextErr)
+	}
+}
+
+func TestGatewayWebSocketUpstreamCloseStopsRelay(t *testing.T) {
+	closeUpstream := make(chan struct{})
+	controller, controllerState := newTask5WebSocketController(t, func(ctx context.Context, conn *websocket.Conn) error {
+		select {
+		case <-closeUpstream:
+			conn.CloseNow()
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	})
+	gateway := newTask5Gateway(t, controller.URL, nil)
+	base := serveWebSocketGateway(t, gateway)
+	stream := dialTask5GatewayStream(t, base)
+	waitDone(t, controllerState.accepted, "upstream WebSocket acceptance")
+	waitTask5SessionCount(t, gateway, 1)
+	requireTask5NotDone(t, controllerState.done, "upstream WebSocket")
+
+	close(closeUpstream)
+	readCtx, cancelRead := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancelRead()
+	if _, _, err := stream.Read(readCtx); err == nil {
+		t.Fatal("browser WebSocket remained readable after upstream close")
+	}
+	if err := readCtx.Err(); err != nil {
+		t.Fatalf("browser WebSocket read ended from its deadline instead of upstream close: %v", err)
+	}
+	waitDone(t, controllerState.done, "upstream WebSocket")
+	if controllerState.relayContextErr != nil {
+		t.Fatalf("upstream WebSocket close ended from its relay context: %v", controllerState.relayContextErr)
+	}
+	if controllerState.relayErr != nil {
+		t.Fatalf("upstream WebSocket shutdown: %v", controllerState.relayErr)
+	}
+	waitTask5SessionCount(t, gateway, 0)
+}
+
+func TestGatewayWebSocketClientCloseStopsUpstream(t *testing.T) {
+	controller, controllerState := newTask5WebSocketController(t, func(ctx context.Context, conn *websocket.Conn) error {
+		_, _, err := conn.Read(ctx)
+		return err
+	})
+	gateway := newTask5Gateway(t, controller.URL, nil)
+	base := serveWebSocketGateway(t, gateway)
+	stream := dialTask5GatewayStream(t, base)
+	waitDone(t, controllerState.accepted, "upstream WebSocket acceptance")
+	waitTask5SessionCount(t, gateway, 1)
+	requireTask5NotDone(t, controllerState.done, "upstream WebSocket")
+
+	stream.CloseNow()
+	waitDone(t, controllerState.done, "upstream WebSocket")
+	requireTask5PeerClose(t, controllerState)
+	waitTask5SessionCount(t, gateway, 0)
+}
+
+func TestGatewayWebSocketContextCancelReleasesBothSides(t *testing.T) {
+	controller, controllerState := newTask5WebSocketController(t, func(ctx context.Context, conn *websocket.Conn) error {
+		_, _, err := conn.Read(ctx)
+		return err
+	})
+	gateway := newTask5Gateway(t, controller.URL, nil)
+
+	requestCtx, cancelRequest := context.WithCancel(context.Background())
+	t.Cleanup(cancelRequest)
+	handlerDone := make(chan struct{})
+	originalHandler := gateway.httpServer.Handler
+	gateway.httpServer.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		originalHandler.ServeHTTP(w, r.WithContext(requestCtx))
+		close(handlerDone)
+	})
+	base := serveWebSocketGateway(t, gateway)
+	stream := dialTask5GatewayStream(t, base)
+	waitDone(t, controllerState.accepted, "upstream WebSocket acceptance")
+	waitTask5SessionCount(t, gateway, 1)
+	requireTask5NotDone(t, controllerState.done, "upstream WebSocket")
+
+	cancelRequest()
+	readCtx, cancelRead := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancelRead()
+	if _, _, err := stream.Read(readCtx); err == nil {
+		t.Fatal("browser WebSocket remained readable after relay context cancellation")
+	}
+	if err := readCtx.Err(); err != nil {
+		t.Fatalf("browser WebSocket read ended from its deadline instead of relay cancellation: %v", err)
+	}
+	waitDone(t, controllerState.done, "upstream WebSocket")
+	requireTask5PeerClose(t, controllerState)
+	waitDone(t, handlerDone, "gateway WebSocket handler")
+	waitTask5SessionCount(t, gateway, 0)
+}
+
+func TestGatewayWebSocketHandshakeFailuresAreSanitized(t *testing.T) {
+	const upstreamBody = "upstream-private-diagnostic-task5"
+	tests := []struct {
+		name             string
+		upstreamStatus   int
+		transportFailure bool
+		invalidURL       bool
+		wantStatus       int
+		wantBody         string
+	}{
+		{name: "upstream 401", upstreamStatus: http.StatusUnauthorized, wantStatus: http.StatusUnauthorized, wantBody: "upstream stream unavailable\n"},
+		{name: "upstream 500", upstreamStatus: http.StatusInternalServerError, wantStatus: http.StatusInternalServerError, wantBody: "upstream stream unavailable\n"},
+		{name: "controller unavailable", transportFailure: true, wantStatus: http.StatusBadGateway, wantBody: "upstream stream unavailable\n"},
+		{name: "invalid controller URL", invalidURL: true, wantStatus: http.StatusBadGateway, wantBody: "bad gateway\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controllerURL := "http://controller.invalid"
+			var transport http.RoundTripper
+			if tt.upstreamStatus != 0 {
+				controller := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("X-Upstream-Diagnostic", task5ControllerSecret+" "+upstreamBody)
+					w.WriteHeader(tt.upstreamStatus)
+					_, _ = io.WriteString(w, task5ControllerSecret+" "+upstreamBody)
+				}))
+				t.Cleanup(func() {
+					controller.CloseClientConnections()
+					controller.Close()
+				})
+				controllerURL = controller.URL
+			}
+			if tt.transportFailure {
+				transport = task5RoundTripFunc(func(*http.Request) (*http.Response, error) {
+					return nil, errors.New(task5ControllerSecret + " " + upstreamBody)
+				})
+			}
+
+			gateway := newTask5Gateway(t, controllerURL, transport)
+			if tt.invalidURL {
+				gateway.ControllerURL = "%"
+			}
+			base := serveWebSocketGateway(t, gateway)
+			dialCtx, cancelDial := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancelDial()
+			header := http.Header{}
+			header.Set("Authorization", "Bearer "+task5WebCredential)
+			stream, response, err := websocket.Dial(
+				dialCtx,
+				"ws"+strings.TrimPrefix(base, "http")+"/connections",
+				&websocket.DialOptions{HTTPHeader: header},
+			)
+			if stream != nil {
+				stream.CloseNow()
+				t.Fatal("gateway WebSocket handshake unexpectedly succeeded")
+			}
+			if err == nil {
+				t.Fatal("gateway WebSocket handshake returned no error")
+			}
+			if response == nil {
+				t.Fatalf("gateway WebSocket handshake returned no HTTP response: %v", err)
+			}
+			body, readErr := io.ReadAll(response.Body)
+			response.Body.Close()
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if response.StatusCode != tt.wantStatus {
+				t.Fatalf("gateway handshake status = %d, want %d", response.StatusCode, tt.wantStatus)
+			}
+			if got := string(body); got != tt.wantBody {
+				t.Fatalf("gateway handshake body = %q, want %q", got, tt.wantBody)
+			}
+			for _, sensitive := range []string{task5ControllerSecret, upstreamBody} {
+				if bytes.Contains(body, []byte(sensitive)) {
+					t.Fatalf("gateway handshake body leaked %q", sensitive)
+				}
+				if strings.Contains(err.Error(), sensitive) {
+					t.Fatalf("gateway handshake error leaked %q", sensitive)
+				}
+				for name, values := range response.Header {
+					if strings.Contains(strings.Join(values, "\n"), sensitive) {
+						t.Fatalf("gateway handshake header %q leaked %q", name, sensitive)
+					}
+				}
+			}
+			waitTask5SessionCount(t, gateway, 0)
+		})
+	}
+}
+
+func TestGatewayWebSocketRelaysBidirectionallyAndInjectsOnlyControllerSecret(t *testing.T) {
+	const webCredential = "web-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	const controllerSecret = "controller-secret-bbbbbbbbbbbbbbbbbbbbbbbb"
+	const upstreamResponseHeaderSentinel = "upstream-response-header-cccccccccccccccc"
+
+	controller := newWebSocketController(t, controllerSecret, webCredential, upstreamResponseHeaderSentinel)
+	gateway, err := New(Options{
+		Addr:             "127.0.0.1:0",
+		Auth:             Authenticator{WebCredential: webCredential, ControllerSecret: controllerSecret},
+		ControllerURL:    controller.URL,
+		ControllerSecret: controllerSecret,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	base := serveWebSocketGateway(t, gateway)
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	browser := &http.Client{
+		Jar: jar,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	t.Cleanup(browser.CloseIdleConnections)
+	streamURL := "ws" + strings.TrimPrefix(base, "http") + "/connections?scope=active&format=full"
+	unauthenticatedCtx, cancelUnauthenticated := context.WithTimeout(context.Background(), 5*time.Second)
+	unauthenticatedStream, unauthenticatedResponse, err := websocket.Dial(
+		unauthenticatedCtx,
+		streamURL,
+		&websocket.DialOptions{HTTPClient: browser},
+	)
+	cancelUnauthenticated()
+	if err == nil {
+		unauthenticatedStream.CloseNow()
+		t.Fatal("unauthenticated browser stream succeeded")
+	}
+	if unauthenticatedResponse == nil {
+		t.Fatalf("unauthenticated browser stream returned no HTTP response: %v", err)
+	}
+	unauthenticatedBody, readErr := io.ReadAll(unauthenticatedResponse.Body)
+	unauthenticatedResponse.Body.Close()
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if unauthenticatedResponse.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated stream status = %d, want %d", unauthenticatedResponse.StatusCode, http.StatusUnauthorized)
+	}
+	if bytes.Contains(unauthenticatedBody, []byte(controllerSecret)) {
+		t.Fatal("controller secret leaked in unauthenticated response body")
+	}
+	for name, values := range unauthenticatedResponse.Header {
+		if strings.Contains(strings.Join(values, "\n"), controllerSecret) {
+			t.Fatalf("controller secret leaked in unauthenticated response header %q", name)
+		}
+	}
+
+	loginValues := url.Values{
+		"password": {webCredential},
+		"next":     {"/connections?scope=active&format=full"},
+	}
+	loginCtx, cancelLogin := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancelLogin)
+	loginRequest, err := http.NewRequestWithContext(
+		loginCtx,
+		http.MethodPost,
+		base+AuthPath,
+		strings.NewReader(loginValues.Encode()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loginRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	loginResponse, err := browser.Do(loginRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loginBody, err := io.ReadAll(loginResponse.Body)
+	loginResponse.Body.Close()
+	cancelLogin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loginResponse.StatusCode != http.StatusFound {
+		t.Fatalf("login status = %d, want %d", loginResponse.StatusCode, http.StatusFound)
+	}
+	if bytes.Contains(loginBody, []byte(controllerSecret)) {
+		t.Fatal("controller secret leaked in login response body")
+	}
+	for name, values := range loginResponse.Header {
+		if strings.Contains(strings.Join(values, "\n"), controllerSecret) {
+			t.Fatalf("controller secret leaked in login response header %q", name)
+		}
+	}
+
+	baseURL, err := url.Parse(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sessionCookie *http.Cookie
+	for _, cookie := range browser.Jar.Cookies(baseURL) {
+		if cookie.Name == CookieName {
+			sessionCookie = cookie
+			break
+		}
+	}
+	if sessionCookie == nil || sessionCookie.Value != webCredential {
+		t.Fatalf("browser session cookie = %v", sessionCookie)
+	}
+
+	streamCtx, cancelStream := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancelStream)
+	stream, handshakeResponse, err := websocket.Dial(streamCtx, streamURL, &websocket.DialOptions{
+		HTTPClient: browser,
+	})
+	if err != nil {
+		t.Fatalf("dial gateway stream: %v", err)
+	}
+	t.Cleanup(func() { stream.CloseNow() })
+	if handshakeResponse == nil || handshakeResponse.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("gateway handshake response = %v", handshakeResponse)
+	}
+	if got := handshakeResponse.Header.Get("X-Upstream-Response-Sentinel"); got != "" {
+		t.Fatalf("gateway handshake exposed upstream response header sentinel %q", got)
+	}
+	for name, values := range handshakeResponse.Header {
+		if strings.Contains(strings.Join(values, "\n"), controllerSecret) {
+			t.Fatalf("controller secret leaked in gateway handshake header %q", name)
+		}
+		if strings.Contains(strings.Join(values, "\n"), upstreamResponseHeaderSentinel) {
+			t.Fatalf("upstream response header leaked through gateway handshake header %q", name)
+		}
+	}
+
+	frames := []struct {
+		messageType websocket.MessageType
+		data        []byte
+	}{
+		{messageType: websocket.MessageText, data: []byte(`{"command":"ping"}`)},
+		{messageType: websocket.MessageBinary, data: []byte{0x00, 0x7f, 0x80, 0xff}},
+	}
+	for i, frame := range frames {
+		if err := stream.Write(streamCtx, frame.messageType, frame.data); err != nil {
+			t.Fatalf("write browser frame %d: %v", i, err)
+		}
+		messageType, data, err := stream.Read(streamCtx)
+		if err != nil {
+			t.Fatalf("read browser frame %d: %v", i, err)
+		}
+		if messageType != frame.messageType {
+			t.Errorf("browser frame %d type = %v, want %v", i, messageType, frame.messageType)
+		}
+		if !bytes.Equal(data, frame.data) {
+			t.Errorf("browser frame %d data = %v, want %v", i, data, frame.data)
+		}
+		if bytes.Contains(data, []byte(controllerSecret)) {
+			t.Errorf("controller secret leaked in browser frame %d", i)
+		}
+	}
 }
 
 func TestGatewayProxiesVersionWithAuthAndRejectsUpgrade(t *testing.T) {

--- a/scripts/coverage-gate/main.go
+++ b/scripts/coverage-gate/main.go
@@ -1,0 +1,344 @@
+// Command coverage-gate reports and compares Go coverprofiles for Mihari CI.
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// criticalPackages are the design-doc load-bearing packages compared for relative regression.
+// Keep this list in code so workflow and tool share one source of truth.
+var criticalPackages = []string{
+	"github.com/mihari-proxy/mihari/internal/config",
+	"github.com/mihari-proxy/mihari/internal/control/client",
+	"github.com/mihari-proxy/mihari/internal/control/protocol",
+	"github.com/mihari-proxy/mihari/internal/control/server",
+	"github.com/mihari-proxy/mihari/internal/daemon",
+	"github.com/mihari-proxy/mihari/internal/runtime",
+	"github.com/mihari-proxy/mihari/internal/state",
+	"github.com/mihari-proxy/mihari/internal/subscription",
+	"github.com/mihari-proxy/mihari/internal/supervisor",
+	"github.com/mihari-proxy/mihari/internal/web",
+}
+
+type coverage struct {
+	Covered    uint64
+	Statements uint64
+}
+
+func (c coverage) percent() (float64, bool) {
+	if c.Statements == 0 {
+		return 0, false
+	}
+	return 100 * float64(c.Covered) / float64(c.Statements), true
+}
+
+type report struct {
+	Total    coverage
+	Packages map[string]coverage
+}
+
+type policy struct {
+	TotalDrop    float64
+	CriticalDrop float64
+	Critical     []string
+}
+
+type result struct {
+	TotalDelta    float64
+	PackageDeltas map[string]float64
+	Violations    []string
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: coverage-gate <report|compare> [flags]")
+		os.Exit(2)
+	}
+	switch os.Args[1] {
+	case "report":
+		os.Exit(runReport(os.Args[2:]))
+	case "compare":
+		os.Exit(runCompare(os.Args[2:]))
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command %q\n", os.Args[1])
+		os.Exit(2)
+	}
+}
+
+func runReport(args []string) int {
+	fs := flag.NewFlagSet("report", flag.ContinueOnError)
+	profile := fs.String("profile", "", "path to coverprofile")
+	fs.SetOutput(io.Discard)
+	if err := fs.Parse(args); err != nil || *profile == "" {
+		fmt.Fprintln(os.Stderr, "usage: coverage-gate report -profile <path>")
+		return 2
+	}
+	rep, err := loadProfile(*profile)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	fmt.Print(formatReport(rep))
+	return 0
+}
+
+func runCompare(args []string) int {
+	fs := flag.NewFlagSet("compare", flag.ContinueOnError)
+	basePath := fs.String("base", "", "base coverprofile")
+	headPath := fs.String("head", "", "head coverprofile")
+	totalDrop := fs.Float64("total-drop", 0.5, "allowed total percentage-point drop")
+	criticalDrop := fs.Float64("critical-drop", 1.0, "allowed critical package percentage-point drop")
+	fs.SetOutput(io.Discard)
+	if err := fs.Parse(args); err != nil || *basePath == "" || *headPath == "" {
+		fmt.Fprintln(os.Stderr, "usage: coverage-gate compare -base <path> -head <path> [-total-drop 0.5] [-critical-drop 1.0]")
+		return 2
+	}
+	base, err := loadProfile(*basePath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "base:", err)
+		return 1
+	}
+	head, err := loadProfile(*headPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "head:", err)
+		return 1
+	}
+	res := compare(base, head, policy{
+		TotalDrop:    *totalDrop,
+		CriticalDrop: *criticalDrop,
+		Critical:     criticalPackages,
+	})
+	fmt.Print(formatCompare(base, head, res))
+	if len(res.Violations) > 0 {
+		return 1
+	}
+	return 0
+}
+
+func loadProfile(path string) (report, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return report{}, err
+	}
+	defer f.Close()
+	return parseProfile(f)
+}
+
+func parseProfile(r io.Reader) (report, error) {
+	scanner := bufio.NewScanner(r)
+	// Coverprofiles can have long paths; raise the token limit modestly.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var (
+		modeSeen bool
+		out      = report{Packages: make(map[string]coverage)}
+	)
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "mode:") {
+			if modeSeen {
+				return report{}, fmt.Errorf("line %d: duplicate mode header", lineNo)
+			}
+			mode := strings.TrimSpace(strings.TrimPrefix(line, "mode:"))
+			if mode == "" {
+				return report{}, fmt.Errorf("line %d: empty mode header", lineNo)
+			}
+			modeSeen = true
+			continue
+		}
+		if !modeSeen {
+			return report{}, fmt.Errorf("line %d: missing mode header", lineNo)
+		}
+		// file:startLine.startCol,endLine.endCol numStmt count
+		fields := strings.Fields(line)
+		if len(fields) != 3 {
+			return report{}, fmt.Errorf("line %d: malformed block", lineNo)
+		}
+		filePart := fields[0]
+		numStmt, err := strconv.ParseUint(fields[1], 10, 64)
+		if err != nil {
+			return report{}, fmt.Errorf("line %d: invalid statement count", lineNo)
+		}
+		count, err := strconv.ParseUint(fields[2], 10, 64)
+		if err != nil {
+			return report{}, fmt.Errorf("line %d: invalid execution count", lineNo)
+		}
+		// Reject negative-looking values that parse as huge unsigned after a leading '-'.
+		if strings.HasPrefix(fields[1], "-") || strings.HasPrefix(fields[2], "-") {
+			return report{}, fmt.Errorf("line %d: negative values are not allowed", lineNo)
+		}
+		colon := strings.LastIndex(filePart, ":")
+		if colon <= 0 {
+			return report{}, fmt.Errorf("line %d: missing file:range", lineNo)
+		}
+		filePath := filePart[:colon]
+		pkg := packageOf(filePath)
+		if pkg == "" {
+			return report{}, fmt.Errorf("line %d: cannot derive package from %q", lineNo, filePath)
+		}
+		block := coverage{Statements: numStmt}
+		if count > 0 {
+			block.Covered = numStmt
+		}
+		out.Total.Statements += block.Statements
+		out.Total.Covered += block.Covered
+		cur := out.Packages[pkg]
+		cur.Statements += block.Statements
+		cur.Covered += block.Covered
+		out.Packages[pkg] = cur
+	}
+	if err := scanner.Err(); err != nil {
+		return report{}, err
+	}
+	if !modeSeen {
+		return report{}, fmt.Errorf("empty or missing coverprofile mode header")
+	}
+	return out, nil
+}
+
+func packageOf(filePath string) string {
+	// Normalize Windows separators so package identity is stable across runners.
+	normalized := strings.ReplaceAll(filePath, "\\", "/")
+	dir := path.Dir(normalized)
+	if dir == "." || dir == "/" {
+		return ""
+	}
+	return dir
+}
+
+func compare(base, head report, p policy) result {
+	res := result{PackageDeltas: make(map[string]float64)}
+	basePct, baseOK := base.Total.percent()
+	headPct, headOK := head.Total.percent()
+	if baseOK && headOK {
+		res.TotalDelta = headPct - basePct
+		if res.TotalDelta < -p.TotalDrop {
+			res.Violations = append(res.Violations,
+				fmt.Sprintf("total coverage dropped by %.2fpp (allowed %.2fpp): base=%.2f%% head=%.2f%%",
+					-res.TotalDelta, p.TotalDrop, basePct, headPct))
+		}
+	} else if baseOK && !headOK {
+		res.Violations = append(res.Violations, "head total coverage is n/a while base has statements")
+	}
+
+	seen := make(map[string]struct{})
+	for _, pkg := range p.Critical {
+		seen[pkg] = struct{}{}
+		b, bHas := base.Packages[pkg]
+		h, hHas := head.Packages[pkg]
+		switch {
+		case bHas && !hHas:
+			res.Violations = append(res.Violations, fmt.Sprintf("critical package missing in head: %s", pkg))
+			continue
+		case !bHas && hHas:
+			// New critical package in head: improvement / expansion, not a violation.
+			hp, ok := h.percent()
+			if ok {
+				res.PackageDeltas[pkg] = hp
+			}
+			continue
+		case !bHas && !hHas:
+			continue
+		}
+		bp, bOK := b.percent()
+		hp, hOK := h.percent()
+		if !bOK || !hOK {
+			if bOK && !hOK {
+				res.Violations = append(res.Violations, fmt.Sprintf("critical package %s head coverage is n/a", pkg))
+			}
+			continue
+		}
+		delta := hp - bp
+		res.PackageDeltas[pkg] = delta
+		if delta < -p.CriticalDrop {
+			res.Violations = append(res.Violations,
+				fmt.Sprintf("critical package %s dropped by %.2fpp (allowed %.2fpp): base=%.2f%% head=%.2f%%",
+					pkg, -delta, p.CriticalDrop, bp, hp))
+		}
+	}
+	// Stable violation order.
+	sort.Strings(res.Violations)
+	return res
+}
+
+func formatReport(rep report) string {
+	var b strings.Builder
+	b.WriteString("## Coverage report\n\n")
+	b.WriteString(fmt.Sprintf("- **total**: %s\n\n", formatCoverage(rep.Total)))
+	b.WriteString("| package | coverage |\n|---|---|\n")
+	for _, pkg := range criticalPackages {
+		cov, ok := rep.Packages[pkg]
+		if !ok {
+			b.WriteString(fmt.Sprintf("| `%s` | n/a |\n", shortPkg(pkg)))
+			continue
+		}
+		b.WriteString(fmt.Sprintf("| `%s` | %s |\n", shortPkg(pkg), formatCoverage(cov)))
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+func formatCompare(base, head report, res result) string {
+	var b strings.Builder
+	b.WriteString("## Coverage compare\n\n")
+	b.WriteString(fmt.Sprintf("- **base total**: %s\n", formatCoverage(base.Total)))
+	b.WriteString(fmt.Sprintf("- **head total**: %s\n", formatCoverage(head.Total)))
+	if _, ok := base.Total.percent(); ok {
+		if _, ok := head.Total.percent(); ok {
+			b.WriteString(fmt.Sprintf("- **total delta**: %+.2fpp\n", res.TotalDelta))
+		}
+	}
+	b.WriteString("\n| package | base | head | delta |\n|---|---|---|---|\n")
+	for _, pkg := range criticalPackages {
+		bc, bOK := base.Packages[pkg]
+		hc, hOK := head.Packages[pkg]
+		baseS, headS := "n/a", "n/a"
+		deltaS := "n/a"
+		if bOK {
+			baseS = formatCoverage(bc)
+		}
+		if hOK {
+			headS = formatCoverage(hc)
+		}
+		if d, ok := res.PackageDeltas[pkg]; ok && bOK && hOK {
+			deltaS = fmt.Sprintf("%+.2fpp", d)
+		}
+		b.WriteString(fmt.Sprintf("| `%s` | %s | %s | %s |\n", shortPkg(pkg), baseS, headS, deltaS))
+	}
+	if len(res.Violations) == 0 {
+		b.WriteString("\n**result**: pass\n")
+	} else {
+		b.WriteString("\n**result**: fail\n\n")
+		for _, v := range res.Violations {
+			b.WriteString(fmt.Sprintf("- %s\n", v))
+		}
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+func formatCoverage(c coverage) string {
+	pct, ok := c.percent()
+	if !ok {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.2f%% (%d/%d)", pct, c.Covered, c.Statements)
+}
+
+func shortPkg(pkg string) string {
+	const prefix = "github.com/mihari-proxy/mihari/"
+	return strings.TrimPrefix(pkg, prefix)
+}

--- a/scripts/coverage-gate/main.go
+++ b/scripts/coverage-gate/main.go
@@ -277,15 +277,15 @@ func compare(base, head report, p policy) result {
 func formatReport(rep report) string {
 	var b strings.Builder
 	b.WriteString("## Coverage report\n\n")
-	b.WriteString(fmt.Sprintf("- **total**: %s\n\n", formatCoverage(rep.Total)))
+	fmt.Fprintf(&b, "- **total**: %s\n\n", formatCoverage(rep.Total))
 	b.WriteString("| package | coverage |\n|---|---|\n")
 	for _, pkg := range criticalPackages {
 		cov, ok := rep.Packages[pkg]
 		if !ok {
-			b.WriteString(fmt.Sprintf("| `%s` | n/a |\n", shortPkg(pkg)))
+			fmt.Fprintf(&b, "| `%s` | n/a |\n", shortPkg(pkg))
 			continue
 		}
-		b.WriteString(fmt.Sprintf("| `%s` | %s |\n", shortPkg(pkg), formatCoverage(cov)))
+		fmt.Fprintf(&b, "| `%s` | %s |\n", shortPkg(pkg), formatCoverage(cov))
 	}
 	b.WriteString("\n")
 	return b.String()
@@ -294,11 +294,11 @@ func formatReport(rep report) string {
 func formatCompare(base, head report, res result) string {
 	var b strings.Builder
 	b.WriteString("## Coverage compare\n\n")
-	b.WriteString(fmt.Sprintf("- **base total**: %s\n", formatCoverage(base.Total)))
-	b.WriteString(fmt.Sprintf("- **head total**: %s\n", formatCoverage(head.Total)))
+	fmt.Fprintf(&b, "- **base total**: %s\n", formatCoverage(base.Total))
+	fmt.Fprintf(&b, "- **head total**: %s\n", formatCoverage(head.Total))
 	if _, ok := base.Total.percent(); ok {
 		if _, ok := head.Total.percent(); ok {
-			b.WriteString(fmt.Sprintf("- **total delta**: %+.2fpp\n", res.TotalDelta))
+			fmt.Fprintf(&b, "- **total delta**: %+.2fpp\n", res.TotalDelta)
 		}
 	}
 	b.WriteString("\n| package | base | head | delta |\n|---|---|---|---|\n")
@@ -316,14 +316,14 @@ func formatCompare(base, head report, res result) string {
 		if d, ok := res.PackageDeltas[pkg]; ok && bOK && hOK {
 			deltaS = fmt.Sprintf("%+.2fpp", d)
 		}
-		b.WriteString(fmt.Sprintf("| `%s` | %s | %s | %s |\n", shortPkg(pkg), baseS, headS, deltaS))
+		fmt.Fprintf(&b, "| `%s` | %s | %s | %s |\n", shortPkg(pkg), baseS, headS, deltaS)
 	}
 	if len(res.Violations) == 0 {
 		b.WriteString("\n**result**: pass\n")
 	} else {
 		b.WriteString("\n**result**: fail\n\n")
 		for _, v := range res.Violations {
-			b.WriteString(fmt.Sprintf("- %s\n", v))
+			fmt.Fprintf(&b, "- %s\n", v)
 		}
 	}
 	b.WriteString("\n")

--- a/scripts/coverage-gate/main_test.go
+++ b/scripts/coverage-gate/main_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseProfileAggregatesTotalAndCriticalPackages(t *testing.T) {
+	input := `mode: atomic
+github.com/mihari-proxy/mihari/internal/runtime/a.go:1.1,2.1 4 1
+github.com/mihari-proxy/mihari/internal/runtime/b.go:3.1,4.1 6 0
+github.com/mihari-proxy/mihari/internal/web/c.go:1.1,2.1 10 1
+`
+	got, err := parseProfile(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Total.Statements != 20 || got.Total.Covered != 14 {
+		t.Fatalf("total=%+v", got.Total)
+	}
+	rt := got.Packages["github.com/mihari-proxy/mihari/internal/runtime"]
+	if rt.Statements != 10 || rt.Covered != 4 {
+		t.Fatalf("runtime=%+v", rt)
+	}
+	web := got.Packages["github.com/mihari-proxy/mihari/internal/web"]
+	if web.Statements != 10 || web.Covered != 10 {
+		t.Fatalf("web=%+v", web)
+	}
+}
+
+func TestParseProfileAcceptsWindowsPaths(t *testing.T) {
+	input := "mode: set\n" +
+		`github.com\mihari-proxy\mihari\internal\state\store.go:1.1,2.1 3 2` + "\n"
+	got, err := parseProfile(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkg := "github.com/mihari-proxy/mihari/internal/state"
+	if _, ok := got.Packages[pkg]; !ok {
+		t.Fatalf("packages=%v", got.Packages)
+	}
+}
+
+func TestParseProfileRejectsMalformed(t *testing.T) {
+	cases := []string{
+		"",
+		"mode:\n",
+		"github.com/mihari-proxy/mihari/internal/runtime/a.go:1.1,2.1 1 1\n",
+		"mode: atomic\nmode: set\n",
+		"mode: atomic\nbadline\n",
+		"mode: atomic\ngithub.com/mihari-proxy/mihari/internal/runtime/a.go:1.1,2.1 -1 1\n",
+		"mode: atomic\ngithub.com/mihari-proxy/mihari/internal/runtime/a.go:1.1,2.1 1 x\n",
+	}
+	for _, input := range cases {
+		if _, err := parseProfile(strings.NewReader(input)); err == nil {
+			t.Fatalf("expected error for %q", input)
+		}
+	}
+}
+
+func TestParseProfileZeroStatements(t *testing.T) {
+	input := `mode: atomic
+github.com/mihari-proxy/mihari/internal/runtime/a.go:1.1,2.1 0 0
+`
+	got, err := parseProfile(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := got.Total.percent(); ok {
+		t.Fatal("expected n/a percent for zero statements")
+	}
+}
+
+func TestCompareDetectsDropsAndAllowsImprovements(t *testing.T) {
+	base := report{
+		Total: coverage{Covered: 80, Statements: 100},
+		Packages: map[string]coverage{
+			"github.com/mihari-proxy/mihari/internal/runtime": {Covered: 90, Statements: 100},
+			"github.com/mihari-proxy/mihari/internal/web":     {Covered: 50, Statements: 100},
+		},
+	}
+	// total drop 0.6pp (>0.5), runtime drop 1.5pp (>1.0), web improves, new critical package appears.
+	head := report{
+		Total: coverage{Covered: 794, Statements: 1000}, // 79.4%
+		Packages: map[string]coverage{
+			"github.com/mihari-proxy/mihari/internal/runtime": {Covered: 885, Statements: 1000}, // 88.5%
+			"github.com/mihari-proxy/mihari/internal/web":     {Covered: 700, Statements: 1000}, // 70%
+			"github.com/mihari-proxy/mihari/internal/state":   {Covered: 10, Statements: 10},
+		},
+	}
+	res := compare(base, head, policy{TotalDrop: 0.5, CriticalDrop: 1.0, Critical: criticalPackages})
+	if len(res.Violations) < 2 {
+		t.Fatalf("violations=%v", res.Violations)
+	}
+	// Improvement for web should not violate.
+	for _, v := range res.Violations {
+		if strings.Contains(v, "internal/web") {
+			t.Fatalf("unexpected web violation: %s", v)
+		}
+	}
+}
+
+func TestCompareMissingCriticalPackage(t *testing.T) {
+	base := report{
+		Total: coverage{Covered: 1, Statements: 1},
+		Packages: map[string]coverage{
+			"github.com/mihari-proxy/mihari/internal/runtime": {Covered: 1, Statements: 1},
+		},
+	}
+	head := report{
+		Total:    coverage{Covered: 1, Statements: 1},
+		Packages: map[string]coverage{},
+	}
+	res := compare(base, head, policy{TotalDrop: 0.5, CriticalDrop: 1.0, Critical: []string{"github.com/mihari-proxy/mihari/internal/runtime"}})
+	if len(res.Violations) != 1 || !strings.Contains(res.Violations[0], "missing in head") {
+		t.Fatalf("violations=%v", res.Violations)
+	}
+}
+
+func TestCompareWithinTolerancePasses(t *testing.T) {
+	base := report{Total: coverage{Covered: 800, Statements: 1000}, Packages: map[string]coverage{
+		"github.com/mihari-proxy/mihari/internal/runtime": {Covered: 900, Statements: 1000},
+	}}
+	head := report{Total: coverage{Covered: 796, Statements: 1000}, Packages: map[string]coverage{
+		"github.com/mihari-proxy/mihari/internal/runtime": {Covered: 895, Statements: 1000},
+	}}
+	res := compare(base, head, policy{TotalDrop: 0.5, CriticalDrop: 1.0, Critical: []string{"github.com/mihari-proxy/mihari/internal/runtime"}})
+	if len(res.Violations) != 0 {
+		t.Fatalf("violations=%v", res.Violations)
+	}
+}


### PR DESCRIPTION
﻿## Summary
- Complete test governance Phases A–D: control/WebSocket contract tests, mutation & platform lifecycle coverage, CI OS matrix + observe-only coverage report, and bounded fuzz targets with nightly workflow.
- Production fixes proven by tests: panel update/reinstall prepare/commit boundary (stale candidates cannot overwrite newer uninstalls), runtime controller mutation revision/IO outside coordinator lock, and minimal web mutation wiring.
- Add `scripts/coverage-gate` for profile report/compare; relative coverage gate stays observational until ≥10 successful `main` samples.

## Test plan
- [x] `go test -count=1 ./...`
- [x] `go test -count=1 -race ./...`
- [x] `go vet ./...`
- [x] Short fuzz smoke (`-fuzztime=5s`) for all four targets
- [x] Platform cross-compile of `./internal/platform` test packages (windows/linux/darwin)
- [ ] GitHub Actions: unit matrix, race, vet-format, coverage, lint, cross-build

## Notes
- Branch protection fan-in jobs: `test` (unit matrix) and existing `cross-build`.
- Coverage job uploads profile artifact only; percentage drops do not fail CI yet.
