### PR TITLE
feat: 增加 mihomo core stable/alpha 通道切换

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- System 页与 daemon 可在 stable / alpha 通道间切换 mihomo 核心（#42）
+
 ### Fixed
 
 ## [v0.4.1] - 2026-08-12

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Specifically:
 - **Web panels**: one-click install / update / activate / rollback for zashboard and MetaCubeXD, served behind a loopback Web gateway with its own access credential.
 - **System proxy & TUN**: cross-platform system proxy control and managed TUN, both daemon-owned and persisted.
 - **In-TUI Mihari updates**: the System page checks GitHub Releases on entry, shows `current · latest available` or `current · Up to date`, and—when Mihari was started with administrator/root privileges—replaces the binary and automatically enters the updated TUI.
+- **Core channel**: the System page can switch the mihomo core between `stable` and `alpha`.
 
 A single CGO-free static binary (< 15 MB) contains everything, with built-in GitHub Releases self-update and local GeoIP resolution.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -32,6 +32,7 @@ Mihari 是一款全新的、独立的 [mihomo](https://github.com/MetaCubeX/miho
 - **Web 面板**:一键安装 / 更新 / 激活 / 回滚 zashboard 与 MetaCubeXD,置于带独立访问凭据的回环 Web 网关之后。
 - **系统代理与 TUN**:跨平台的系统代理控制与托管 TUN,均由守护进程持有并持久化。
 - **TUI 内更新 Mihari**:System 页面进入时检查 GitHub Releases,显示 `当前版本 · 最新版本 available` 或 `当前版本 · Up to date`;以管理员/root 权限启动时可替换二进制并自动进入更新后的 TUI。
+- **内核通道**:System 页面可在 mihomo 的 `stable` / `alpha` 通道之间切换。
 
 单个无 CGO 的静态二进制(< 15 MB)即包含全部功能,内置 GitHub Releases 自动更新与本地 GeoIP 解析。
 

--- a/cmd/mihari/main.go
+++ b/cmd/mihari/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 
 	"github.com/mihari-proxy/mihari/internal/app"
@@ -36,7 +37,8 @@ func main() {
 		if err := paths.EnsureDirs(); err != nil {
 			return protocol.APIError{Code: protocol.CodeDataFailure, Message: "create mihari data directories"}
 		}
-		settings, created, err := config.LoadOrCreateResult(paths.Settings)
+		sidecar := filepath.Join(paths.Bin, "core-channel")
+		settings, created, err := config.LoadOrCreateWithSidecar(paths.Settings, sidecar)
 		if err != nil {
 			return err
 		}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,6 +12,16 @@ Mihari 围绕一个由守护进程持有的控制面(control plane)设计,由 CL
 - 守护进程可以安装、校验、托管、查询并重启 mihomo,同时将控制器保持在内环回。
 - 守护进程还负责订阅持久化、有界的自动刷新、校验过的配置生成、重载回滚与离线配置切换。
 - 控制面新增只读端点 `GET /v1/service/status`,返回 mihari 自身的 OS 服务注册状态(`running`/`stopped`/`not_installed`/`unknown`);`GET /v1/core` 增加可选 `localReady`/`localVersion` 字段反映本地 core 就绪。两者均为向后兼容增量,不改变现有协议字段、onboarding `Complete` 契约或持久化格式。
+- `/v1` 的 `CoreStatus`、`CoreInstallResult` 增加可选 `channel`;`MutationRequest` 增加可选 `channel` 以显式指定本次安装通道。均为向后兼容增量。
+
+## 核心安装
+
+守护进程通过同一条下载、校验、替换链路安装 mihomo,并支持 `stable` 与 `alpha` 两个通道:
+
+- `stable` 从 GitHub `/releases/latest` 取当前稳定版;`alpha` 从固定滚动 tag `Prerelease-Alpha` 取预览版。
+- 展示与协议里的 Version 永远来自 `ParseVersion(mihomo -v)`:稳定版为 semver(如 `v1.19.x`),alpha 为 `alpha-{sha}`(实测 `-v` 形如 `Mihomo Meta alpha-dd7bc4c ...`,不是 `v1.19.x`)。GitHub tag `Prerelease-Alpha` 从不作为版本显示或写入 Version。
+- 本次安装意图随请求进入安装链路;`settings.core-channel` 只在 Commit 成功后写入,表示上次成功安装的通道。切换失败或未提交时,持久化通道与界面仍为旧值。
+- all-in-one 包在 `data/bin/core-channel` 写入 sidecar(第 1 行通道,第 2 行 stamp)。安装器覆盖 sidecar,不改 `mihari.yaml`;守护进程仅在 stamp 变化时把打包通道写入 settings,避免旧 sidecar 覆盖用户后来在 System 页切换的通道。
 
 ## TUI
 
@@ -24,6 +34,7 @@ Mihari 围绕一个由守护进程持有的控制面(control plane)设计,由 CL
 - Setup 审查页汇总端口(改端口且守护进程报告需重启时标注「需重启生效」)/ core 来源与版本(本地已有/新装/安装失败)/ 订阅 / GeoIP / mihari 服务注册状态(经 `GET /v1/service/status` 拉取);跳过项如实标注。各步结果在命令闭包内回写 Model,依赖 Bubble Tea 的 cmd→channel→Update happens-before 保证。
 - System 页面通过与 `mihari service` 相同的本地服务适配器管理 OS 服务(安装/卸载/启动/停止/重启/状态);这些操作要求进程已经提权,且不经过守护进程控制协议。当守护进程通告相应能力时,System 页面显示实时的系统代理与 TUN 状态,并通过本地控制 API 切换它们(开启外部代理需要强制确认;Mihari 从不清除其他产品的代理)。
 - System 页面还在进入时以只读方式检查 Mihari 的最新 GitHub Release,并用 `当前版本 · 最新版本 available` 或 `当前版本 · Up to date` 展示结果。确认更新后,本地 updater 在控制协议之外替换 Mihari 可执行文件并尝试重启已安装服务;该写操作要求 TUI 进程已经具备管理员/root 权限,不会自动触发 UAC 或 sudo。旧 Bubble Tea 程序先退出并恢复终端,随后平台适配器从已替换的二进制自动进入新 TUI。
+- System 页面的 `Core Channel` 行可在 `stable` / `alpha` 之间切换;切换后由守护进程按新通道重装核心。版本行显示 `ParseVersion(mihomo -v)` 的身份 token,从不显示 `Prerelease-Alpha`。
 - 规则顺序从不排序;onboarding、系统、provider、订阅、面板和浏览器变更都经由守护进程变更协调器,破坏性或大范围操作需要确认。
 
 ## Web 网关

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -67,7 +67,26 @@ sh install-aio.sh        # Windows: powershell -File install-aio.ps1
 
 ---
 
-## 二、AList 网盘目录结构
+## 二、核心通道与 sidecar
+
+`scripts/build-all-in-one` 默认打包 **stable** 内核。需要预置 alpha 时传入 `--channel alpha`，bundler 从 GitHub 滚动 tag `Prerelease-Alpha` 选取标准资产（非 `-compatible` / `-v3` / `-goNNN` 变体）。
+
+无论 `--channel` 是 `stable` 还是 `alpha`，bundle 都会写入 sidecar `data/bin/core-channel`（UTF-8 文本）：
+
+```
+<stable|alpha>
+<stamp>
+```
+
+第 1 行为 `stable` 或 `alpha`；第 2 行为非空 stamp（通道 + 二进制指纹，例如 `stable-v1.19.29` 或 `alpha-e183c58`）。缺行、非法通道或 stamp 为空视为无效，守护进程忽略、不改 settings。
+
+`install-aio.sh` / `install-aio.ps1` 覆盖 `data/bin/mihomo` 时，若 bundle 带 sidecar 则一并覆盖到 `$MIHARI_DATA/bin/core-channel`，**仍不修改** `mihari.yaml`。守护进程在启动与 setup 快路径按 stamp 应用 sidecar：与已记录的 `core-channel-bundle` 相同则不改 `core-channel`（保护用户后来在 System 页切换的通道）；stamp 变化才把打包通道写入 settings。
+
+settings 新增可选字段 `core-channel` 与 `core-channel-bundle`（schema 仍为 `mihari.settings/v1`）。加载使用 `KnownFields(true)`：无这些字段的旧文件可由新 daemon 读取（空通道视为 `stable`）；**含这些字段的新 settings 文件无法被旧 daemon 加载**。
+
+---
+
+## 三、AList 网盘目录结构
 
 base_path 默认 `/mihari-release/mihari`（AList fs/API 路径，通过 GitHub 变量 `ALIST_BASE_PATH` 配置）：
 
@@ -115,7 +134,7 @@ release workflow 的 AList 步骤顺序保证用户永远拿不到半成品：
 
 ---
 
-## 三、版本保留策略
+## 四、版本保留策略
 
 `MIHARI_KEEP_VERSIONS`（GitHub 变量，默认 `5`）控制保留数量：
 
@@ -125,7 +144,7 @@ release workflow 的 AList 步骤顺序保证用户永远拿不到半成品：
 
 ---
 
-## 四、版本撤回（致命错误）
+## 五、版本撤回（致命错误）
 
 独立 workflow `.github/workflows/retract.yml` 手动触发，**彻底删除**坏版本：
 
@@ -143,7 +162,7 @@ release workflow 的 AList 步骤顺序保证用户永远拿不到半成品：
 
 ---
 
-## 五、CI 配置（前置依赖）
+## 六、CI 配置（前置依赖）
 
 AList 分发步骤在 release workflow 中以 `if: env.ALIST_URL != ''` 包裹——**未配置时跳过，不阻塞 GitHub 发布**。启用国内分发需配置：
 

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -82,7 +82,7 @@ func BuildRuntimeWithOptions(paths platform.Paths, settings config.Settings, dae
 	if info, err := os.Stat(paths.CoreBinary); err == nil && !info.IsDir() {
 		if version, err := core.DetectVersion(context.Background(), core.OSCommandRunner{}, paths.CoreBinary); err == nil {
 			snapshot := store.Load()
-			snapshot.Core = state.CoreState{Status: "stopped", Version: version}
+			snapshot.Core = state.CoreState{Status: "stopped", Version: version, Channel: settings.CoreChannel}
 			store.Store(snapshot)
 		}
 	}

--- a/internal/app/runtime_test.go
+++ b/internal/app/runtime_test.go
@@ -3,8 +3,10 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -220,6 +222,40 @@ func TestBuildRuntimeRejectsOccupiedManagedPort(t *testing.T) {
 	var apiError protocol.APIError
 	if !errors.As(err, &apiError) || apiError.Code != protocol.CodeInvalidState || apiError.Details["setting"] != "controller-addr" {
 		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestBuildRuntimeSetsCoreChannelFromSettingsWhenVersionDetected(t *testing.T) {
+	paths := platform.NewPaths(filepath.Join(t.TempDir(), "data"))
+	if err := os.MkdirAll(filepath.Dir(paths.CoreBinary), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeFakeCoreBinary(t, paths.CoreBinary, "Mihomo Meta v1.19.0 windows amd64")
+	settings := testRuntimeSettings(t)
+	settings.ControllerSecret = strings.Repeat("e", 64)
+	settings.CoreChannel = "alpha"
+	assembly, err := BuildRuntimeWithOptions(paths, settings, "test-version", nil, nil, RuntimeBuildOptions{SettingsPath: paths.Settings})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := assembly.Store.Load()
+	if snapshot.Core.Status != "stopped" || snapshot.Core.Version != "v1.19.0" || snapshot.Core.Channel != "alpha" {
+		t.Fatalf("core=%#v", snapshot.Core)
+	}
+}
+
+func writeFakeCoreBinary(t *testing.T, dest, versionOutput string) {
+	t.Helper()
+	srcDir := t.TempDir()
+	src := filepath.Join(srcDir, "main.go")
+	source := fmt.Sprintf("package main\nimport (\n\t\"fmt\"\n\t\"os\"\n)\nfunc main() {\n\tif len(os.Args) > 1 && os.Args[1] == \"-v\" {\n\t\tfmt.Print(%q)\n\t\treturn\n\t}\n\tos.Exit(1)\n}\n", versionOutput)
+	if err := os.WriteFile(src, []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("go", "build", "-o", dest, src)
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build fake core: %v\n%s", err, out)
 	}
 }
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -25,6 +25,8 @@ type Settings struct {
 	ControllerSecret   string         `yaml:"controller-secret"`
 	SystemProxyDesired bool           `yaml:"system-proxy-desired,omitempty"`
 	Tun                map[string]any `yaml:"tun,omitempty"` // managed block; empty = unmanaged
+	CoreChannel        string         `yaml:"core-channel,omitempty"`
+	CoreChannelBundle  string         `yaml:"core-channel-bundle,omitempty"`
 }
 
 func Defaults() Settings {
@@ -33,6 +35,7 @@ func Defaults() Settings {
 		MixedAddr:      "127.0.0.1:9190",
 		ControllerAddr: "127.0.0.1:9090",
 		WebAddr:        "127.0.0.1:9191",
+		CoreChannel:    "stable",
 	}
 }
 
@@ -194,6 +197,11 @@ func (s Settings) Validate() error {
 	}
 	if err := validateTun(s.Tun); err != nil {
 		return err
+	}
+	switch s.CoreChannel {
+	case "", "stable", "alpha":
+	default:
+		return dataError("invalid core channel")
 	}
 	return nil
 }

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -78,9 +78,20 @@ func LoadOrCreate(path string) (Settings, error) {
 
 // LoadOrCreateResult loads settings or creates them and reports whether this call created the file.
 func LoadOrCreateResult(path string) (Settings, bool, error) {
+	return loadOrCreate(path, "")
+}
+
+// LoadOrCreateWithSidecar loads settings or creates them, applying a packaged
+// core-channel sidecar. On first create the sidecar is applied before the first
+// Save so the file is never written as a stable-only default and then rewritten.
+func LoadOrCreateWithSidecar(path, sidecar string) (Settings, bool, error) {
+	return loadOrCreate(path, sidecar)
+}
+
+func loadOrCreate(path, sidecar string) (Settings, bool, error) {
 	settings, err := loadSettings(path)
 	if err == nil {
-		return settings, false, nil
+		return persistSidecarIfChanged(path, settings, sidecar)
 	}
 	if !errors.Is(err, os.ErrNotExist) {
 		return Settings{}, false, err
@@ -99,7 +110,7 @@ func LoadOrCreateResult(path string) (Settings, bool, error) {
 	}()
 	settings, err = loadSettings(path)
 	if err == nil {
-		return settings, false, nil
+		return persistSidecarIfChanged(path, settings, sidecar)
 	}
 	if !errors.Is(err, os.ErrNotExist) {
 		return Settings{}, false, err
@@ -110,10 +121,33 @@ func LoadOrCreateResult(path string) (Settings, bool, error) {
 		return Settings{}, false, fmt.Errorf("generate controller secret: %w", err)
 	}
 	settings.ControllerSecret = hex.EncodeToString(secret[:])
+	if _, err := applySidecarIfPresent(&settings, sidecar); err != nil {
+		return Settings{}, false, err
+	}
 	if err := Save(path, settings); err != nil {
 		return Settings{}, false, err
 	}
 	return settings, true, nil
+}
+
+func persistSidecarIfChanged(path string, settings Settings, sidecar string) (Settings, bool, error) {
+	changed, err := applySidecarIfPresent(&settings, sidecar)
+	if err != nil {
+		return Settings{}, false, err
+	}
+	if changed {
+		if err := Save(path, settings); err != nil {
+			return Settings{}, false, err
+		}
+	}
+	return settings, false, nil
+}
+
+func applySidecarIfPresent(settings *Settings, sidecar string) (bool, error) {
+	if sidecar == "" {
+		return false, nil
+	}
+	return ApplyCoreChannelSidecar(settings, sidecar)
 }
 
 // loadSettings loads settings, retrying while the file exists on disk but is

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -9,6 +9,7 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/mihari-proxy/mihari/internal/control/protocol"
@@ -204,6 +205,34 @@ func (s Settings) Validate() error {
 		return dataError("invalid core channel")
 	}
 	return nil
+}
+
+// ApplyCoreChannelSidecar applies a packaged core-channel sidecar to settings.
+// A missing or invalid sidecar is ignored. An unchanged stamp is a no-op so a
+// later TUI channel switch is not reverted by an old sidecar file.
+func ApplyCoreChannelSidecar(settings *Settings, sidecarPath string) (bool, error) {
+	raw, err := os.ReadFile(sidecarPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	lines := strings.Split(strings.ReplaceAll(string(raw), "\r\n", "\n"), "\n")
+	if len(lines) < 2 {
+		return false, nil
+	}
+	channel := strings.TrimSpace(lines[0])
+	stamp := strings.TrimSpace(lines[1])
+	if stamp == "" || (channel != "stable" && channel != "alpha") {
+		return false, nil
+	}
+	if settings.CoreChannelBundle == stamp {
+		return false, nil
+	}
+	settings.CoreChannel = channel
+	settings.CoreChannelBundle = stamp
+	return true, nil
 }
 
 func validateTun(tun map[string]any) error {

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -349,3 +349,71 @@ func TestApplyCoreChannelSidecar(t *testing.T) {
 		t.Fatalf("missing sidecar must be ignored: %#v changed=%v err=%v", settings, changed, err)
 	}
 }
+
+func TestLoadOrCreateAppliesSidecarBeforeFirstSave(t *testing.T) {
+	root := t.TempDir()
+	sidecar := filepath.Join(root, "bin", "core-channel")
+	if err := os.MkdirAll(filepath.Dir(sidecar), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sidecar, []byte("alpha\nalpha-e183c58\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(root, "mihari.yaml")
+	settings, created, err := LoadOrCreateWithSidecar(path, sidecar)
+	if err != nil || !created {
+		t.Fatalf("created=%v err=%v settings=%#v", created, err, settings)
+	}
+	if settings.CoreChannel != "alpha" || settings.CoreChannelBundle != "alpha-e183c58" {
+		t.Fatalf("settings=%#v", settings)
+	}
+	if settings.ControllerSecret == "" {
+		t.Fatal("controller secret must be generated before first save")
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(raw)
+	if !strings.Contains(text, "core-channel: alpha") {
+		t.Fatalf("first save missing alpha channel: %s", text)
+	}
+	if !strings.Contains(text, "core-channel-bundle: alpha-e183c58") {
+		t.Fatalf("first save missing sidecar stamp: %s", text)
+	}
+}
+
+func TestLoadOrCreateWithSidecarAppliesNewStampToExistingSettings(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "mihari.yaml")
+	settings := Defaults()
+	settings.ControllerSecret = strings.Repeat("ab", 32)
+	settings.CoreChannel = "stable"
+	settings.CoreChannelBundle = "alpha-e183c58"
+	if err := Save(path, settings); err != nil {
+		t.Fatal(err)
+	}
+
+	sidecar := filepath.Join(root, "bin", "core-channel")
+	if err := os.MkdirAll(filepath.Dir(sidecar), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sidecar, []byte("alpha\nalpha-ffffff\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, created, err := LoadOrCreateWithSidecar(path, sidecar)
+	if err != nil || created {
+		t.Fatalf("created=%v err=%v loaded=%#v", created, err, loaded)
+	}
+	if loaded.CoreChannel != "alpha" || loaded.CoreChannelBundle != "alpha-ffffff" {
+		t.Fatalf("loaded=%#v", loaded)
+	}
+
+	reloaded, err := Load(path)
+	if err != nil || reloaded.CoreChannel != "alpha" || reloaded.CoreChannelBundle != "alpha-ffffff" {
+		t.Fatalf("reloaded=%#v err=%v", reloaded, err)
+	}
+}

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -186,6 +186,70 @@ func TestSettingsValidationRejectsInvalidTunTypes(t *testing.T) {
 	}
 }
 
+func TestDefaultsCoreChannelIsStable(t *testing.T) {
+	settings := Defaults()
+	if settings.CoreChannel != "stable" {
+		t.Fatalf("CoreChannel=%q", settings.CoreChannel)
+	}
+	if settings.CoreChannelBundle != "" {
+		t.Fatalf("CoreChannelBundle=%q", settings.CoreChannelBundle)
+	}
+}
+
+func TestSettingsCoreChannelRoundTripAndValidation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mihari.yaml")
+	settings := Defaults()
+	settings.ControllerSecret = strings.Repeat("ab", 32)
+	if err := Save(path, settings); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.CoreChannel != "stable" {
+		t.Fatalf("CoreChannel=%q, want stable from Defaults", loaded.CoreChannel)
+	}
+
+	settings.CoreChannel = "alpha"
+	settings.CoreChannelBundle = "alpha-e183c58"
+	if err := Save(path, settings); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err = Load(path)
+	if err != nil || loaded.CoreChannel != "alpha" || loaded.CoreChannelBundle != "alpha-e183c58" {
+		t.Fatalf("loaded=%#v err=%v", loaded, err)
+	}
+
+	settings.CoreChannel = "nightly"
+	if err := settings.Validate(); err == nil {
+		t.Fatal("expected invalid core-channel")
+	}
+
+	omittedPath := filepath.Join(t.TempDir(), "legacy.yaml")
+	legacy := strings.Join([]string{
+		"schema: mihari.settings/v1",
+		"mixed-addr: 127.0.0.1:9190",
+		"controller-addr: 127.0.0.1:9090",
+		"web-addr: 127.0.0.1:9191",
+		"controller-secret: " + strings.Repeat("ab", 32),
+		"",
+	}, "\n")
+	if err := os.WriteFile(omittedPath, []byte(legacy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err = Load(omittedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.CoreChannel != "" {
+		t.Fatalf("omitted core-channel loaded as %q", loaded.CoreChannel)
+	}
+	if err := loaded.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestSettingsValidationAcceptsValidTunBlock(t *testing.T) {
 	settings := Defaults()
 	settings.Tun = map[string]any{

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -304,3 +304,48 @@ func TestConcurrentLoadOrCreateUsesOneControllerSecret(t *testing.T) {
 		}
 	}
 }
+
+func TestApplyCoreChannelSidecar(t *testing.T) {
+	write := func(t *testing.T, body string) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "core-channel")
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+
+	settings := Defaults()
+	changed, err := ApplyCoreChannelSidecar(&settings, write(t, "alpha\nalpha-e183c58\n"))
+	if err != nil || !changed || settings.CoreChannel != "alpha" || settings.CoreChannelBundle != "alpha-e183c58" {
+		t.Fatalf("settings=%#v changed=%v err=%v", settings, changed, err)
+	}
+
+	changed, err = ApplyCoreChannelSidecar(&settings, write(t, "alpha\nalpha-e183c58\n"))
+	if err != nil || changed {
+		t.Fatalf("same stamp should be no-op: changed=%v err=%v", changed, err)
+	}
+
+	settings.CoreChannel = "stable" // 模拟 TUI 后来切走
+	changed, err = ApplyCoreChannelSidecar(&settings, write(t, "alpha\nalpha-e183c58\n"))
+	if err != nil || changed || settings.CoreChannel != "stable" {
+		t.Fatalf("old stamp must not revert TUI channel: %#v changed=%v", settings, changed)
+	}
+
+	changed, err = ApplyCoreChannelSidecar(&settings, write(t, "alpha\nalpha-ffffff\n"))
+	if err != nil || !changed || settings.CoreChannel != "alpha" || settings.CoreChannelBundle != "alpha-ffffff" {
+		t.Fatalf("new stamp should apply: %#v changed=%v", settings, changed)
+	}
+
+	before := settings
+	changed, err = ApplyCoreChannelSidecar(&settings, write(t, "nightly\nstamp\n"))
+	if err != nil || changed || !reflect.DeepEqual(settings, before) {
+		t.Fatalf("invalid sidecar must be ignored: %#v err=%v", settings, err)
+	}
+
+	before = settings
+	changed, err = ApplyCoreChannelSidecar(&settings, filepath.Join(t.TempDir(), "missing-core-channel"))
+	if err != nil || changed || !reflect.DeepEqual(settings, before) {
+		t.Fatalf("missing sidecar must be ignored: %#v changed=%v err=%v", settings, changed, err)
+	}
+}

--- a/internal/control/protocol/runtime.go
+++ b/internal/control/protocol/runtime.go
@@ -19,6 +19,7 @@ type CoreStatus struct {
 	// the runtime exposes local-core detection (design §4.3).
 	LocalReady   bool   `json:"localReady,omitempty"`
 	LocalVersion string `json:"localVersion,omitempty"`
+	Channel      string `json:"channel,omitempty"`
 }
 
 type ProxyGroup struct {
@@ -114,6 +115,7 @@ type MutationRequest struct {
 	OperationID string  `json:"operation_id"`
 	IfRevision  *uint64 `json:"if_revision,omitempty"`
 	Source      string  `json:"source,omitempty"` // request origin; empty defaults to "control" (normalized by handlers)
+	Channel     *string `json:"channel,omitempty"`
 }
 
 type ProxySelectionRequest struct {
@@ -137,6 +139,7 @@ type CoreInstallResult struct {
 	Version  string `json:"version"`
 	Updated  bool   `json:"updated"`
 	Revision uint64 `json:"revision"`
+	Channel  string `json:"channel,omitempty"`
 }
 
 type StreamEvent struct {

--- a/internal/control/protocol/runtime_test.go
+++ b/internal/control/protocol/runtime_test.go
@@ -147,3 +147,55 @@ func TestCoreStatusMarshalsLocalReadinessOptionally(t *testing.T) {
 		t.Fatalf("zero-value local fields should be omitted: %s", omitted)
 	}
 }
+
+func TestCoreStatusMarshalsChannelOptionally(t *testing.T) {
+	raw, err := json.Marshal(CoreStatus{Channel: "alpha"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `"channel":"alpha"`) {
+		t.Fatalf("channel not surfaced: %s", raw)
+	}
+	omitted, err := json.Marshal(CoreStatus{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(omitted), "channel") {
+		t.Fatalf("zero-value channel should be omitted: %s", omitted)
+	}
+}
+
+func TestCoreInstallResultMarshalsChannelOptionally(t *testing.T) {
+	raw, err := json.Marshal(CoreInstallResult{Channel: "alpha"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `"channel":"alpha"`) {
+		t.Fatalf("channel not surfaced: %s", raw)
+	}
+	omitted, err := json.Marshal(CoreInstallResult{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(omitted), "channel") {
+		t.Fatalf("zero-value channel should be omitted: %s", omitted)
+	}
+}
+
+func TestMutationRequestDecodesChannelOptionally(t *testing.T) {
+	var withChannel MutationRequest
+	if err := json.Unmarshal([]byte(`{"operation_id":"x","channel":"alpha"}`), &withChannel); err != nil {
+		t.Fatal(err)
+	}
+	if withChannel.Channel == nil || *withChannel.Channel != "alpha" {
+		t.Fatalf("channel=%v want non-nil alpha", withChannel.Channel)
+	}
+
+	var omitted MutationRequest
+	if err := json.Unmarshal([]byte(`{"operation_id":"x"}`), &omitted); err != nil {
+		t.Fatal(err)
+	}
+	if omitted.Channel != nil {
+		t.Fatalf("channel=%v want nil", omitted.Channel)
+	}
+}

--- a/internal/control/server/runtime.go
+++ b/internal/control/server/runtime.go
@@ -103,13 +103,14 @@ func (s *Server) installCore(writer http.ResponseWriter, request *http.Request) 
 	if !decodeControlJSON(writer, request, &body) || !requireOperationID(writer, body.OperationID) {
 		return
 	}
-	result, err := s.runtime.Install(request.Context(), runtimeapi.Operation{ID: body.OperationID, Source: mutationSource(body.Source), IfRevision: body.IfRevision})
+	result, err := s.runtime.Install(request.Context(), runtimeapi.Operation{ID: body.OperationID, Source: mutationSource(body.Source), IfRevision: body.IfRevision, Channel: body.Channel})
 	if err != nil {
 		writeControlError(writer, err)
 		return
 	}
+	snapshot := s.runtime.Snapshot()
 	writeJSON(writer, http.StatusOK, protocol.CoreInstallResult{
-		Schema: "mihari/v1", Version: result.Version, Updated: result.Updated, Revision: s.runtime.Snapshot().Revision,
+		Schema: "mihari/v1", Version: result.Version, Updated: result.Updated, Revision: snapshot.Revision, Channel: snapshot.Core.Channel,
 	})
 }
 
@@ -424,7 +425,7 @@ func (s *Server) requireRuntime(writer http.ResponseWriter) bool {
 
 func coreStatusDTO(snapshot state.Snapshot) protocol.CoreStatus {
 	return protocol.CoreStatus{
-		Schema: "mihari/v1", Revision: snapshot.Revision, Status: snapshot.Core.Status, Version: snapshot.Core.Version,
+		Schema: "mihari/v1", Revision: snapshot.Revision, Status: snapshot.Core.Status, Version: snapshot.Core.Version, Channel: snapshot.Core.Channel,
 		PID: snapshot.Core.PID, Restarts: snapshot.Core.Restarts, LastError: snapshot.Core.LastError, NextRetryAt: snapshot.Core.NextRetryAt,
 	}
 }

--- a/internal/control/server/runtime_test.go
+++ b/internal/control/server/runtime_test.go
@@ -620,6 +620,84 @@ func TestInstallCoreThreadsRequestSource(t *testing.T) {
 	}
 }
 
+func TestInstallCoreThreadsRequestChannel(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want *string
+	}{
+		{"alpha channel", `{"operation_id":"install-1","channel":"alpha"}`, stringPtr("alpha")},
+		{"omitted channel", `{"operation_id":"install-2"}`, nil},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fake := &fakeRuntime{installResult: core.InstallResult{Version: "v1.19.0"}}
+			server := New(Options{Token: "token", Store: state.NewStore(state.Snapshot{}), Runtime: fake})
+			recorder := httptest.NewRecorder()
+			server.Handler().ServeHTTP(recorder, authorizedRequest(http.MethodPost, "/v1/core/install", bytes.NewBufferString(test.body)))
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+			}
+			if test.want == nil {
+				if fake.operation.Channel != nil {
+					t.Fatalf("channel=%v want nil", fake.operation.Channel)
+				}
+				return
+			}
+			if fake.operation.Channel == nil || *fake.operation.Channel != *test.want {
+				t.Fatalf("channel=%v want %q", fake.operation.Channel, *test.want)
+			}
+		})
+	}
+}
+
+func TestCoreEndpointIncludesChannelFromSnapshot(t *testing.T) {
+	store := state.NewStore(state.Snapshot{Revision: 8, Core: state.CoreState{Status: "running", Version: "v1.19.0", Channel: "alpha"}})
+	server := New(Options{Token: "token", Store: store, Runtime: &fakeRuntime{snapshot: store.Load()}})
+	recorder := httptest.NewRecorder()
+	server.Handler().ServeHTTP(recorder, authorizedRequest(http.MethodGet, "/v1/core", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !bytes.Contains(recorder.Body.Bytes(), []byte(`"channel":"alpha"`)) {
+		t.Fatalf("channel missing: %s", recorder.Body.String())
+	}
+	var status protocol.CoreStatus
+	if err := json.Unmarshal(recorder.Body.Bytes(), &status); err != nil {
+		t.Fatal(err)
+	}
+	if status.Channel != "alpha" {
+		t.Fatalf("status=%#v", status)
+	}
+}
+
+func TestInstallCoreResponseIncludesChannelFromSnapshot(t *testing.T) {
+	fake := &fakeRuntime{
+		installResult: core.InstallResult{Version: "v1.19.0", Updated: true},
+		snapshot:      state.Snapshot{Revision: 12, Core: state.CoreState{Channel: "alpha"}},
+	}
+	server := New(Options{Token: "token", Store: state.NewStore(fake.snapshot), Runtime: fake})
+	recorder := httptest.NewRecorder()
+	server.Handler().ServeHTTP(recorder, authorizedRequest(http.MethodPost, "/v1/core/install", bytes.NewBufferString(`{"operation_id":"install-1"}`)))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !bytes.Contains(recorder.Body.Bytes(), []byte(`"channel":"alpha"`)) {
+		t.Fatalf("channel missing: %s", recorder.Body.String())
+	}
+	var result protocol.CoreInstallResult
+	if err := json.Unmarshal(recorder.Body.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Channel != "alpha" || result.Version != "v1.19.0" || result.Revision != 12 {
+		t.Fatalf("result=%#v", result)
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
+}
+
 func FuzzDecodeControlJSON(f *testing.F) {
 	seeds := [][]byte{
 		[]byte(`{"operation_id":"op-1"}`),

--- a/internal/core/install.go
+++ b/internal/core/install.go
@@ -124,6 +124,24 @@ func (c *Candidate) Cleanup() {
 	})
 }
 
+// localReadyVersion 在二进制存在且 DetectVersion（含 ParseVersion）成功时返回版本。
+// 判据与 Manager.Install setup 预检同一路径（design §4.3）；失败则走下载修复。
+func (i Installer) localReadyVersion(ctx context.Context, binaryPath string) (string, bool) {
+	info, err := os.Stat(binaryPath)
+	if err != nil || info.IsDir() {
+		return "", false
+	}
+	runner := i.Runner
+	if runner == nil {
+		runner = OSCommandRunner{}
+	}
+	version, err := DetectVersion(ctx, runner, binaryPath)
+	if err != nil || version == "" {
+		return "", false
+	}
+	return version, true
+}
+
 func (i Installer) Prepare(ctx context.Context, request InstallRequest) (PreparedCore, error) {
 	checkCtx, cancel := context.WithTimeout(ctx, i.checkTimeout())
 	release, err := i.LatestRelease(checkCtx, request.Channel)
@@ -131,22 +149,22 @@ func (i Installer) Prepare(ctx context.Context, request InstallRequest) (Prepare
 	if err != nil {
 		return nil, withAIOHint(err)
 	}
-	if request.CurrentVersion == release.TagName {
-		if info, statErr := os.Stat(request.BinaryPath); statErr == nil && !info.IsDir() {
-			// 文件存在还要 -v 成功才短路；判据复用 DetectVersion（含 ParseVersion 版本格式校验）
-			// ——design §4.3，与 Manager.Install setup 预检同一判据、DRY。-v 失败 → 走下载修复。
-			runner := i.Runner
-			if runner == nil {
-				runner = OSCommandRunner{}
-			}
-			if version, vErr := DetectVersion(ctx, runner, request.BinaryPath); vErr == nil && version != "" {
-				return &Candidate{binaryPath: request.BinaryPath, version: version, updated: false}, nil
-			}
+	if request.Channel != "alpha" && request.CurrentVersion == release.TagName {
+		if version, ok := i.localReadyVersion(ctx, request.BinaryPath); ok {
+			return &Candidate{binaryPath: request.BinaryPath, version: version, updated: false}, nil
 		}
 	}
 	asset, err := SelectAsset(release, i.targetOS(), i.targetArch(), request.Channel)
 	if err != nil {
 		return nil, err
+	}
+	if request.Channel == "alpha" {
+		releaseSHA := ParseAlphaSHA(asset.Name)
+		if releaseSHA != "" && releaseSHA == request.AlphaSHA {
+			if version, ok := i.localReadyVersion(ctx, request.BinaryPath); ok {
+				return &Candidate{binaryPath: request.BinaryPath, version: version, alphaSHA: releaseSHA, updated: false}, nil
+			}
+		}
 	}
 	if asset.Size < 0 || asset.Size > maxCoreArchiveSize {
 		return nil, protocol.APIError{Code: protocol.CodeDataFailure, Message: "mihomo asset is too large"}

--- a/internal/core/install.go
+++ b/internal/core/install.go
@@ -41,11 +41,13 @@ type InstallRequest struct {
 	StagingDir     string
 	CurrentVersion string
 	Channel        string
+	AlphaSHA       string
 }
 
 type InstallResult struct {
-	Version string
-	Updated bool
+	Version  string
+	Updated  bool
+	AlphaSHA string
 }
 
 // LocalCoreInfo reports whether an existing local core binary satisfies setup
@@ -81,6 +83,7 @@ type Candidate struct {
 	path       string
 	binaryPath string
 	version    string
+	alphaSHA   string
 	updated    bool
 	cleanup    sync.Once
 }
@@ -98,7 +101,7 @@ func (c *Candidate) Updated() bool { return c.updated }
 
 func (c *Candidate) Commit() (InstallResult, error) {
 	if !c.updated {
-		return InstallResult{Version: c.version, Updated: false}, nil
+		return InstallResult{Version: c.version, Updated: false, AlphaSHA: c.alphaSHA}, nil
 	}
 	if c.path == "" {
 		return InstallResult{}, protocol.APIError{Code: protocol.CodeInvalidState, Message: "mihomo candidate is unavailable"}
@@ -110,7 +113,7 @@ func (c *Candidate) Commit() (InstallResult, error) {
 		return InstallResult{}, protocol.APIError{Code: protocol.CodeDataFailure, Message: "replace mihomo core"}
 	}
 	c.path = ""
-	return InstallResult{Version: c.version, Updated: true}, nil
+	return InstallResult{Version: c.version, Updated: true, AlphaSHA: c.alphaSHA}, nil
 }
 
 func (c *Candidate) Cleanup() {
@@ -137,7 +140,7 @@ func (i Installer) Prepare(ctx context.Context, request InstallRequest) (Prepare
 				runner = OSCommandRunner{}
 			}
 			if version, vErr := DetectVersion(ctx, runner, request.BinaryPath); vErr == nil && version != "" {
-				return &Candidate{binaryPath: request.BinaryPath, version: release.TagName, updated: false}, nil
+				return &Candidate{binaryPath: request.BinaryPath, version: version, updated: false}, nil
 			}
 		}
 	}
@@ -188,11 +191,15 @@ func (i Installer) Prepare(ctx context.Context, request InstallRequest) (Prepare
 	if err != nil || len(strings.TrimSpace(string(versionOutput))) == 0 {
 		return nil, protocol.APIError{Code: protocol.CodeDataFailure, Message: "mihomo candidate did not start"}
 	}
+	version, err := ParseVersion(string(versionOutput))
+	if err != nil {
+		return nil, err
+	}
 	if err := ValidateConfig(ctx, runner, candidatePath, request.DataDir, request.ConfigPath); err != nil {
 		return nil, err
 	}
 	keepCandidate = true
-	return &Candidate{path: candidatePath, binaryPath: request.BinaryPath, version: release.TagName, updated: true}, nil
+	return &Candidate{path: candidatePath, binaryPath: request.BinaryPath, version: version, alphaSHA: ParseAlphaSHA(asset.Name), updated: true}, nil
 }
 
 // Download 取 asset 并落盘到 destination，校验 asset.Digest 的 sha256:<hex>

--- a/internal/core/install.go
+++ b/internal/core/install.go
@@ -40,6 +40,7 @@ type InstallRequest struct {
 	ConfigPath     string
 	StagingDir     string
 	CurrentVersion string
+	Channel        string
 }
 
 type InstallResult struct {
@@ -122,7 +123,7 @@ func (c *Candidate) Cleanup() {
 
 func (i Installer) Prepare(ctx context.Context, request InstallRequest) (PreparedCore, error) {
 	checkCtx, cancel := context.WithTimeout(ctx, i.checkTimeout())
-	release, err := i.LatestRelease(checkCtx)
+	release, err := i.LatestRelease(checkCtx, request.Channel)
 	cancel()
 	if err != nil {
 		return nil, withAIOHint(err)
@@ -140,7 +141,7 @@ func (i Installer) Prepare(ctx context.Context, request InstallRequest) (Prepare
 			}
 		}
 	}
-	asset, err := SelectAsset(release, i.targetOS(), i.targetArch())
+	asset, err := SelectAsset(release, i.targetOS(), i.targetArch(), request.Channel)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/install_test.go
+++ b/internal/core/install_test.go
@@ -81,7 +81,8 @@ func TestInstallerDownloadsExtractsValidatesAndReplaces(t *testing.T) {
 		t.Run(target.goos+"/"+target.goarch, func(t *testing.T) {
 			binary := []byte("fake-mihomo-binary")
 			archive := target.archive(t, binary)
-			server := releaseFixture(t, target.name, archive)
+			// TagName is deliberately not a semver so Version cannot be copied from the release tag.
+			server := releaseFixtureWithTag(t, "Prerelease-Alpha", target.name, archive)
 			defer server.Close()
 
 			root := t.TempDir()
@@ -106,7 +107,7 @@ func TestInstallerDownloadsExtractsValidatesAndReplaces(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if result.Version != "v1.19.0" || !result.Updated {
+			if result.Version != "v1.19.0" || !result.Updated || result.AlphaSHA != "" {
 				t.Fatalf("result=%#v", result)
 			}
 			got, err := os.ReadFile(binaryPath)
@@ -117,6 +118,46 @@ func TestInstallerDownloadsExtractsValidatesAndReplaces(t *testing.T) {
 				t.Fatal("candidate was not validated")
 			}
 		})
+	}
+}
+
+func TestInstallerDownloadsAlphaReportsParseVersionAndAlphaSHA(t *testing.T) {
+	archive := gzipFixture(t, []byte("alpha-binary"))
+	server := alphaReleaseFixture(t, "mihomo-linux-amd64-alpha-e183c58.gz", archive, nil)
+	defer server.Close()
+
+	root := t.TempDir()
+	binaryPath := filepath.Join(root, "bin", "mihomo")
+	if err := os.MkdirAll(filepath.Dir(binaryPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	installer := Installer{
+		HTTPClient: server.Client(), APIBase: server.URL, Repository: "MetaCubeX/mihomo",
+		GOOS: "linux", GOARCH: "amd64",
+		Runner: &recordingRunner{output: []byte("Mihomo Meta alpha-e183c58 linux amd64")},
+	}
+	result, err := installer.Install(context.Background(), InstallRequest{
+		BinaryPath: binaryPath,
+		DataDir:    root,
+		ConfigPath: filepath.Join(root, "config.yaml"),
+		StagingDir: filepath.Join(root, "staging"),
+		Channel:    "alpha",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Version != "alpha-e183c58" || result.AlphaSHA != "e183c58" || !result.Updated {
+		t.Fatalf("result=%#v", result)
+	}
+}
+
+func TestCandidateCommitWithoutUpdateReturnsAlphaSHA(t *testing.T) {
+	result, err := (&Candidate{version: "v1.19.0", updated: false}).Commit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Version != "v1.19.0" || result.Updated || result.AlphaSHA != "" {
+		t.Fatalf("result=%#v", result)
 	}
 }
 
@@ -203,6 +244,11 @@ func TestInstallerRejectsUnsafeZipMember(t *testing.T) {
 
 func releaseFixture(t *testing.T, assetName string, archive []byte) *httptest.Server {
 	t.Helper()
+	return releaseFixtureWithTag(t, "v1.19.0", assetName, archive)
+}
+
+func releaseFixtureWithTag(t *testing.T, tagName, assetName string, archive []byte) *httptest.Server {
+	t.Helper()
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		switch request.URL.Path {
@@ -210,7 +256,7 @@ func releaseFixture(t *testing.T, assetName string, archive []byte) *httptest.Se
 			if request.Header.Get("Accept") != "application/vnd.github+json" || request.Header.Get("X-GitHub-Api-Version") == "" {
 				t.Errorf("missing GitHub API headers")
 			}
-			_ = json.NewEncoder(response).Encode(Release{TagName: "v1.19.0", Assets: []Asset{{Name: assetName, URL: server.URL + "/asset", Size: int64(len(archive))}}})
+			_ = json.NewEncoder(response).Encode(Release{TagName: tagName, Assets: []Asset{{Name: assetName, URL: server.URL + "/asset", Size: int64(len(archive))}}})
 		case "/asset":
 			_, _ = response.Write(archive)
 		default:
@@ -350,6 +396,13 @@ func TestPrepare(t *testing.T) {
 		}
 		if got, _ := os.ReadFile(binaryPath); string(got) != "existing-valid" {
 			t.Fatalf("binary changed=%q (download should not happen)", got)
+		}
+		result, err := candidate.Commit()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Updated || result.Version != "v1.19.0" || result.AlphaSHA != "" {
+			t.Fatalf("result=%#v", result)
 		}
 	})
 

--- a/internal/core/install_test.go
+++ b/internal/core/install_test.go
@@ -38,11 +38,32 @@ func TestSelectAssetForReleaseTargets(t *testing.T) {
 		{"windows", "arm64", "mihomo-windows-arm64-v1.19.0.zip"},
 	} {
 		t.Run(target.goos+"/"+target.goarch, func(t *testing.T) {
-			asset, err := SelectAsset(release, target.goos, target.goarch)
+			asset, err := SelectAsset(release, target.goos, target.goarch, "stable")
 			if err != nil || asset.Name != target.want {
 				t.Fatalf("asset=%#v err=%v", asset, err)
 			}
 		})
+	}
+}
+
+func TestSelectAssetAlphaPicksStandardName(t *testing.T) {
+	release := Release{TagName: "Prerelease-Alpha", Assets: []Asset{
+		{Name: "mihomo-linux-amd64-compatible-alpha-e183c58.gz"},
+		{Name: "mihomo-linux-amd64-v3-alpha-e183c58.gz"},
+		{Name: "mihomo-linux-amd64-alpha-e183c58-go124.gz"},
+		{Name: "mihomo-linux-amd64-alpha-e183c58.gz"},
+		{Name: "mihomo-windows-amd64-compatible-alpha-e183c58.zip"},
+		{Name: "mihomo-windows-amd64-v3-alpha-e183c58.zip"},
+		{Name: "mihomo-windows-amd64-alpha-e183c58-go124.zip"},
+		{Name: "mihomo-windows-amd64-alpha-e183c58.zip"},
+	}}
+	asset, err := SelectAsset(release, "linux", "amd64", "alpha")
+	if err != nil || asset.Name != "mihomo-linux-amd64-alpha-e183c58.gz" {
+		t.Fatalf("linux asset=%#v err=%v", asset, err)
+	}
+	asset, err = SelectAsset(release, "windows", "amd64", "alpha")
+	if err != nil || asset.Name != "mihomo-windows-amd64-alpha-e183c58.zip" {
+		t.Fatalf("windows asset=%#v err=%v", asset, err)
 	}
 }
 
@@ -190,6 +211,28 @@ func releaseFixture(t *testing.T, assetName string, archive []byte) *httptest.Se
 				t.Errorf("missing GitHub API headers")
 			}
 			_ = json.NewEncoder(response).Encode(Release{TagName: "v1.19.0", Assets: []Asset{{Name: assetName, URL: server.URL + "/asset", Size: int64(len(archive))}}})
+		case "/asset":
+			_, _ = response.Write(archive)
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	return server
+}
+
+func alphaReleaseFixture(t *testing.T, assetName string, archive []byte, requested *[]string) *httptest.Server {
+	t.Helper()
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if requested != nil {
+			*requested = append(*requested, request.URL.Path)
+		}
+		switch request.URL.Path {
+		case "/repos/MetaCubeX/mihomo/releases/tags/Prerelease-Alpha":
+			if request.Header.Get("Accept") != "application/vnd.github+json" || request.Header.Get("X-GitHub-Api-Version") == "" {
+				t.Errorf("missing GitHub API headers")
+			}
+			_ = json.NewEncoder(response).Encode(Release{TagName: "Prerelease-Alpha", Assets: []Asset{{Name: assetName, URL: server.URL + "/asset", Size: int64(len(archive))}}})
 		case "/asset":
 			_, _ = response.Write(archive)
 		default:
@@ -481,7 +524,7 @@ func TestLatestReleaseExport(t *testing.T) {
 	server := releaseFixture(t, "mihomo-linux-amd64-compatible-v1.19.0.gz", archive)
 	defer server.Close()
 	installer := Installer{HTTPClient: server.Client(), APIBase: server.URL, Repository: "MetaCubeX/mihomo"}
-	release, err := installer.LatestRelease(context.Background())
+	release, err := installer.LatestRelease(context.Background(), "stable")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -490,6 +533,23 @@ func TestLatestReleaseExport(t *testing.T) {
 	}
 	if release.Assets[0].Name != "mihomo-linux-amd64-compatible-v1.19.0.gz" {
 		t.Fatalf("asset=%#v", release.Assets[0])
+	}
+}
+
+func TestLatestReleaseAlphaHitsPrereleaseTag(t *testing.T) {
+	var requested []string
+	server := alphaReleaseFixture(t, "mihomo-linux-amd64-alpha-e183c58.gz", gzipFixture(t, []byte("payload")), &requested)
+	defer server.Close()
+	installer := Installer{HTTPClient: server.Client(), APIBase: server.URL, Repository: "MetaCubeX/mihomo"}
+	release, err := installer.LatestRelease(context.Background(), "alpha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if release.TagName != "Prerelease-Alpha" {
+		t.Fatalf("TagName=%q", release.TagName)
+	}
+	if len(requested) != 1 || requested[0] != "/repos/MetaCubeX/mihomo/releases/tags/Prerelease-Alpha" {
+		t.Fatalf("requested=%q", requested)
 	}
 }
 

--- a/internal/core/install_test.go
+++ b/internal/core/install_test.go
@@ -536,6 +536,102 @@ func TestPrepare(t *testing.T) {
 	})
 }
 
+func TestPrepareAlphaShortCircuitUsesSHA(t *testing.T) {
+	const assetName = "mihomo-linux-amd64-alpha-e183c58.gz"
+	archive := gzipFixture(t, []byte("alpha-binary"))
+
+	tests := []struct {
+		name           string
+		currentVersion string
+		alphaSHA       string
+		wantUpdated    bool
+		wantAssetHits  int
+	}{
+		{
+			name:           "matching sha short-circuits",
+			currentVersion: "alpha-e183c58",
+			alphaSHA:       "e183c58",
+			wantUpdated:    false,
+			wantAssetHits:  0,
+		},
+		{
+			name:           "rolling sha downloads",
+			currentVersion: "alpha-oldsha",
+			alphaSHA:       "oldsha",
+			wantUpdated:    true,
+			wantAssetHits:  1,
+		},
+		{
+			name:           "B1 rolling sha downloads despite Prerelease-Alpha version",
+			currentVersion: "Prerelease-Alpha",
+			alphaSHA:       "oldsha",
+			wantUpdated:    true,
+			wantAssetHits:  1,
+		},
+		{
+			name:           "B1 matching sha short-circuits despite Prerelease-Alpha version",
+			currentVersion: "Prerelease-Alpha",
+			alphaSHA:       "e183c58",
+			wantUpdated:    false,
+			wantAssetHits:  0,
+		},
+		{
+			name:           "empty AlphaSHA must download",
+			currentVersion: "alpha-e183c58",
+			alphaSHA:       "",
+			wantUpdated:    true,
+			wantAssetHits:  1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var requested []string
+			server := alphaReleaseFixture(t, assetName, archive, &requested)
+			defer server.Close()
+
+			root := t.TempDir()
+			binaryPath := filepath.Join(root, "mihomo")
+			if err := os.WriteFile(binaryPath, []byte("existing-alpha"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			installer := Installer{
+				HTTPClient: server.Client(), APIBase: server.URL, Repository: "MetaCubeX/mihomo",
+				GOOS: "linux", GOARCH: "amd64",
+				Runner: &recordingRunner{output: []byte("Mihomo Meta alpha-e183c58 linux amd64")},
+			}
+			candidate, err := installer.Prepare(context.Background(), InstallRequest{
+				BinaryPath:     binaryPath,
+				DataDir:        root,
+				ConfigPath:     filepath.Join(root, "config.yaml"),
+				StagingDir:     filepath.Join(root, "staging"),
+				CurrentVersion: test.currentVersion,
+				Channel:        "alpha",
+				AlphaSHA:       test.alphaSHA,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer candidate.Cleanup()
+			if candidate.Updated() != test.wantUpdated {
+				t.Fatalf("Updated=%v want %v", candidate.Updated(), test.wantUpdated)
+			}
+			if got := candidate.Version(); got != "alpha-e183c58" {
+				t.Fatalf("Version=%q want alpha-e183c58", got)
+			}
+			assetHits := 0
+			for _, path := range requested {
+				if path == "/asset" {
+					assetHits++
+				}
+			}
+			if assetHits != test.wantAssetHits {
+				t.Fatalf("asset downloads=%d want %d requested=%q", assetHits, test.wantAssetHits, requested)
+			}
+		})
+	}
+}
+
 // selectiveRunner mimics a broken/odd existing binary (existingPath) while
 // serving a valid candidate response for any other path (downloaded candidate,
 // config validation). existingOut nil → running existingPath errors.

--- a/internal/core/release.go
+++ b/internal/core/release.go
@@ -25,9 +25,14 @@ type Release struct {
 }
 
 // LatestRelease 取 mihomo 最新 release（bundler 复用入口，design §4.1 export 边界）。
-func (i Installer) LatestRelease(ctx context.Context) (Release, error) {
+// channel=="alpha" 走滚动 tag Prerelease-Alpha；其余（含空）走 /releases/latest。
+func (i Installer) LatestRelease(ctx context.Context, channel string) (Release, error) {
 	var release Release
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(i.apiBase(), "/")+"/repos/"+i.repository()+"/releases/latest", nil)
+	path := "/releases/latest"
+	if channel == "alpha" {
+		path = "/releases/tags/Prerelease-Alpha"
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(i.apiBase(), "/")+"/repos/"+i.repository()+path, nil)
 	if err != nil {
 		return release, protocol.APIError{Code: protocol.CodeInternal, Message: "create release request"}
 	}
@@ -55,10 +60,13 @@ func (i Installer) LatestRelease(ctx context.Context) (Release, error) {
 	return release, nil
 }
 
-func SelectAsset(release Release, goos, goarch string) (Asset, error) {
+func SelectAsset(release Release, goos, goarch, channel string) (Asset, error) {
 	extension := ".gz"
 	if goos == "windows" {
 		extension = ".zip"
+	}
+	if channel == "alpha" {
+		return selectAlphaAsset(release, goos, goarch, extension)
 	}
 	prefix := "mihomo-" + strings.ToLower(goos) + "-"
 	archToken := strings.ToLower(goarch)
@@ -88,4 +96,23 @@ func SelectAsset(release Release, goos, goarch string) (Asset, error) {
 		return Asset{}, protocol.APIError{Code: protocol.CodeDataFailure, Message: "mihomo release has no compatible asset"}
 	}
 	return best, nil
+}
+
+func selectAlphaAsset(release Release, goos, goarch, extension string) (Asset, error) {
+	prefix := "mihomo-" + strings.ToLower(goos) + "-"
+	archToken := strings.ToLower(goarch)
+	for _, asset := range release.Assets {
+		if _, ok := parseAlphaAsset(asset.Name); !ok {
+			continue
+		}
+		name := strings.ToLower(asset.Name)
+		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, extension) {
+			continue
+		}
+		if !strings.HasPrefix(name, prefix+archToken+"-") {
+			continue
+		}
+		return asset, nil
+	}
+	return Asset{}, protocol.APIError{Code: protocol.CodeDataFailure, Message: "mihomo release has no compatible asset"}
 }

--- a/internal/core/version.go
+++ b/internal/core/version.go
@@ -25,6 +25,44 @@ func ParseVersion(output string) (string, error) {
 		if len(candidate) >= 4 && candidate[0] == 'v' && unicode.IsDigit(rune(candidate[1])) && strings.Contains(candidate, ".") {
 			return candidate, nil
 		}
+		if sha, ok := strings.CutPrefix(candidate, "alpha-"); ok && isHex(sha) {
+			return candidate, nil
+		}
 	}
 	return "", protocol.APIError{Code: protocol.CodeDataFailure, Message: "invalid mihomo version output"}
+}
+
+func ParseAlphaSHA(name string) string {
+	sha, ok := parseAlphaAsset(name)
+	if !ok {
+		return ""
+	}
+	return sha
+}
+
+func parseAlphaAsset(name string) (string, bool) {
+	base := name
+	switch lower := strings.ToLower(name); {
+	case strings.HasSuffix(lower, ".gz"):
+		base = name[:len(name)-len(".gz")]
+	case strings.HasSuffix(lower, ".zip"):
+		base = name[:len(name)-len(".zip")]
+	}
+	parts := strings.Split(base, "-")
+	if len(parts) != 5 || parts[0] != "mihomo" || parts[3] != "alpha" || !isHex(parts[4]) {
+		return "", false
+	}
+	return parts[4], true
+}
+
+func isHex(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if !unicode.Is(unicode.ASCII_Hex_Digit, r) {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/core/version_test.go
+++ b/internal/core/version_test.go
@@ -23,6 +23,36 @@ func TestParseVersionFromMihomoOutput(t *testing.T) {
 	}
 }
 
+func TestParseAlphaSHA(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"mihomo-linux-amd64-alpha-e183c58.gz", "e183c58"},
+		{"mihomo-windows-arm64-alpha-abc1234.zip", "abc1234"},
+		{"mihomo-linux-amd64-compatible-v1.19.0.gz", ""},
+		{"mihomo-linux-amd64-v3-alpha-e183c58.gz", ""},
+		{"mihomo-linux-amd64-alpha-e183c58-go124.gz", ""},
+		{"not-an-asset", ""},
+	}
+	for _, test := range tests {
+		if got := ParseAlphaSHA(test.name); got != test.want {
+			t.Fatalf("ParseAlphaSHA(%q)=%q want %q", test.name, got, test.want)
+		}
+	}
+}
+
+func TestParseVersionAcceptsAlphaToken(t *testing.T) {
+	version, err := ParseVersion("Mihomo Meta alpha-dd7bc4c windows amd64 with go1.26.5")
+	if err != nil || version != "alpha-dd7bc4c" {
+		t.Fatalf("version=%q err=%v", version, err)
+	}
+	version, err = ParseVersion("Mihomo Meta v1.19.0 windows amd64 with go1.26.0")
+	if err != nil || version != "v1.19.0" {
+		t.Fatalf("stable version=%q err=%v", version, err)
+	}
+}
+
 func TestDetectVersionRunsVersionFlag(t *testing.T) {
 	runner := &recordingRunner{output: []byte("Mihomo Meta v1.19.0")}
 	version, err := DetectVersion(context.Background(), runner, "mihomo")

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -418,10 +418,14 @@ func (m *Manager) Install(ctx context.Context, operation Operation) (core.Instal
 					return nil, applyErr
 				}
 				if changed {
-					snapshot := m.store.Load()
-					snapshot.Core.Version = version
-					snapshot.Core.Channel = appliedChannel
-					m.store.Store(snapshot)
+					_, coordErr := m.coordinator.Do(ctx, state.CommandMeta{ID: operation.ID, Source: operation.Source, IfRevision: operation.IfRevision}, func(snapshot state.Snapshot) (state.Snapshot, error) {
+						snapshot.Core.Version = version
+						snapshot.Core.Channel = appliedChannel
+						return snapshot, nil
+					})
+					if coordErr != nil {
+						return nil, coordErr
+					}
 				}
 				return core.InstallResult{Version: version, Updated: false}, nil
 			}

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -277,13 +277,16 @@ func (m *Manager) Run(ctx context.Context) error {
 }
 
 func (m *Manager) Observe(observation supervisor.Observation) {
+	current := m.store.Load().Core
 	m.setCoreState(state.CoreState{
 		Status:      string(observation.Status),
 		PID:         observation.PID,
 		Restarts:    observation.Restarts,
 		LastError:   observation.LastError,
 		NextRetryAt: observation.NextRetryAt,
-		Version:     m.store.Load().Core.Version,
+		Version:     current.Version,
+		Channel:     current.Channel,
+		AlphaSHA:    current.AlphaSHA,
 	})
 }
 

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -53,6 +53,7 @@ type Operation struct {
 	ID         string
 	Source     string
 	IfRevision *uint64
+	Channel    *string
 }
 
 // GeoIPCandidate is the minimal prepared-pair contract used by the mutation coordinator.
@@ -381,8 +382,22 @@ func (m *Manager) Install(ctx context.Context, operation Operation) (core.Instal
 		if m.installer == nil {
 			return nil, protocol.APIError{Code: protocol.CodeInvalidState, Message: "core installer is unavailable"}
 		}
+		m.settingsMu.Lock()
+		channel := m.settings.CoreChannel
+		m.settingsMu.Unlock()
+		if channel == "" {
+			channel = "stable"
+		}
+		if operation.Channel != nil {
+			channel = *operation.Channel
+		}
+		if channel != "stable" && channel != "alpha" {
+			return nil, protocol.APIError{Code: protocol.CodeDataFailure, Message: "invalid core channel"}
+		}
 		installRequest := m.installRequest
 		installRequest.CurrentVersion = m.store.Load().Core.Version
+		installRequest.Channel = channel
+		installRequest.AlphaSHA = m.store.Load().Core.AlphaSHA
 		// setup 预检（design §4.3）：aio 脚本已预置核心时，对现有文件 -v 成功即秒过，不联网。
 		// store.Core.Version 不作判据（DetectVersion 失败时旧值残留，见 runtime.go 启动检测）。
 		if operation.Source == "setup" {
@@ -411,6 +426,18 @@ func (m *Manager) Install(ctx context.Context, operation Operation) (core.Instal
 					return snapshot, err
 				}
 				snapshot.Core.Version = result.Version
+				snapshot.Core.Channel = channel
+				snapshot.Core.AlphaSHA = result.AlphaSHA
+				if channel == "stable" {
+					snapshot.Core.AlphaSHA = ""
+				}
+				m.settingsMu.Lock()
+				m.settings.CoreChannel = channel
+				saveErr := m.persistSettings()
+				m.settingsMu.Unlock()
+				if saveErr != nil {
+					return snapshot, saveErr
+				}
 				return snapshot, nil
 			})
 			if err != nil {

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/netip"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 
@@ -405,6 +406,23 @@ func (m *Manager) Install(ctx context.Context, operation Operation) (core.Instal
 		// store.Core.Version 不作判据（DetectVersion 失败时旧值残留，见 runtime.go 启动检测）。
 		if operation.Source == "setup" {
 			if version, detectErr := m.installer.DetectVersion(ctx, installRequest.BinaryPath); detectErr == nil && version != "" {
+				sidecar := filepath.Join(filepath.Dir(installRequest.BinaryPath), "core-channel")
+				m.settingsMu.Lock()
+				changed, applyErr := config.ApplyCoreChannelSidecar(&m.settings, sidecar)
+				if changed && applyErr == nil {
+					applyErr = m.persistSettings()
+				}
+				appliedChannel := m.settings.CoreChannel
+				m.settingsMu.Unlock()
+				if applyErr != nil {
+					return nil, applyErr
+				}
+				if changed {
+					snapshot := m.store.Load()
+					snapshot.Core.Version = version
+					snapshot.Core.Channel = appliedChannel
+					m.store.Store(snapshot)
+				}
 				return core.InstallResult{Version: version, Updated: false}, nil
 			}
 			// -v 失败（缺失/损坏）→ 落 Prepare 联网修复（失败由 Prepare 报错并提示 aio 脚本）。

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/netip"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -1160,6 +1161,102 @@ func TestManagerInstallSetupSkipsNetworkWhenLocalCoreValid(t *testing.T) {
 	}
 	if got := installer.detectCalls.Load(); got != 1 {
 		t.Fatalf("detect calls=%d", got)
+	}
+}
+
+func TestManagerInstallSetupAppliesSidecarChannelWhenStampNew(t *testing.T) {
+	installer := &fakeInstaller{}
+	installer.detectVersion = func(context.Context, string) (string, error) {
+		return "v1.18.0", nil
+	}
+	installer.prepare = func(context.Context, core.InstallRequest) (PreparedCore, error) {
+		t.Fatal("Prepare must not be called when setup local core is valid")
+		return nil, nil
+	}
+
+	binDir := t.TempDir()
+	binaryPath := filepath.Join(binDir, "mihomo")
+	if err := os.WriteFile(binaryPath, []byte("placeholder"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "core-channel"), []byte("alpha\nalpha-e183c58\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	settings, settingsPath := persistedChannelSettings(t, "stable")
+	manager := newTestManager(Options{Installer: installer, Settings: settings, SettingsPath: settingsPath})
+	manager.installRequest.BinaryPath = binaryPath
+
+	result, err := manager.Install(context.Background(), Operation{ID: "setup-sidecar", Source: "setup"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Version != "v1.18.0" || result.Updated {
+		t.Fatalf("result=%#v", result)
+	}
+	if got := installer.calls.Load(); got != 0 {
+		t.Fatalf("prepare calls=%d (setup must skip network)", got)
+	}
+	if manager.settings.CoreChannel != "alpha" || manager.settings.CoreChannelBundle != "alpha-e183c58" {
+		t.Fatalf("settings channel=%q bundle=%q", manager.settings.CoreChannel, manager.settings.CoreChannelBundle)
+	}
+	if got := manager.store.Load().Core.Channel; got != "alpha" {
+		t.Fatalf("store.Core.Channel=%q want alpha", got)
+	}
+	if got := manager.store.Load().Core.Version; got != "v1.18.0" {
+		t.Fatalf("store.Core.Version=%q want v1.18.0", got)
+	}
+	loaded, err := config.Load(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.CoreChannel != "alpha" || loaded.CoreChannelBundle != "alpha-e183c58" {
+		t.Fatalf("persisted settings=%#v", loaded)
+	}
+}
+
+func TestManagerInstallSetupDoesNotRevertTUIChannelWhenSidecarStampMatches(t *testing.T) {
+	installer := &fakeInstaller{}
+	installer.detectVersion = func(context.Context, string) (string, error) {
+		return "v1.18.0", nil
+	}
+	installer.prepare = func(context.Context, core.InstallRequest) (PreparedCore, error) {
+		t.Fatal("Prepare must not be called when setup local core is valid")
+		return nil, nil
+	}
+
+	binDir := t.TempDir()
+	binaryPath := filepath.Join(binDir, "mihomo")
+	if err := os.WriteFile(binaryPath, []byte("placeholder"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "core-channel"), []byte("alpha\nalpha-e183c58\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	settings, settingsPath := persistedChannelSettings(t, "stable")
+	settings.CoreChannelBundle = "alpha-e183c58"
+	if err := config.Save(settingsPath, settings); err != nil {
+		t.Fatal(err)
+	}
+	manager := newTestManager(Options{Installer: installer, Settings: settings, SettingsPath: settingsPath})
+	manager.installRequest.BinaryPath = binaryPath
+
+	if _, err := manager.Install(context.Background(), Operation{ID: "setup-sidecar-stamp", Source: "setup"}); err != nil {
+		t.Fatal(err)
+	}
+	if manager.settings.CoreChannel != "stable" {
+		t.Fatalf("settings.CoreChannel=%q want stable", manager.settings.CoreChannel)
+	}
+	if got := manager.store.Load().Core.Channel; got == "alpha" {
+		t.Fatalf("store.Core.Channel=%q must not revert to alpha", got)
+	}
+	loaded, err := config.Load(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.CoreChannel != "stable" || loaded.CoreChannelBundle != "alpha-e183c58" {
+		t.Fatalf("persisted settings=%#v", loaded)
 	}
 }
 

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -1186,6 +1186,13 @@ func TestManagerInstallSetupAppliesSidecarChannelWhenStampNew(t *testing.T) {
 	settings, settingsPath := persistedChannelSettings(t, "stable")
 	manager := newTestManager(Options{Installer: installer, Settings: settings, SettingsPath: settingsPath})
 	manager.installRequest.BinaryPath = binaryPath
+	seeded := manager.store.Load()
+	seeded.Core.Status = "running"
+	seeded.Core.PID = 4242
+	seeded.Core.Restarts = 3
+	seeded.Core.AlphaSHA = "deadbeef"
+	manager.store.Store(seeded)
+	beforeRevision := manager.store.Load().Revision
 
 	result, err := manager.Install(context.Background(), Operation{ID: "setup-sidecar", Source: "setup"})
 	if err != nil {
@@ -1200,11 +1207,18 @@ func TestManagerInstallSetupAppliesSidecarChannelWhenStampNew(t *testing.T) {
 	if manager.settings.CoreChannel != "alpha" || manager.settings.CoreChannelBundle != "alpha-e183c58" {
 		t.Fatalf("settings channel=%q bundle=%q", manager.settings.CoreChannel, manager.settings.CoreChannelBundle)
 	}
-	if got := manager.store.Load().Core.Channel; got != "alpha" {
-		t.Fatalf("store.Core.Channel=%q want alpha", got)
+	core := manager.store.Load().Core
+	if core.Channel != "alpha" {
+		t.Fatalf("store.Core.Channel=%q want alpha", core.Channel)
 	}
-	if got := manager.store.Load().Core.Version; got != "v1.18.0" {
-		t.Fatalf("store.Core.Version=%q want v1.18.0", got)
+	if core.Version != "v1.18.0" {
+		t.Fatalf("store.Core.Version=%q want v1.18.0", core.Version)
+	}
+	if core.Status != "running" || core.PID != 4242 || core.Restarts != 3 || core.AlphaSHA != "deadbeef" {
+		t.Fatalf("setup sidecar store write must preserve existing Core fields: %#v", core)
+	}
+	if got := manager.store.Load().Revision; got != beforeRevision+1 {
+		t.Fatalf("revision=%d want %d (coordinator.Do must increment)", got, beforeRevision+1)
 	}
 	loaded, err := config.Load(settingsPath)
 	if err != nil {

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -735,6 +735,31 @@ func TestInstallCommitPersistsChannelAndClearsAlphaSHAOnStable(t *testing.T) {
 	}
 }
 
+func TestObservePreservesCoreChannelAndAlphaSHA(t *testing.T) {
+	installer := &fakeInstaller{candidate: &fakeCandidate{
+		version:  "v1.19.0",
+		alphaSHA: "e183c58",
+	}}
+	settings, settingsPath := persistedChannelSettings(t, "stable")
+	manager := newTestManager(Options{
+		Installer: installer, Settings: settings, SettingsPath: settingsPath, Supervisor: &fakeSupervisor{},
+	})
+	alpha := "alpha"
+	if _, err := manager.Install(context.Background(), Operation{ID: "alpha-install", Source: "test", Channel: &alpha}); err != nil {
+		t.Fatal(err)
+	}
+
+	manager.Observe(supervisor.Observation{Status: supervisor.StatusRunning, PID: 4242})
+
+	core := manager.store.Load().Core
+	if core.Status != string(supervisor.StatusRunning) || core.PID != 4242 {
+		t.Fatalf("observe did not apply runtime fields: %#v", core)
+	}
+	if core.Version != "v1.19.0" || core.Channel != "alpha" || core.AlphaSHA != "e183c58" {
+		t.Fatalf("observe wiped identity: %#v", core)
+	}
+}
+
 func TestInstallRejectsNightlyChannelBeforePrepare(t *testing.T) {
 	installer := &fakeInstaller{candidate: &fakeCandidate{version: "v1.19.0"}}
 	settings, settingsPath := persistedChannelSettings(t, "stable")

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -635,6 +635,140 @@ func TestInstallUsesCurrentVersionAndSkipsRestartWhenUnchanged(t *testing.T) {
 	}
 }
 
+func TestInstallCoalescesSettingsChannelWhenOperationChannelNil(t *testing.T) {
+	requestSeen := make(chan core.InstallRequest, 1)
+	installer := &fakeInstaller{candidate: &fakeCandidate{version: "v1.19.0"}}
+	installer.prepare = func(_ context.Context, request core.InstallRequest) (PreparedCore, error) {
+		requestSeen <- request
+		return installer.candidate, nil
+	}
+	settings := config.Defaults()
+	settings.ControllerSecret = strings.Repeat("a", 64)
+	settings.CoreChannel = "alpha"
+	manager := newTestManager(Options{Installer: installer, Settings: settings, Supervisor: &fakeSupervisor{}})
+	snapshot := manager.store.Load()
+	snapshot.Core.AlphaSHA = "e183c58"
+	manager.store.Store(snapshot)
+
+	if _, err := manager.Install(context.Background(), Operation{ID: "coalesce-settings", Source: "test"}); err != nil {
+		t.Fatal(err)
+	}
+	request := <-requestSeen
+	if request.Channel != "alpha" {
+		t.Fatalf("request.Channel=%q want alpha", request.Channel)
+	}
+	if request.AlphaSHA != "e183c58" {
+		t.Fatalf("request.AlphaSHA=%q want e183c58", request.AlphaSHA)
+	}
+}
+
+func TestInstallDoesNotPersistChannelWhenPrepareFails(t *testing.T) {
+	requestSeen := make(chan core.InstallRequest, 1)
+	installer := &fakeInstaller{}
+	installer.prepare = func(_ context.Context, request core.InstallRequest) (PreparedCore, error) {
+		requestSeen <- request
+		return nil, protocol.APIError{Code: protocol.CodeDataFailure, Message: "prepare failed"}
+	}
+	settings, settingsPath := persistedChannelSettings(t, "stable")
+	manager := newTestManager(Options{Installer: installer, Settings: settings, SettingsPath: settingsPath})
+	channel := "alpha"
+	_, err := manager.Install(context.Background(), Operation{ID: "switch-fail", Source: "test", Channel: &channel})
+	if err == nil {
+		t.Fatal("expected prepare error")
+	}
+	request := <-requestSeen
+	if request.Channel != "alpha" {
+		t.Fatalf("request.Channel=%q want alpha", request.Channel)
+	}
+	loaded, err := config.Load(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.CoreChannel != "stable" {
+		t.Fatalf("settings.CoreChannel=%q want stable", loaded.CoreChannel)
+	}
+	if got := manager.store.Load().Core.Channel; got != "" {
+		t.Fatalf("store.Core.Channel=%q want empty", got)
+	}
+}
+
+func TestInstallCommitPersistsChannelAndClearsAlphaSHAOnStable(t *testing.T) {
+	installer := &fakeInstaller{candidate: &fakeCandidate{
+		version:  "v1.19.0",
+		alphaSHA: "e183c58",
+	}}
+	settings, settingsPath := persistedChannelSettings(t, "stable")
+	manager := newTestManager(Options{
+		Installer: installer, Settings: settings, SettingsPath: settingsPath, Supervisor: &fakeSupervisor{},
+	})
+	alpha := "alpha"
+	if _, err := manager.Install(context.Background(), Operation{ID: "alpha-install", Source: "test", Channel: &alpha}); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := config.Load(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.CoreChannel != "alpha" {
+		t.Fatalf("settings.CoreChannel=%q want alpha", loaded.CoreChannel)
+	}
+	core := manager.store.Load().Core
+	if core.Version != "v1.19.0" || core.Channel != "alpha" || core.AlphaSHA != "e183c58" {
+		t.Fatalf("after alpha install core=%#v", core)
+	}
+
+	installer.candidate = &fakeCandidate{version: "v1.19.1"}
+	stable := "stable"
+	if _, err := manager.Install(context.Background(), Operation{ID: "stable-install", Source: "test", Channel: &stable}); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err = config.Load(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.CoreChannel != "stable" {
+		t.Fatalf("settings.CoreChannel=%q want stable", loaded.CoreChannel)
+	}
+	core = manager.store.Load().Core
+	if core.Channel != "stable" || core.AlphaSHA != "" {
+		t.Fatalf("after stable install core=%#v", core)
+	}
+}
+
+func TestInstallRejectsNightlyChannelBeforePrepare(t *testing.T) {
+	installer := &fakeInstaller{candidate: &fakeCandidate{version: "v1.19.0"}}
+	settings, settingsPath := persistedChannelSettings(t, "stable")
+	manager := newTestManager(Options{Installer: installer, Settings: settings, SettingsPath: settingsPath})
+	nightly := "nightly"
+	_, err := manager.Install(context.Background(), Operation{ID: "nightly", Source: "test", Channel: &nightly})
+	var apiError protocol.APIError
+	if !errors.As(err, &apiError) || apiError.Code != protocol.CodeDataFailure {
+		t.Fatalf("err=%v", err)
+	}
+	if got := installer.calls.Load(); got != 0 {
+		t.Fatalf("Prepare called %d times", got)
+	}
+	loaded, err := config.Load(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.CoreChannel != "stable" {
+		t.Fatalf("settings.CoreChannel=%q want stable", loaded.CoreChannel)
+	}
+}
+
+func persistedChannelSettings(t *testing.T, channel string) (config.Settings, string) {
+	t.Helper()
+	settings := config.Defaults()
+	settings.ControllerSecret = strings.Repeat("a", 64)
+	settings.CoreChannel = channel
+	path := filepath.Join(t.TempDir(), "settings.yaml")
+	if err := config.Save(path, settings); err != nil {
+		t.Fatal(err)
+	}
+	return settings, path
+}
+
 func TestMissingCoreStaysControllableAndStartsAfterInstall(t *testing.T) {
 	var exists atomic.Bool
 	supervisorStarted := make(chan struct{})
@@ -787,6 +921,7 @@ func (i *fakeInstaller) DetectVersion(ctx context.Context, binaryPath string) (s
 
 type fakeCandidate struct {
 	version    string
+	alphaSHA   string
 	notUpdated bool
 	commit     func() (core.InstallResult, error)
 	cleaned    atomic.Bool
@@ -800,7 +935,7 @@ func (c *fakeCandidate) Commit() (core.InstallResult, error) {
 	if c.commit != nil {
 		return c.commit()
 	}
-	return core.InstallResult{Version: c.version, Updated: !c.notUpdated}, nil
+	return core.InstallResult{Version: c.version, Updated: !c.notUpdated, AlphaSHA: c.alphaSHA}, nil
 }
 
 func (c *fakeCandidate) Cleanup() { c.cleaned.Store(true) }

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -38,6 +38,8 @@ type SubscriptionState struct {
 type CoreState struct {
 	Status      string
 	Version     string
+	Channel     string
+	AlphaSHA    string
 	PID         int
 	Restarts    uint64
 	LastError   string

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -11,6 +11,7 @@ const (
 	RollbackPanel           = ui.ActionRollbackPanel
 	RestartCore             = ui.ActionRestartCore
 	UpdateCore              = ui.ActionUpdateCore
+	SwitchCoreChannel       = ui.ActionSwitchCoreChannel
 	UpdateMihari            = ui.ActionUpdateMihari
 	ApplyEndpointChange     = ui.ActionApplyEndpointChange
 	SelectProxy             = ui.ActionSelectProxy
@@ -40,7 +41,7 @@ const (
 
 func RequiresConfirmation(action Action) bool {
 	switch action {
-	case DeleteSubscription, CloseAllConnections, UpdateAllProviders, RefreshAllSubscriptions, RollbackPanel, RestartCore, UpdateCore, UpdateMihari, ApplyEndpointChange,
+	case DeleteSubscription, CloseAllConnections, UpdateAllProviders, RefreshAllSubscriptions, RollbackPanel, RestartCore, UpdateCore, SwitchCoreChannel, UpdateMihari, ApplyEndpointChange,
 		UninstallPanel, ReinstallPanel,
 		ServiceInstall, ServiceUninstall, ServiceReinstall, ServiceStart, ServiceStop, ServiceRestart,
 		EnableSystemProxy, ForceSystemProxy, DisableSystemProxy, EnableTun, ForceTun, DisableTun:
@@ -63,7 +64,7 @@ func RequiresDaemon(action Action) bool {
 
 func knownAction(action Action) bool {
 	switch action {
-	case DeleteSubscription, CloseAllConnections, UpdateAllProviders, RefreshAllSubscriptions, RollbackPanel, RestartCore, UpdateCore, UpdateMihari, ApplyEndpointChange,
+	case DeleteSubscription, CloseAllConnections, UpdateAllProviders, RefreshAllSubscriptions, RollbackPanel, RestartCore, UpdateCore, SwitchCoreChannel, UpdateMihari, ApplyEndpointChange,
 		SelectProxy, CloseConnection, RefreshSubscription, UpdateProvider,
 		InstallPanel, UpdatePanel, ActivatePanel, OpenWebGUI, UninstallPanel, ReinstallPanel,
 		ServiceInstall, ServiceUninstall, ServiceReinstall, ServiceStart, ServiceStop, ServiceRestart,

--- a/internal/tui/pages/system/model.go
+++ b/internal/tui/pages/system/model.go
@@ -23,7 +23,7 @@ import (
 const (
 	rowDaemon            = "daemon"
 	rowCore              = "core"
-	rowCoreChannel      = "core-channel"
+	rowCoreChannel       = "core-channel"
 	rowCoreUpdate        = "core-update"
 	rowCoreRestart       = "core-restart"
 	rowMihariUpdate      = "mihari-update"

--- a/internal/tui/pages/system/model.go
+++ b/internal/tui/pages/system/model.go
@@ -23,6 +23,7 @@ import (
 const (
 	rowDaemon            = "daemon"
 	rowCore              = "core"
+	rowCoreChannel      = "core-channel"
 	rowCoreUpdate        = "core-update"
 	rowCoreRestart       = "core-restart"
 	rowMihariUpdate      = "mihari-update"
@@ -194,6 +195,7 @@ type actionKind uint8
 const (
 	actionUpdate actionKind = iota
 	actionRestart
+	actionSwitchChannel
 )
 
 type serviceActionKind uint8
@@ -253,6 +255,8 @@ type actionStartMsg struct {
 	kind        actionKind
 	operationID string
 	revision    uint64
+	channel     string
+	source      string
 }
 
 type actionResultMsg struct {
@@ -696,7 +700,7 @@ func (m *Model) Update(message tea.Msg) (ui.Page, tea.Cmd) {
 		}
 		m.markRowOutcome(rowID, true, "")
 		revision := typed.restart.Revision
-		if typed.kind == actionUpdate {
+		if typed.kind == actionUpdate || typed.kind == actionSwitchChannel {
 			revision = typed.install.Revision
 		}
 		return m, tea.Batch(m.refresh(), m.loadCore(), func() tea.Msg { return ui.RuntimeRevisionMsg{Revision: revision} }, m.rowSpinCmdIfNeeded())
@@ -763,6 +767,11 @@ func (m *Model) Update(message tea.Msg) (ui.Page, tea.Cmd) {
 				return m, nil
 			}
 			return m, func() tea.Msg { return ui.RouteRequestMsg{Page: ui.PageSetup} }
+		case rowCoreChannel:
+			if m.client == nil || !m.mutationsEnabled || !m.hasCapability(protocol.CapabilityCore) {
+				return m, nil
+			}
+			return m, m.confirmSwitchCoreChannel(otherCoreChannel(m.core.Channel))
 		case rowCoreUpdate:
 			if m.client == nil || !m.mutationsEnabled || !m.hasCapability(protocol.CapabilityCore) {
 				return m, nil
@@ -966,6 +975,7 @@ func (m *Model) rows() []row {
 	rows = append(rows,
 		row{id: rowRunSetup, section: ui.DaemonSectionTitle, label: ui.RunSetupLabel, detail: ui.RunSetupDetail},
 		row{id: rowCore, section: ui.CoreSectionTitle, label: ui.MihomoCoreLabel, value: coreValue(m.theme, m.core, !m.mutationsEnabled), detail: core},
+		row{id: rowCoreChannel, section: ui.CoreSectionTitle, label: ui.CoreChannelLabel, value: coreChannelName(m.core.Channel), detail: ui.SwitchCoreChannelImpact},
 		row{id: rowCoreUpdate, section: ui.CoreSectionTitle, label: m.coreActionLabel(), value: actionState(m.hasCapability(protocol.CapabilityCore), m.mutationsEnabled), detail: ui.UpdateCoreImpact},
 		row{id: rowCoreRestart, section: ui.CoreSectionTitle, label: ui.RestartCoreLabel, value: actionState(m.hasCapability(protocol.CapabilityCore), m.mutationsEnabled), detail: ui.RestartCoreImpact},
 	)
@@ -1400,6 +1410,8 @@ func coreRowForKind(kind actionKind) string {
 		return rowCoreUpdate
 	case actionRestart:
 		return rowCoreRestart
+	case actionSwitchChannel:
+		return rowCoreChannel
 	default:
 		return ""
 	}
@@ -1453,6 +1465,8 @@ func rowProgressForAction(action ui.Action, coreMissing bool) (rowID, note strin
 			return rowCoreUpdate, ui.CoreProgressInstalling
 		}
 		return rowCoreUpdate, ui.CoreProgressUpdating
+	case ui.ActionSwitchCoreChannel:
+		return rowCoreChannel, ui.CoreProgressSwitching
 	case ui.ActionRestartCore:
 		return rowCoreRestart, ui.CoreProgressRestarting
 	case ui.ActionEnableSystemProxy, ui.ActionForceSystemProxy:
@@ -1699,6 +1713,25 @@ func (m *Model) tunRevision() uint64 {
 	return m.currentRevision()
 }
 
+func (m *Model) confirmSwitchCoreChannel(target string) tea.Cmd {
+	if coreChannelName(m.core.Channel) == target {
+		return nil
+	}
+	revision, operationID := m.currentRevision(), m.newOperationID()
+	return func() tea.Msg {
+		return ui.ActionIntentMsg{
+			Action: ui.ActionSwitchCoreChannel, Page: ui.PageSystem, Capability: protocol.CapabilityCore,
+			Key:   "system:" + string(ui.ActionSwitchCoreChannel),
+			Title: ui.SwitchCoreChannelTitle, Object: ui.MihomoCoreLabel,
+			Impact: ui.SwitchCoreChannelImpact, Rollback: ui.SwitchCoreChannelRollback,
+			Execute: m.runAction(actionStartMsg{
+				kind: actionSwitchChannel, operationID: operationID, revision: revision,
+				channel: target, source: "channel-switch",
+			}),
+		}
+	}
+}
+
 func (m *Model) confirmAction(kind actionKind) tea.Cmd {
 	revision, operationID := m.currentRevision(), m.newOperationID()
 	title, object, impact, rollback := ui.UpdateCoreTitle, ui.MihomoCoreLabel, ui.UpdateCoreImpact, ui.UpdateCoreRollback
@@ -1751,8 +1784,12 @@ func (m *Model) tunActionLabel() string {
 func (m *Model) runAction(start actionStartMsg) tea.Cmd {
 	return func() tea.Msg {
 		revision := start.revision
-		request := protocol.MutationRequest{OperationID: start.operationID, IfRevision: &revision}
-		if start.kind == actionUpdate {
+		request := protocol.MutationRequest{OperationID: start.operationID, IfRevision: &revision, Source: start.source}
+		if start.channel != "" {
+			channel := start.channel
+			request.Channel = &channel
+		}
+		if start.kind == actionUpdate || start.kind == actionSwitchChannel {
 			result, err := m.client.InstallCore(m.ctx, request)
 			return actionResultMsg{kind: start.kind, install: result, err: err}
 		}
@@ -1827,7 +1864,21 @@ func coreValue(theme ui.Theme, core protocol.CoreStatus, stale bool) string {
 		status += " · " + ui.StaleLabel
 	}
 	return ui.StatusDot(theme, tone, status) + "  " +
-		theme.Muted.Render(valueOr(core.Version, ui.UnknownLabel))
+		theme.Muted.Render(valueOr(core.Version, ui.UnknownLabel)+"  "+coreChannelName(core.Channel))
+}
+
+func coreChannelName(channel string) string {
+	if strings.TrimSpace(channel) == "" {
+		return "stable"
+	}
+	return channel
+}
+
+func otherCoreChannel(channel string) string {
+	if coreChannelName(channel) == "alpha" {
+		return "stable"
+	}
+	return "alpha"
 }
 
 // proxyTone derives the system-proxy status tone: a foreign observer or a

--- a/internal/tui/pages/system/model_test.go
+++ b/internal/tui/pages/system/model_test.go
@@ -2039,7 +2039,9 @@ func TestSystemCoreChannelEnterSwitchesToOtherChannel(t *testing.T) {
 	model.SetMutationsEnabled(true)
 	model.focusID = rowCoreChannel
 	updated, command := model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
-	model = updated.(*Model)
+	if _, ok := updated.(*Model); !ok {
+		t.Fatalf("updated=%T", updated)
+	}
 	if command == nil || client.installCalls != 0 {
 		t.Fatalf("command=%v installCalls=%d", command != nil, client.installCalls)
 	}

--- a/internal/tui/pages/system/model_test.go
+++ b/internal/tui/pages/system/model_test.go
@@ -650,7 +650,7 @@ func TestSystemOffersCoreInstallWhenNoVersionIsPresent(t *testing.T) {
 func TestSystemDisablesMutationsAndSetupRouteWhileDisconnected(t *testing.T) {
 	model := New(&fakeClient{}, func() string { return "system-op" })
 	model.SetSnapshot(protocol.Status{Capabilities: []string{protocol.CapabilityCore, protocol.CapabilityOnboarding}}, protocol.CoreStatus{Version: "v1.19.0"})
-	for _, id := range []string{rowCoreUpdate, rowCoreRestart, rowRunSetup} {
+	for _, id := range []string{rowCoreUpdate, rowCoreRestart, rowCoreChannel, rowRunSetup} {
 		model.focusID = id
 		updated, command := model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 		model = updated.(*Model)
@@ -682,7 +682,7 @@ func TestSystemSuccessfulRestartReconcilesAuthoritativeCore(t *testing.T) {
 
 func TestSystemDoesNotOfferCoreMutationWithoutClientOrCapability(t *testing.T) {
 	for _, model := range []*Model{New(nil, func() string { return "system-op" }), New(&fakeClient{}, func() string { return "system-op" })} {
-		for _, id := range []string{rowCoreUpdate, rowCoreRestart} {
+		for _, id := range []string{rowCoreUpdate, rowCoreRestart, rowCoreChannel} {
 			model.focusID = id
 			updated, command := model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 			model = updated.(*Model)
@@ -2004,5 +2004,130 @@ func TestSystemDaemonCoreRowsDegradeWhenDisconnected(t *testing.T) {
 	reconnected := model.View()
 	if strings.Contains(reconnected, " · "+ui.StaleLabel) || !strings.Contains(reconnected, "38;5;78") {
 		t.Fatalf("reconnected view should drop stale and restore green:\n%s", reconnected)
+	}
+}
+
+func TestSystemCoreChannelRowRendersSnapshotChannelAndVersion(t *testing.T) {
+	model := New(nil, func() string { return "op" })
+	model.SetSize(100, 40)
+	model.SetSnapshot(
+		protocol.Status{Capabilities: []string{protocol.CapabilityCore}},
+		protocol.CoreStatus{Status: "running", Version: "v1.19.0", Channel: "stable"},
+	)
+	view := model.View()
+	if !strings.Contains(view, ui.CoreChannelLabel) {
+		t.Fatalf("missing core channel label:\n%s", view)
+	}
+	if !strings.Contains(view, "stable") {
+		t.Fatalf("missing stable channel:\n%s", view)
+	}
+	if !strings.Contains(view, "v1.19.0") {
+		t.Fatalf("missing core version:\n%s", view)
+	}
+	if strings.Contains(view, "Prerelease-Alpha") {
+		t.Fatalf("must not show Prerelease-Alpha as version:\n%s", view)
+	}
+}
+
+func TestSystemCoreChannelEnterSwitchesToOtherChannel(t *testing.T) {
+	client := &fakeClient{onboarding: protocol.OnboardingStatus{Revision: 11}}
+	model := New(client, func() string { return "system-op" })
+	model.SetSnapshot(
+		protocol.Status{Revision: 11, Capabilities: []string{protocol.CapabilityCore}},
+		protocol.CoreStatus{Revision: 11, Status: "running", Version: "alpha-dd7bc4c", Channel: "alpha"},
+	)
+	model.SetMutationsEnabled(true)
+	model.focusID = rowCoreChannel
+	updated, command := model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	model = updated.(*Model)
+	if command == nil || client.installCalls != 0 {
+		t.Fatalf("command=%v installCalls=%d", command != nil, client.installCalls)
+	}
+	intent, ok := command().(ui.ActionIntentMsg)
+	if !ok || intent.Action != ui.ActionSwitchCoreChannel || intent.Execute == nil {
+		t.Fatalf("intent=%#v", intent)
+	}
+	if intent.Title != ui.SwitchCoreChannelTitle || intent.Impact != ui.SwitchCoreChannelImpact || intent.Rollback != ui.SwitchCoreChannelRollback {
+		t.Fatalf("confirmation copy=%#v", intent)
+	}
+	_ = intent.Execute()
+	if client.installCalls != 1 {
+		t.Fatalf("installCalls=%d", client.installCalls)
+	}
+	if client.lastMutation.Source != "channel-switch" {
+		t.Fatalf("source=%q", client.lastMutation.Source)
+	}
+	if client.lastMutation.Channel == nil || *client.lastMutation.Channel != "stable" {
+		t.Fatalf("channel=%v", client.lastMutation.Channel)
+	}
+	if client.lastMutation.IfRevision == nil || *client.lastMutation.IfRevision != 11 {
+		t.Fatalf("mutation=%#v", client.lastMutation)
+	}
+	if client.lastMutation.OperationID != "system-op" {
+		t.Fatalf("operation=%q", client.lastMutation.OperationID)
+	}
+}
+
+func TestSystemCoreChannelEnterDoesNotReinstallSameChannel(t *testing.T) {
+	client := &fakeClient{onboarding: protocol.OnboardingStatus{Revision: 4}}
+	model := New(client, func() string { return "system-op" })
+	model.SetSnapshot(
+		protocol.Status{Revision: 4, Capabilities: []string{protocol.CapabilityCore}},
+		protocol.CoreStatus{Revision: 4, Status: "running", Version: "v1.19.0", Channel: "stable"},
+	)
+	model.SetMutationsEnabled(true)
+	model.focusID = rowCoreChannel
+
+	if cmd := model.confirmSwitchCoreChannel("stable"); cmd != nil {
+		t.Fatal("switching to the current channel must be a no-op")
+	}
+	if client.installCalls != 0 {
+		t.Fatalf("installCalls=%d", client.installCalls)
+	}
+
+	model.core.Channel = ""
+	if cmd := model.confirmSwitchCoreChannel("stable"); cmd != nil || client.installCalls != 0 {
+		t.Fatalf("empty channel is stable; installCalls=%d cmd=%v", client.installCalls, cmd != nil)
+	}
+}
+
+func TestSystemCoreChannelFailureKeepsSnapshotChannel(t *testing.T) {
+	model := New(&fakeClient{}, func() string { return "op" })
+	model.SetSnapshot(
+		protocol.Status{Capabilities: []string{protocol.CapabilityCore}},
+		protocol.CoreStatus{Status: "running", Version: "v1.19.0", Channel: "alpha"},
+	)
+	model.SetMutationsEnabled(true)
+
+	updated, _ := model.Update(ui.ActionPendingMsg{Action: ui.ActionSwitchCoreChannel})
+	model = updated.(*Model)
+	if model.pendingRow != rowCoreChannel {
+		t.Fatalf("pending row=%q", model.pendingRow)
+	}
+	if model.pendingNote != ui.CoreProgressSwitching && model.pendingNote != ui.CoreProgressUpdating {
+		t.Fatalf("pending note=%q", model.pendingNote)
+	}
+	model.rowSpinClock = time.Unix(0, 0)
+	if view := model.View(); !strings.Contains(view, model.pendingNote) {
+		t.Fatalf("missing pending chip:\n%s", view)
+	}
+
+	updated, _ = model.Update(actionResultMsg{
+		kind: actionSwitchChannel,
+		err:  protocol.APIError{Code: protocol.CodeNetworkFailure, Message: "download core asset failed"},
+	})
+	model = updated.(*Model)
+	if model.outcomeRow != rowCoreChannel || model.outcomeOK {
+		t.Fatalf("outcome row=%q ok=%v", model.outcomeRow, model.outcomeOK)
+	}
+	view := model.View()
+	if !strings.Contains(view, ui.FailedLabel) {
+		t.Fatalf("missing Failed chip:\n%s", view)
+	}
+	if !strings.Contains(view, "alpha") {
+		t.Fatalf("failed view must keep snapshot channel:\n%s", view)
+	}
+	if strings.Contains(view, "Prerelease-Alpha") {
+		t.Fatalf("must not show Prerelease-Alpha:\n%s", view)
 	}
 }

--- a/internal/tui/pages/system/section_test.go
+++ b/internal/tui/pages/system/section_test.go
@@ -40,6 +40,9 @@ func TestView_SectionGroups(t *testing.T) {
 	if !strings.Contains(view, "v0.4.0") || !strings.Contains(view, "v1.19.0") {
 		t.Fatalf("status values missing:\n%s", view)
 	}
+	if !strings.Contains(view, ui.CoreChannelLabel) {
+		t.Fatalf("missing core channel row in Core section:\n%s", view)
+	}
 	// Borders are globally constant: every section uses the surface border
 	// (240) with an accent (63) title. The old per-section palette
 	// (info 75 / warning 214) must be gone — color now means status, not region.

--- a/internal/tui/policy_test.go
+++ b/internal/tui/policy_test.go
@@ -10,7 +10,7 @@ import (
 func TestConfirmationPolicy(t *testing.T) {
 	want := map[Action]bool{
 		DeleteSubscription: true, CloseAllConnections: true, UpdateAllProviders: true, RefreshAllSubscriptions: true,
-		RollbackPanel: true, RestartCore: true, UpdateCore: true, ApplyEndpointChange: true,
+		RollbackPanel: true, RestartCore: true, UpdateCore: true, SwitchCoreChannel: true, ApplyEndpointChange: true,
 		SelectProxy: false, CloseConnection: false, RefreshSubscription: false, UpdateProvider: false,
 		InstallPanel: false, UpdatePanel: false, ActivatePanel: false, OpenWebGUI: false,
 		UninstallPanel: true, ReinstallPanel: true,
@@ -32,6 +32,18 @@ func TestConfirmationPolicy(t *testing.T) {
 	}
 	if !RequiresDaemon(UpdateCore) {
 		t.Fatal("core update should require daemon connection")
+	}
+}
+
+func TestCoreChannelPolicyRequiresConfirmationAndDaemon(t *testing.T) {
+	if !knownAction(SwitchCoreChannel) {
+		t.Fatal("core channel switch must be registered")
+	}
+	if !RequiresConfirmation(SwitchCoreChannel) {
+		t.Fatal("core channel switch must require confirmation")
+	}
+	if !RequiresDaemon(SwitchCoreChannel) {
+		t.Fatal("core channel switch must require a daemon connection")
 	}
 }
 

--- a/internal/tui/ui/action.go
+++ b/internal/tui/ui/action.go
@@ -11,6 +11,7 @@ const (
 	ActionRollbackPanel           Action = "rollback-panel"
 	ActionRestartCore             Action = "restart-core"
 	ActionUpdateCore              Action = "update-core"
+	ActionSwitchCoreChannel       Action = "switch-core-channel"
 	ActionUpdateMihari            Action = "update-mihari"
 	ActionApplyEndpointChange     Action = "apply-endpoint-change"
 	ActionSelectProxy             Action = "select-proxy"

--- a/internal/tui/ui/strings.go
+++ b/internal/tui/ui/strings.go
@@ -179,6 +179,7 @@ const (
 	PanelOpenDetail         = "Web GUI panel mount. Enter opens it in the default browser."
 	CoreSectionTitle        = "mihomo core"
 	MihomoCoreLabel         = "mihomo core"
+	CoreChannelLabel        = "Core channel"
 	UpdateCoreLabel         = "Update core"
 	UpdateMihariLabel       = "Update Mihari"
 	InstallCoreLabel        = "Install core"
@@ -240,6 +241,7 @@ const (
 	CoreProgressUpdating        = "Updating"
 	CoreProgressInstalling      = "Installing"
 	CoreProgressRestarting      = "Restarting"
+	CoreProgressSwitching       = "Switching"
 	MihariProgressChecking      = "Checking"
 	MihariProgressUpdating      = "Updating"
 	ProxyProgressEnabling       = "Enabling"
@@ -304,6 +306,9 @@ const (
 	RestartCoreTitle             = "Restart mihomo core"
 	RestartCoreImpact            = "Current proxy connections may be interrupted."
 	RestartCoreRollback          = "The supervised core will retry according to daemon policy."
+	SwitchCoreChannelTitle       = "Switch core channel"
+	SwitchCoreChannelImpact      = "The current core will be discarded and reinstalled from the selected channel, then restarted."
+	SwitchCoreChannelRollback    = "The previous valid core remains if installation fails."
 )
 
 const (

--- a/scripts/build-all-in-one/main.go
+++ b/scripts/build-all-in-one/main.go
@@ -40,6 +40,7 @@ type options struct {
 	ScriptsDir  string // directory holding install-aio.sh / install-aio.ps1 (scripts/install in CI)
 	Platforms   []string
 	GitHubToken string // optional; adds Authorization: Bearer when set
+	Channel     string // mihomo channel: stable (default) or alpha
 
 	// Test seams (zero-valued in production).
 	HTTPClient    *http.Client
@@ -56,11 +57,12 @@ func main() {
 	platforms := flag.String("platforms", strings.Join(defaultPlatforms, ","), "comma-separated goos/goarch targets")
 	scriptsDir := flag.String("scripts-dir", "scripts/install", "directory holding install-aio.sh / install-aio.ps1")
 	token := flag.String("github-token", os.Getenv("GITHUB_TOKEN"), "GitHub API token (default $GITHUB_TOKEN)")
+	channel := flag.String("channel", "stable", "mihomo channel: stable or alpha")
 	flag.Parse()
 
 	if err := run(options{
 		MihariDir: *mihariDir, Out: *out, ScriptsDir: *scriptsDir,
-		Platforms: splitPlatforms(*platforms), GitHubToken: *token,
+		Platforms: splitPlatforms(*platforms), GitHubToken: *token, Channel: *channel,
 	}); err != nil {
 		fmt.Fprintln(os.Stderr, "build-all-in-one:", err)
 		os.Exit(1)
@@ -80,6 +82,9 @@ func run(o options) error {
 	if o.ScriptsDir == "" {
 		o.ScriptsDir = "scripts/install"
 	}
+	if o.Channel == "" {
+		o.Channel = "stable"
+	}
 	if err := os.MkdirAll(o.Out, 0o755); err != nil {
 		return fmt.Errorf("create bundles directory: %w", err)
 	}
@@ -91,7 +96,7 @@ func run(o options) error {
 	ctx := context.Background()
 
 	// Exactly one mihomo API request returns every platform asset.
-	release, err := installer.LatestRelease(ctx, "stable")
+	release, err := installer.LatestRelease(ctx, o.Channel)
 	if err != nil {
 		return fmt.Errorf("fetch mihomo release: %w", err)
 	}
@@ -126,7 +131,7 @@ func buildPlatform(ctx context.Context, installer core.Installer, release core.R
 	}
 	defer os.RemoveAll(stage)
 
-	asset, err := core.SelectAsset(release, goos, goarch, "stable")
+	asset, err := core.SelectAsset(release, goos, goarch, o.Channel)
 	if err != nil {
 		return err
 	}
@@ -149,6 +154,9 @@ func buildPlatform(ctx context.Context, installer core.Installer, release core.R
 	}
 	mihomoDest := filepath.Join(stage, "data", "bin", mihomoName)
 	if err := extractMihomo(archivePath, asset.Name, mihomoDest); err != nil {
+		return err
+	}
+	if err := writeCoreChannelSidecar(filepath.Join(stage, "data", "bin", "core-channel"), o.Channel, release, asset); err != nil {
 		return err
 	}
 	if err := os.Remove(archivePath); err != nil {
@@ -238,6 +246,7 @@ var stageWhitelist = map[string]bool{
 	"mihari": true, "mihari.exe": true,
 	"install-aio.sh": true, "install-aio.ps1": true,
 	"data/bin/mihomo": true, "data/bin/mihomo.exe": true,
+	"data/bin/core-channel":            true,
 	"data/geoip/GeoLite2-Country.mmdb": true,
 	"data/geoip/GeoLite2-ASN.mmdb":     true,
 }
@@ -256,6 +265,7 @@ func assertStage(goos string, files []string) error {
 		"mihari" + suffix,
 		script,
 		"data/bin/mihomo" + suffix,
+		"data/bin/core-channel",
 		"data/geoip/GeoLite2-Country.mmdb",
 		"data/geoip/GeoLite2-ASN.mmdb",
 	}
@@ -269,6 +279,21 @@ func assertStage(goos string, files []string) error {
 		}
 	}
 	return nil
+}
+
+func writeCoreChannelSidecar(path, channel string, release core.Release, asset core.Asset) error {
+	if channel == "" {
+		channel = "stable"
+	}
+	fingerprint := release.TagName
+	if channel == "alpha" {
+		fingerprint = core.ParseAlphaSHA(asset.Name)
+	}
+	if fingerprint == "" {
+		return fmt.Errorf("empty core-channel fingerprint for %s asset %q", channel, asset.Name)
+	}
+	content := channel + "\n" + channel + "-" + fingerprint + "\n"
+	return os.WriteFile(path, []byte(content), 0o644)
 }
 
 func extractMihomo(archivePath, assetName, dest string) error {

--- a/scripts/build-all-in-one/main.go
+++ b/scripts/build-all-in-one/main.go
@@ -91,7 +91,7 @@ func run(o options) error {
 	ctx := context.Background()
 
 	// Exactly one mihomo API request returns every platform asset.
-	release, err := installer.LatestRelease(ctx)
+	release, err := installer.LatestRelease(ctx, "stable")
 	if err != nil {
 		return fmt.Errorf("fetch mihomo release: %w", err)
 	}
@@ -126,7 +126,7 @@ func buildPlatform(ctx context.Context, installer core.Installer, release core.R
 	}
 	defer os.RemoveAll(stage)
 
-	asset, err := core.SelectAsset(release, goos, goarch)
+	asset, err := core.SelectAsset(release, goos, goarch, "stable")
 	if err != nil {
 		return err
 	}

--- a/scripts/build-all-in-one/main_test.go
+++ b/scripts/build-all-in-one/main_test.go
@@ -166,7 +166,7 @@ func TestSidecarScriptInstallersCopyCoreChannel(t *testing.T) {
 	}
 	root := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
 	for _, name := range []string{"install-aio.sh", "install-aio.ps1"} {
-		data, err := os.ReadFile(filepath.Join(root, name))
+		data, err := os.ReadFile(filepath.Join(root, "scripts", "install", name))
 		if err != nil {
 			t.Fatalf("read %s: %v", name, err)
 		}

--- a/scripts/build-all-in-one/main_test.go
+++ b/scripts/build-all-in-one/main_test.go
@@ -159,6 +159,27 @@ func TestBundlerAlphaChannelWritesSidecar(t *testing.T) {
 	}
 }
 
+func TestSidecarScriptInstallersCopyCoreChannel(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+	for _, name := range []string{"install-aio.sh", "install-aio.ps1"} {
+		data, err := os.ReadFile(filepath.Join(root, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		text := string(data)
+		if !strings.Contains(text, "core-channel") {
+			t.Errorf("%s: expected to copy data/bin/core-channel sidecar", name)
+		}
+		if !strings.Contains(text, "Never touches") || !strings.Contains(text, "mihari.yaml") {
+			t.Errorf("%s: expected Never touches comment to mention mihari.yaml", name)
+		}
+	}
+}
+
 func TestSmokeMihomoExecutesHostTarget(t *testing.T) {
 	ctx := context.Background()
 	// Deliberately invalid magic: the host-matching target must exec the runner

--- a/scripts/build-all-in-one/main_test.go
+++ b/scripts/build-all-in-one/main_test.go
@@ -88,6 +88,7 @@ func TestBundlerProducesSixPlatformBundles(t *testing.T) {
 			"mihari" + suffix:                  true,
 			script:                             true,
 			"data/bin/mihomo" + suffix:         true,
+			"data/bin/core-channel":            true,
 			"data/geoip/GeoLite2-Country.mmdb": true,
 			"data/geoip/GeoLite2-ASN.mmdb":     true,
 		}
@@ -107,6 +108,53 @@ func TestBundlerProducesSixPlatformBundles(t *testing.T) {
 		// fakeRunner; the other five went through the magic check; verify bytes).
 		if mihomo := entries["data/bin/mihomo"+suffix]; len(mihomo) == 0 {
 			t.Fatalf("%s: empty mihomo binary", platform)
+		}
+		assertCoreChannelSidecar(t, entries, "stable", "stable-v1.19.0")
+	}
+}
+
+func TestBundlerAlphaChannelWritesSidecar(t *testing.T) {
+	api := fakeGitHubAlphaAPI(t)
+	defer api.Close()
+	geoipSrv := fakeGeoIPServer(t)
+	defer geoipSrv.Close()
+
+	mihariDir := t.TempDir()
+	writeMihariDist(t, mihariDir)
+
+	scriptsDir := t.TempDir()
+	for _, name := range []string{"install-aio.sh", "install-aio.ps1"} {
+		if err := os.WriteFile(filepath.Join(scriptsDir, name), []byte("# aio installer\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	out := t.TempDir()
+	err := run(options{
+		MihariDir: mihariDir, Out: out, ScriptsDir: scriptsDir,
+		Channel:    "alpha",
+		Platforms:  []string{"linux/amd64", "linux/arm64", "darwin/amd64", "darwin/arm64", "windows/amd64", "windows/arm64"},
+		HTTPClient: api.Client(), APIBase: api.URL, Repository: "MetaCubeX/mihomo",
+		GeoIPBase: geoipSrv.URL, GeoIPValidate: func(string) error { return nil },
+		Runner: fakeRunner{output: []byte("Mihomo Meta alpha-e183c58")},
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	expected := map[string]string{
+		"linux/amd64":   "mihari-all-in-one-linux-amd64.tar.gz",
+		"linux/arm64":   "mihari-all-in-one-linux-arm64.tar.gz",
+		"darwin/amd64":  "mihari-all-in-one-darwin-amd64.tar.gz",
+		"darwin/arm64":  "mihari-all-in-one-darwin-arm64.tar.gz",
+		"windows/amd64": "mihari-all-in-one-windows-amd64.zip",
+		"windows/arm64": "mihari-all-in-one-windows-arm64.zip",
+	}
+	for platform, bundle := range expected {
+		entries := extractBundle(t, filepath.Join(out, bundle))
+		assertCoreChannelSidecar(t, entries, "alpha", "alpha-e183c58")
+		if _, ok := entries["data/bin/core-channel"]; !ok {
+			t.Fatalf("%s: missing data/bin/core-channel", platform)
 		}
 	}
 }
@@ -177,11 +225,11 @@ func TestAssertStageEnforcesWhitelist(t *testing.T) {
 		files   []string
 		wantErr bool
 	}{
-		{name: "unix complete", goos: "linux", files: []string{"mihari", "install-aio.sh", "data/bin/mihomo", "data/geoip/GeoLite2-Country.mmdb", "data/geoip/GeoLite2-ASN.mmdb"}},
-		{name: "windows complete", goos: "windows", files: []string{"mihari.exe", "install-aio.ps1", "data/bin/mihomo.exe", "data/geoip/GeoLite2-Country.mmdb", "data/geoip/GeoLite2-ASN.mmdb"}},
-		{name: "missing geoip", goos: "linux", files: []string{"mihari", "install-aio.sh", "data/bin/mihomo", "data/geoip/GeoLite2-Country.mmdb"}, wantErr: true},
-		{name: "forbidden onboarding.json", goos: "linux", files: []string{"mihari", "install-aio.sh", "data/bin/mihomo", "data/geoip/GeoLite2-Country.mmdb", "data/geoip/GeoLite2-ASN.mmdb", "onboarding.json"}, wantErr: true},
-		{name: "forbidden mihari.yaml", goos: "windows", files: []string{"mihari.exe", "install-aio.ps1", "data/bin/mihomo.exe", "data/geoip/GeoLite2-Country.mmdb", "data/geoip/GeoLite2-ASN.mmdb", "mihari.yaml"}, wantErr: true},
+		{name: "unix complete", goos: "linux", files: []string{"mihari", "install-aio.sh", "data/bin/mihomo", "data/bin/core-channel", "data/geoip/GeoLite2-Country.mmdb", "data/geoip/GeoLite2-ASN.mmdb"}},
+		{name: "windows complete", goos: "windows", files: []string{"mihari.exe", "install-aio.ps1", "data/bin/mihomo.exe", "data/bin/core-channel", "data/geoip/GeoLite2-Country.mmdb", "data/geoip/GeoLite2-ASN.mmdb"}},
+		{name: "missing geoip", goos: "linux", files: []string{"mihari", "install-aio.sh", "data/bin/mihomo", "data/bin/core-channel", "data/geoip/GeoLite2-Country.mmdb"}, wantErr: true},
+		{name: "forbidden onboarding.json", goos: "linux", files: []string{"mihari", "install-aio.sh", "data/bin/mihomo", "data/bin/core-channel", "data/geoip/GeoLite2-Country.mmdb", "data/geoip/GeoLite2-ASN.mmdb", "onboarding.json"}, wantErr: true},
+		{name: "forbidden mihari.yaml", goos: "windows", files: []string{"mihari.exe", "install-aio.ps1", "data/bin/mihomo.exe", "data/bin/core-channel", "data/geoip/GeoLite2-Country.mmdb", "data/geoip/GeoLite2-ASN.mmdb", "mihari.yaml"}, wantErr: true},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -194,6 +242,52 @@ func TestAssertStageEnforcesWhitelist(t *testing.T) {
 			}
 		})
 	}
+}
+
+func fakeGitHubAlphaAPI(t *testing.T) *httptest.Server {
+	t.Helper()
+	// Standard names first; variants must exist so a stable-style scorer
+	// that prefers -compatible / would accept -v3 is observable as a miss.
+	names := []string{
+		"mihomo-linux-amd64-compatible-alpha-e183c58.gz",
+		"mihomo-linux-amd64-v3-alpha-e183c58.gz",
+		"mihomo-linux-amd64-alpha-e183c58.gz",
+		"mihomo-linux-arm64-alpha-e183c58.gz",
+		"mihomo-darwin-amd64-compatible-alpha-e183c58.gz",
+		"mihomo-darwin-amd64-v3-alpha-e183c58.gz",
+		"mihomo-darwin-amd64-alpha-e183c58.gz",
+		"mihomo-darwin-arm64-alpha-e183c58.gz",
+		"mihomo-windows-amd64-compatible-alpha-e183c58.zip",
+		"mihomo-windows-amd64-v3-alpha-e183c58.zip",
+		"mihomo-windows-amd64-alpha-e183c58.zip",
+		"mihomo-windows-arm64-alpha-e183c58.zip",
+	}
+	archives := make(map[string][]byte, len(names))
+	for _, name := range names {
+		archives[name] = fakeMihomoArchive(t, name)
+	}
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.URL.Path == "/repos/MetaCubeX/mihomo/releases/tags/Prerelease-Alpha":
+			assets := make([]core.Asset, 0, len(names))
+			for _, name := range names {
+				data := archives[name]
+				sum := sha256.Sum256(data)
+				assets = append(assets, core.Asset{
+					Name: name, URL: server.URL + "/asset/" + name,
+					Size: int64(len(data)), Digest: "sha256:" + hex.EncodeToString(sum[:]),
+				})
+			}
+			response.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(response).Encode(core.Release{TagName: "Prerelease-Alpha", Assets: assets})
+		case strings.HasPrefix(request.URL.Path, "/asset/"):
+			_, _ = response.Write(archives[strings.TrimPrefix(request.URL.Path, "/asset/")])
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	return server
 }
 
 func fakeGitHubAPI(t *testing.T) *httptest.Server {
@@ -365,6 +459,29 @@ func extractBundle(t *testing.T, path string) map[string][]byte {
 		t.Fatalf("unknown bundle type: %s", path)
 	}
 	return entries
+}
+
+func assertCoreChannelSidecar(t *testing.T, entries map[string][]byte, wantChannel, wantStamp string) {
+	t.Helper()
+	raw, ok := entries["data/bin/core-channel"]
+	if !ok {
+		t.Fatal("missing data/bin/core-channel")
+	}
+	text := strings.ReplaceAll(string(raw), "\r\n", "\n")
+	lines := strings.Split(text, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("sidecar %q: want at least 2 lines", text)
+	}
+	if got := strings.TrimSpace(lines[0]); got != wantChannel {
+		t.Fatalf("sidecar channel=%q want %q", got, wantChannel)
+	}
+	stamp := strings.TrimSpace(lines[1])
+	if stamp == "" {
+		t.Fatal("sidecar stamp is empty")
+	}
+	if wantStamp != "" && stamp != wantStamp {
+		t.Fatalf("sidecar stamp=%q want %q", stamp, wantStamp)
+	}
 }
 
 func sortedKeys(m map[string]bool) []string {

--- a/scripts/install/install-aio.ps1
+++ b/scripts/install/install-aio.ps1
@@ -4,9 +4,10 @@
 #   powershell -File install-aio.ps1 [-BundleDir <path>]   (default: script dir)
 #
 # Bundle layout (produced by scripts/build-all-in-one):
-#   mihari.exe          -> $binDir\mihari.exe
-#   data\bin\mihomo.exe -> $MIHARI_DATA\bin\mihomo.exe       (overwrite)
-#   data\geoip\*.mmdb   -> $MIHARI_DATA\geoip\*.mmdb         (overwrite)
+#   mihari.exe             -> $binDir\mihari.exe
+#   data\bin\mihomo.exe    -> $MIHARI_DATA\bin\mihomo.exe       (overwrite)
+#   data\bin\core-channel  -> $MIHARI_DATA\bin\core-channel     (overwrite if present)
+#   data\geoip\*.mmdb      -> $MIHARI_DATA\geoip\*.mmdb         (overwrite)
 #
 # Never touches: mihari.yaml, subscriptions\, control.token, onboarding.json,
 # logs\, web\ (user-private config and panel state stay intact).
@@ -87,6 +88,10 @@ New-Item -ItemType Directory -Force -Path (Join-Path $dataDir 'bin') | Out-Null
 New-Item -ItemType Directory -Force -Path (Join-Path $dataDir 'geoip') | Out-Null
 Info "覆盖 mihomo 核心与 GeoIP 到 $dataDir"
 Copy-Item -LiteralPath $mihomoSrc -Destination (Join-Path $dataDir 'bin\mihomo.exe') -Force
+$sidecarSrc = Join-Path $BundleDir 'data\bin\core-channel'
+if (Test-Path -LiteralPath $sidecarSrc) {
+  Copy-Item -LiteralPath $sidecarSrc -Destination (Join-Path $dataDir 'bin\core-channel') -Force
+}
 Copy-Item -LiteralPath (Join-Path $BundleDir 'data\geoip\GeoLite2-Country.mmdb') -Destination (Join-Path $dataDir 'geoip\GeoLite2-Country.mmdb') -Force
 Copy-Item -LiteralPath (Join-Path $BundleDir 'data\geoip\GeoLite2-ASN.mmdb') -Destination (Join-Path $dataDir 'geoip\GeoLite2-ASN.mmdb') -Force
 

--- a/scripts/install/install-aio.sh
+++ b/scripts/install/install-aio.sh
@@ -4,9 +4,10 @@
 #   sh install-aio.sh [bundle_dir]      (bundle_dir defaults to this script's dir)
 #
 # Bundle layout (produced by scripts/build-all-in-one):
-#   mihari            -> $BIN_DIR/mihari
-#   data/bin/mihomo   -> $MIHARI_DATA/bin/mihomo      (overwrite)
-#   data/geoip/*.mmdb -> $MIHARI_DATA/geoip/*.mmdb    (overwrite)
+#   mihari                 -> $BIN_DIR/mihari
+#   data/bin/mihomo        -> $MIHARI_DATA/bin/mihomo         (overwrite)
+#   data/bin/core-channel  -> $MIHARI_DATA/bin/core-channel   (overwrite if present)
+#   data/geoip/*.mmdb      -> $MIHARI_DATA/geoip/*.mmdb       (overwrite)
 #
 # Never touches: mihari.yaml, subscriptions/, control.token, onboarding.json,
 # logs/, web/ (user-private config and panel state stay intact).
@@ -65,6 +66,9 @@ $SUDO install -m 0755 "$bundle_dir/mihari" "$mihari_bin"
 mkdir -p "$DATA_DIR/bin" "$DATA_DIR/geoip"
 info "覆盖 mihomo 核心与 GeoIP 到 $DATA_DIR"
 install -m 0755 "$bundle_dir/data/bin/mihomo" "$DATA_DIR/bin/mihomo"
+if [ -f "$bundle_dir/data/bin/core-channel" ]; then
+  install -m 0644 "$bundle_dir/data/bin/core-channel" "$DATA_DIR/bin/core-channel"
+fi
 install -m 0644 "$bundle_dir/data/geoip/GeoLite2-Country.mmdb" "$DATA_DIR/geoip/GeoLite2-Country.mmdb"
 install -m 0644 "$bundle_dir/data/geoip/GeoLite2-ASN.mmdb" "$DATA_DIR/geoip/GeoLite2-ASN.mmdb"
 


### PR DESCRIPTION
## 变更内容

给 Mihari 增加 mihomo **stable / alpha** 双通道：System 页可切换，daemon 从滚动 tag `Prerelease-Alpha` 下载 alpha 二进制，用 asset commit sha 判断是否需要重装，通道持久化到 settings。

下载 / 解压 / `-v` / ValidateConfig / 替换仍是同一条链。分叉只在 release URL、选包和短路判据。

实测 alpha `mihomo -v` 输出为 `Mihomo Meta alpha-{sha} ...`（不是 semver）。`ParseVersion` 同时接受 `vX.Y.Z` 与 `alpha-{hex}`。Version 禁止写成 `Prerelease-Alpha`。

`settings.core-channel` 只在 Commit 成功后写入。aio `--channel alpha` 写出 `data/bin/core-channel` sidecar（stamp 防重启打回 TUI 切换）；安装器只覆盖 sidecar，不改 `mihari.yaml`。

Closes #42

## 类型

- [x] feat: 新功能
- [ ] fix: Bug 修复
- [ ] refactor: 重构
- [ ] docs: 文档
- [ ] test: 测试
- [ ] chore: 构建/工具

## 检查清单

- [x] `go test ./...` 通过（rebase 后已复跑受影响包）
- [x] `go test -race` 覆盖 core/config/runtime/server/system（rebase 前）
- [x] `go vet ./...` 通过（rebase 前）
- [x] `gofmt -l` 无输出（rebase 前）
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] `/v1` 仅新增可选 `channel` 字段（`CoreStatus` / `CoreInstallResult` / `MutationRequest`），向后兼容；settings schema 仍为 `mihari.settings/v1`，新增 `core-channel` / `core-channel-bundle`。旧 daemon 因 `KnownFields` 无法加载含这些字段的 settings。

## 相关 Issues

#42

## 其他

- 已 rebase 到当前 `origin/main`（含 #43/#44/#45/#47）。
- 默认测试不访问公网、不下载真实 alpha 安装包。
- 设计稿/实施计划仍在 worktree 未跟踪，未纳入本 PR。