### PR TITLE
chore: .gitignore 忽略 docs/plans/ 设计文档

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ go.work.sum
 
 .codegraph
 .playwright-mcp
+# 开发期间设计文档（中间文件，不进仓库）
+docs/plans/


### PR DESCRIPTION
## 改动
- `docs/plans/`（开发期间设计文档，中间文件，不进仓库）
- 顺带补齐 `.gitignore` 末尾换行

仅改动 `.gitignore`，不影响代码与构建。