### PR TITLE
feat(tui): 选中行改用对比色背景渲染（替代纯反白）

### DIFF
--- a/internal/tui/ui/theme.go
+++ b/internal/tui/ui/theme.go
@@ -16,6 +16,10 @@ type Theme struct {
 	ColorInfo          color.Color
 	ColorMuted         color.Color
 	ColorSurfaceBorder color.Color
+	// ColorFocusBg is the row keyboard-focus background: a desaturated dim of
+	// accent that reads as a clear block in dense lists, replacing the
+	// low-contrast Reverse(true) highlight (issue #46).
+	ColorFocusBg color.Color
 	// ColorOnSolid is the foreground for solid-background chips (Done/Failed/Pending).
 	// Dark text keeps contrast on Success/Warning/Danger fills in 256-color terminals.
 	ColorOnSolid color.Color
@@ -60,6 +64,7 @@ func DefaultTheme() Theme {
 	info := lipgloss.Color("75")
 	surfaceBorder := lipgloss.Color("240")
 	muted := lipgloss.Color("245")
+	focusBg := lipgloss.Color("60")
 	onSolid := lipgloss.Color("0")
 
 	return Theme{
@@ -70,6 +75,7 @@ func DefaultTheme() Theme {
 		ColorInfo:          info,
 		ColorMuted:         muted,
 		ColorSurfaceBorder: surfaceBorder,
+		ColorFocusBg:       focusBg,
 		ColorOnSolid:       onSolid,
 
 		Rail:         lipgloss.NewStyle().Padding(0, 1),
@@ -83,7 +89,7 @@ func DefaultTheme() Theme {
 		Button:       lipgloss.NewStyle().Padding(0, 1),
 		ButtonActive: lipgloss.NewStyle().Bold(true).Foreground(accent).Padding(0, 1),
 		RowSelected:  lipgloss.NewStyle().Bold(true).Foreground(accent),
-		RowFocus:     lipgloss.NewStyle().Reverse(true),
+		RowFocus:     lipgloss.NewStyle().Background(focusBg),
 
 		Success: lipgloss.NewStyle().Foreground(success),
 		Warning: lipgloss.NewStyle().Foreground(warning),

--- a/internal/tui/ui/theme_test.go
+++ b/internal/tui/ui/theme_test.go
@@ -17,6 +17,7 @@ func TestDefaultTheme_HasSemanticRoles(t *testing.T) {
 	assertColor(t, "ColorDanger", theme.ColorDanger, lipgloss.Color("203"))
 	assertColor(t, "ColorInfo", theme.ColorInfo, lipgloss.Color("75"))
 	assertColor(t, "ColorSurfaceBorder", theme.ColorSurfaceBorder, lipgloss.Color("240"))
+	assertColor(t, "ColorFocusBg", theme.ColorFocusBg, lipgloss.Color("60"))
 	assertColor(t, "ColorMuted", theme.ColorMuted, lipgloss.Color("245"))
 	assertColor(t, "ColorOnSolid", theme.ColorOnSolid, lipgloss.Color("0"))
 
@@ -57,13 +58,17 @@ func TestDefaultTheme_HasSemanticRoles(t *testing.T) {
 
 	// RowFocus is distinct from business RowSelected.
 	if theme.RowFocus.GetReverse() == theme.RowSelected.GetReverse() &&
+		colorsEqual(theme.RowFocus.GetBackground(), theme.RowSelected.GetBackground()) &&
 		colorsEqual(theme.RowFocus.GetForeground(), theme.RowSelected.GetForeground()) &&
 		theme.RowFocus.GetBold() == theme.RowSelected.GetBold() {
 		t.Fatal("RowFocus must be visually distinct from RowSelected")
 	}
-	if !theme.RowFocus.GetReverse() && isNoColor(theme.RowFocus.GetForeground()) && !theme.RowFocus.GetBold() {
-		t.Fatal("RowFocus should apply reverse, foreground, or bold")
+	if !theme.RowFocus.GetReverse() && isNoColor(theme.RowFocus.GetForeground()) &&
+		isNoColor(theme.RowFocus.GetBackground()) && !theme.RowFocus.GetBold() {
+		t.Fatal("RowFocus should apply reverse, foreground, background, or bold")
 	}
+	// RowFocus now fills the row background (issue #46) instead of reverse video.
+	assertStyleBG(t, "RowFocus", theme.RowFocus, theme.ColorFocusBg)
 }
 
 func assertColor(t *testing.T, name string, got, want color.Color) {
@@ -78,6 +83,14 @@ func assertStyleFG(t *testing.T, name string, style lipgloss.Style, want color.C
 	got := style.GetForeground()
 	if !colorsEqual(got, want) {
 		t.Fatalf("%s foreground: got %#v want %#v", name, got, want)
+	}
+}
+
+func assertStyleBG(t *testing.T, name string, style lipgloss.Style, want color.Color) {
+	t.Helper()
+	got := style.GetBackground()
+	if !colorsEqual(got, want) {
+		t.Fatalf("%s background: got %#v want %#v", name, got, want)
 	}
 }
 


### PR DESCRIPTION
Closes #46

## 问题

进入 logs / rules 页后，键盘焦点行（选中行）与下方一行行普通内容对比不明显——`RowFocus` 原先是 `Reverse(true)` 纯反白，反白只是默认前后景互换、不产生色块，在密集表格 / 浅色终端里和普通行的差异就是「颜色翻一下」，缺乏一眼可辨的跳跃感。

## 改动

- **`theme.go`**：新增 `ColorFocusBg` token（color `60`，accent `63` 的暗化同色系），`RowFocus` 从 `Reverse(true)` 改为 `Background(ColorFocusBg)`。
- **`theme_test.go`**：断言纳入 background 维度（`RowFocus` 与 `RowSelected` 仍可区分；「有效视觉手段」检查新增 background），并验证 `RowFocus` 实际用了 `ColorFocusBg`。
- **`ApplyFocusStyle` / 各页面渲染不变**：分段包裹机制对背景色同样生效，rules / logs / system 的 apply 代码零改动即获得新效果。

## 效果

选中行用暗紫背景填充。rules/logs 中**最宽的列**（message / payload 等纯文本段）获得连续背景，占选中行大部分视觉，光标位置一眼可辨。

## 局限 / 后续

窄彩色列（level / type 的语义色 span）暂无背景——`ApplyFocusStyle` 只包裹纯文本段，彩色 span 原样保留。要让背景**完全连续**（注入到彩色 span、并保护实心 chip 不被覆盖）需 ANSI 改写，**关联 #10**（全局 emoji/宽字符渲染）一并处理。

## 验证

- [x] `gofmt -l` clean
- [x] `go build ./...`
- [x] `go test ./internal/tui/...` 全绿（含 theme/focus_style 断言 + golden 快照；golden 因 ANSI 剥离不受颜色变化影响）
- [x] `golangci-lint run` 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)