### PR TITLE
refactor(subscription): catalog 配置加载引入 fillDefaults 层 (#32)

### DIFF
--- a/internal/subscription/catalog.go
+++ b/internal/subscription/catalog.go
@@ -23,6 +23,19 @@ func Defaults() Catalog {
 	return Catalog{Schema: CatalogSchema, GlobalInterval: "12h", Profiles: []Profile{}}
 }
 
+// Catalog loading pipeline (Load) runs these stages after decode:
+//
+//	migrate       — forward schema migrations (no-op for current schema);
+//	                extension point for future vN→vN+1 reshapes.
+//	Normalize     — validates schema and fields, repairs invariants. Reports
+//	                errors; does NOT fill defaults.
+//	fillDefaults  — fills zero values with intended defaults. Pure filling,
+//	                never validates. Runs last so cleared values get a default.
+//
+// Contract: any caller that Normalize()s an in-memory catalog (Load, Save,
+// service.Mutate, service.CommitRefresh) MUST follow with fillDefaults().
+// Add new "zero ≠ default" fields to fillDefaults; keep Normalize about
+// validation and invariant repair only.
 func Load(path string) (Catalog, error) {
 	file, err := os.Open(path)
 	if err != nil {

--- a/internal/subscription/catalog.go
+++ b/internal/subscription/catalog.go
@@ -122,6 +122,34 @@ func (c *Catalog) Normalize() error {
 	return nil
 }
 
+// migrate applies forward schema migrations to a decoded catalog before
+// Normalize validates it. The current schema needs no migration; this switch
+// is the extension point for future vN→vN+1 field renames or reshapes that
+// fillDefaults cannot express. Schema validity itself stays enforced by
+// Normalize, so unknown schemas are left untouched here.
+func (c *Catalog) migrate() {
+	switch c.Schema {
+	case CatalogSchema:
+		// no migration needed
+	}
+}
+
+// fillDefaults fills zero values with their intended defaults. It only fills,
+// never validates — run it after Normalize so values Normalize cleared get a
+// sensible default. Today it selects an active subscription when none is set;
+// future "zero ≠ default" fields belong here rather than scattered in Normalize.
+func (c *Catalog) fillDefaults() {
+	if c.ActiveID != "" {
+		return
+	}
+	for _, profile := range c.Profiles {
+		if profile.Enabled && profile.Generation > 0 {
+			c.ActiveID = profile.ID
+			return
+		}
+	}
+}
+
 func (c Catalog) Index(id string) int {
 	for index := range c.Profiles {
 		if c.Profiles[index].ID == id {

--- a/internal/subscription/catalog.go
+++ b/internal/subscription/catalog.go
@@ -38,7 +38,7 @@ func Load(path string) (Catalog, error) {
 	decoder.KnownFields(true)
 	var catalog Catalog
 	if err := decoder.Decode(&catalog); err != nil {
-		return Catalog{}, dataError("invalid subscription catalog")
+		return Catalog{}, dataError(decodeErrorMessage(err, "subscription catalog"))
 	}
 	var extra any
 	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
@@ -180,4 +180,20 @@ func parseInterval(value string) (time.Duration, error) {
 
 func dataError(message string) error {
 	return protocol.APIError{Code: protocol.CodeDataFailure, Message: message}
+}
+
+// decodeErrorMessage turns a yaml decode error into a user-facing message.
+// Unknown fields (surfaced as *yaml.TypeError with "not found in type") are
+// called out explicitly so a downgrade mismatch or a typo is obvious instead
+// of a generic "invalid" failure.
+func decodeErrorMessage(err error, what string) string {
+	var te *yaml.TypeError
+	if errors.As(err, &te) {
+		for _, item := range te.Errors {
+			if strings.Contains(item, "not found in type") {
+				return fmt.Sprintf("invalid %s: unknown field — %s; it may have been written by a newer mihari version or be a typo", what, item)
+			}
+		}
+	}
+	return "invalid " + what
 }

--- a/internal/subscription/catalog.go
+++ b/internal/subscription/catalog.go
@@ -44,9 +44,11 @@ func Load(path string) (Catalog, error) {
 	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
 		return Catalog{}, dataError("subscription catalog must contain one document")
 	}
+	catalog.migrate()
 	if err := catalog.Normalize(); err != nil {
 		return Catalog{}, err
 	}
+	catalog.fillDefaults()
 	return catalog, nil
 }
 
@@ -69,6 +71,7 @@ func Save(path string, catalog Catalog) error {
 	if err := catalog.Normalize(); err != nil {
 		return err
 	}
+	catalog.fillDefaults()
 	content, err := yaml.Marshal(catalog)
 	if err != nil {
 		return dataError("encode subscription catalog")
@@ -110,13 +113,12 @@ func (c *Catalog) Normalize() error {
 			}
 		}
 	}
-	if index := c.Index(c.ActiveID); index < 0 || !c.Profiles[index].Enabled || c.Profiles[index].Generation == 0 {
-		c.ActiveID = ""
-		for _, profile := range c.Profiles {
-			if profile.Enabled && profile.Generation > 0 {
-				c.ActiveID = profile.ID
-				break
-			}
+	// ActiveID must point at an enabled profile with a fetched generation;
+	// otherwise clear it so fillDefaults can re-pick. Pure repair — default
+	// selection lives in fillDefaults, not here.
+	if c.ActiveID != "" {
+		if index := c.Index(c.ActiveID); index < 0 || !c.Profiles[index].Enabled || c.Profiles[index].Generation == 0 {
+			c.ActiveID = ""
 		}
 	}
 	return nil

--- a/internal/subscription/catalog_test.go
+++ b/internal/subscription/catalog_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -117,5 +118,50 @@ func TestNormalizeValidatesProxyMode(t *testing.T) {
 	catalog.Profiles = []Profile{{ID: "0123456789abcdef0123456789abcdef", Name: "bad", URL: "https://one.test", ProxyMode: "bogus"}}
 	if err := catalog.Normalize(); err == nil {
 		t.Fatal("expected invalid proxy mode to be rejected")
+	}
+}
+
+// fillDefaults picks the first enabled profile with a fetched generation when
+// no active id is set; leaves a set id untouched; no-op without a usable profile.
+func TestFillDefaultsSelectsActiveProfile(t *testing.T) {
+	disabled := Profile{ID: "0123456789abcdef0123456789abcdef", Name: "disabled", URL: "https://one.test", Enabled: false, AutoRefresh: true}
+	enabled := Profile{ID: "fedcba9876543210fedcba9876543210", Name: "enabled", URL: "https://two.test", Enabled: true, AutoRefresh: true, Generation: 1}
+	t.Run("picks first enabled with generation", func(t *testing.T) {
+		catalog := Defaults()
+		catalog.Profiles = []Profile{disabled, enabled}
+		catalog.fillDefaults()
+		if catalog.ActiveID != enabled.ID {
+			t.Fatalf("active=%q want %q", catalog.ActiveID, enabled.ID)
+		}
+	})
+	t.Run("leaves existing id untouched", func(t *testing.T) {
+		catalog := Defaults()
+		catalog.ActiveID = "preset"
+		catalog.Profiles = []Profile{enabled}
+		catalog.fillDefaults()
+		if catalog.ActiveID != "preset" {
+			t.Fatalf("overwrote set id: %q", catalog.ActiveID)
+		}
+	})
+	t.Run("no-op without a usable profile", func(t *testing.T) {
+		catalog := Defaults()
+		catalog.Profiles = []Profile{disabled}
+		catalog.fillDefaults()
+		if catalog.ActiveID != "" {
+			t.Fatalf("active=%q want empty", catalog.ActiveID)
+		}
+	})
+}
+
+// migrate must not mutate a current-schema catalog (reflective deep check,
+// not just a few fields, so future profile-level migrations can't slip through).
+func TestMigrateNoOpForCurrentSchema(t *testing.T) {
+	catalog := Defaults()
+	catalog.Profiles = []Profile{{ID: "0123456789abcdef0123456789abcdef", Name: "ok", URL: "https://one.test", Enabled: true, AutoRefresh: true, Generation: 1}}
+	catalog.ActiveID = catalog.Profiles[0].ID
+	before := catalog
+	catalog.migrate()
+	if !reflect.DeepEqual(before, catalog) {
+		t.Fatalf("migrate mutated current-schema catalog:\n before=%#v\n after=%#v", before, catalog)
 	}
 }

--- a/internal/subscription/catalog_test.go
+++ b/internal/subscription/catalog_test.go
@@ -56,6 +56,28 @@ func TestLoadRejectsUnknownFieldsAndInvalidInterval(t *testing.T) {
 	}
 }
 
+// An unknown field must surface the offending name and a newer-version/typo
+// hint, not the generic "invalid subscription catalog" message KnownFields
+// used to collapse every decode error into.
+func TestLoadReportsUnknownField(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "catalog.yaml")
+	doc := []byte("schema: mihari.subscriptions/v1\nglobal-interval: 12h\nmystery-field: true\n")
+	if err := os.WriteFile(path, doc, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected load failure")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "mystery-field") {
+		t.Fatalf("error should name the unknown field: %s", msg)
+	}
+	if !strings.Contains(msg, "newer") && !strings.Contains(msg, "typo") {
+		t.Fatalf("error should hint at newer-version/typo: %s", msg)
+	}
+}
+
 // Normalize only clears an invalid ActiveID; it must NOT re-pick a default
 // (that is fillDefaults' job). Keeps the duplicate-ID rejection assertion.
 func TestNormalizeClearsInvalidActiveIDAndRejectsDuplicates(t *testing.T) {

--- a/internal/subscription/catalog_test.go
+++ b/internal/subscription/catalog_test.go
@@ -56,7 +56,9 @@ func TestLoadRejectsUnknownFieldsAndInvalidInterval(t *testing.T) {
 	}
 }
 
-func TestValidateRepairsActiveAndRejectsDuplicateIDs(t *testing.T) {
+// Normalize only clears an invalid ActiveID; it must NOT re-pick a default
+// (that is fillDefaults' job). Keeps the duplicate-ID rejection assertion.
+func TestNormalizeClearsInvalidActiveIDAndRejectsDuplicates(t *testing.T) {
 	catalog := Defaults()
 	catalog.ActiveID = "missing"
 	catalog.Profiles = []Profile{
@@ -66,12 +68,49 @@ func TestValidateRepairsActiveAndRejectsDuplicateIDs(t *testing.T) {
 	if err := catalog.Normalize(); err != nil {
 		t.Fatal(err)
 	}
-	if catalog.ActiveID != catalog.Profiles[1].ID {
-		t.Fatalf("active=%q", catalog.ActiveID)
+	if catalog.ActiveID != "" {
+		t.Fatalf("normalize should clear invalid active, got %q", catalog.ActiveID)
 	}
 	catalog.Profiles[1].ID = catalog.Profiles[0].ID
 	if err := catalog.Normalize(); err == nil {
 		t.Fatal("expected duplicate ID failure")
+	}
+}
+
+// Load's full pipeline must repair an invalid ActiveID exactly like the
+// pre-split Normalize self-heal. Covers missing / disabled / gen=0 / empty.
+func TestLoadPipelineRepairsActiveID(t *testing.T) {
+	const profileDisabled = "0123456789abcdef0123456789abcdef"
+	const profileEnabled = "fedcba9876543210fedcba9876543210"
+	const profileGenZero = "00112233445566778899aabbccddeeff"
+	base := "schema: mihari.subscriptions/v1\nglobal-interval: 12h\n" +
+		"profiles:\n" +
+		"  - id: \"" + profileDisabled + "\"\n    name: disabled\n    url: https://one.test\n    enabled: false\n    auto-refresh: true\n" +
+		"  - id: \"" + profileGenZero + "\"\n    name: genzero\n    url: https://three.test\n    enabled: true\n    auto-refresh: true\n    generation: 0\n" +
+		"  - id: \"" + profileEnabled + "\"\n    name: enabled\n    url: https://two.test\n    enabled: true\n    auto-refresh: true\n    generation: 1\n"
+	for name, active := range map[string]string{
+		"missing":  "nonexistent",
+		"disabled": profileDisabled,
+		"gen-zero": profileGenZero,
+		"empty":    "",
+	} {
+		t.Run(name, func(t *testing.T) {
+			doc := base
+			if active != "" {
+				doc = "active-id: " + active + "\n" + base
+			}
+			path := filepath.Join(t.TempDir(), "catalog.yaml")
+			if err := os.WriteFile(path, []byte(doc), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			loaded, err := Load(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if loaded.ActiveID != profileEnabled {
+				t.Fatalf("active=%q want %q", loaded.ActiveID, profileEnabled)
+			}
+		})
 	}
 }
 

--- a/internal/subscription/service.go
+++ b/internal/subscription/service.go
@@ -118,6 +118,7 @@ func (s *Service) Mutate(mutate func(*Catalog) error) (Catalog, Catalog, error) 
 	if err := after.Normalize(); err != nil {
 		return Catalog{}, Catalog{}, err
 	}
+	after.fillDefaults()
 	if err := Save(s.catalogPath, after); err != nil {
 		return Catalog{}, Catalog{}, err
 	}
@@ -216,6 +217,7 @@ func (s *Service) CommitRefresh(prepared PreparedRefresh) (Receipt, error) {
 	if err := after.Normalize(); err != nil {
 		return Receipt{}, s.failAfterRestore(err, cachePath, cacheBefore, hadCache, wroteCache)
 	}
+	after.fillDefaults()
 	if err := Save(s.catalogPath, after); err != nil {
 		return Receipt{}, s.failAfterRestore(err, cachePath, cacheBefore, hadCache, wroteCache)
 	}


### PR DESCRIPTION
## 概述

实现 #32：subscription catalog 配置加载链引入显式 `fillDefaults` 钩子与 `migrate` 扩展点，分离「零值→默认」与「校验/修复」职责，并改进 `KnownFields` 未知字段报错。

## 设计：三阶段流水线

```
Load:  Decode → migrate → Normalize → fillDefaults
Save:  Normalize → fillDefaults → Marshal
```

| 阶段 | 职责 |
|---|---|
| `migrate()` | 跨 schema 版本迁移（当前 no-op，扩展点） |
| `Normalize()` | 校验 schema/字段 + 修复不变量（清空无效 ActiveID，**不再重选**） |
| `fillDefaults()` | 零值→默认（纯填充，不校验） |

**契约**：任何对内存 catalog 调 `Normalize` 的 caller，之后必须跟 `fillDefaults`（Load / Save / service.Mutate / service.CommitRefresh 四处）。

## 改动

- `catalog.go`：新增 `migrate`/`fillDefaults`；`Normalize` 的 ActiveID 自愈拆为「只清空」；Load/Save 串入流水线；`decodeErrorMessage` 让未知字段报错点名字段 + newer/typo 提示；流水线职责契约注释。
- `service.go`：`Mutate`/`CommitRefresh` 在 `Normalize` 后补 `after.fillDefaults()` —— 修复内存 `s.catalog.ActiveID` 与磁盘不一致（首次抓取不激活的回归面）。
- `catalog_test.go`：`fillDefaults`/`migrate` 单测；`Normalize-clears`（红→绿 TDD）；`TestLoadPipelineRepairsActiveID`（missing/disabled/gen-zero/empty 4 场景等价回归门）；`TestLoadReportsUnknownField`。

## 验证

- `gofmt -l .` 空
- `go vet ./...` 无输出
- `golangci-lint run` v2.12.2 — 0 issues
- `go test -count=1 ./...` — 全部 45 包 ok
- 回归门 `TestAddSubscriptionFetchesImmediately` / `TestReloadFailureRollsBackSubscriptionActivation` 绿

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)