### PR TITLE
revert(tui): 撤销选中行对比色背景渲染

### DIFF
--- a/internal/tui/ui/theme.go
+++ b/internal/tui/ui/theme.go
@@ -16,10 +16,6 @@ type Theme struct {
 	ColorInfo          color.Color
 	ColorMuted         color.Color
 	ColorSurfaceBorder color.Color
-	// ColorFocusBg is the row keyboard-focus background: a desaturated dim of
-	// accent that reads as a clear block in dense lists, replacing the
-	// low-contrast Reverse(true) highlight (issue #46).
-	ColorFocusBg color.Color
 	// ColorOnSolid is the foreground for solid-background chips (Done/Failed/Pending).
 	// Dark text keeps contrast on Success/Warning/Danger fills in 256-color terminals.
 	ColorOnSolid color.Color
@@ -64,7 +60,6 @@ func DefaultTheme() Theme {
 	info := lipgloss.Color("75")
 	surfaceBorder := lipgloss.Color("240")
 	muted := lipgloss.Color("245")
-	focusBg := lipgloss.Color("60")
 	onSolid := lipgloss.Color("0")
 
 	return Theme{
@@ -75,7 +70,6 @@ func DefaultTheme() Theme {
 		ColorInfo:          info,
 		ColorMuted:         muted,
 		ColorSurfaceBorder: surfaceBorder,
-		ColorFocusBg:       focusBg,
 		ColorOnSolid:       onSolid,
 
 		Rail:         lipgloss.NewStyle().Padding(0, 1),
@@ -89,7 +83,7 @@ func DefaultTheme() Theme {
 		Button:       lipgloss.NewStyle().Padding(0, 1),
 		ButtonActive: lipgloss.NewStyle().Bold(true).Foreground(accent).Padding(0, 1),
 		RowSelected:  lipgloss.NewStyle().Bold(true).Foreground(accent),
-		RowFocus:     lipgloss.NewStyle().Background(focusBg),
+		RowFocus:     lipgloss.NewStyle().Reverse(true),
 
 		Success: lipgloss.NewStyle().Foreground(success),
 		Warning: lipgloss.NewStyle().Foreground(warning),

--- a/internal/tui/ui/theme_test.go
+++ b/internal/tui/ui/theme_test.go
@@ -17,7 +17,6 @@ func TestDefaultTheme_HasSemanticRoles(t *testing.T) {
 	assertColor(t, "ColorDanger", theme.ColorDanger, lipgloss.Color("203"))
 	assertColor(t, "ColorInfo", theme.ColorInfo, lipgloss.Color("75"))
 	assertColor(t, "ColorSurfaceBorder", theme.ColorSurfaceBorder, lipgloss.Color("240"))
-	assertColor(t, "ColorFocusBg", theme.ColorFocusBg, lipgloss.Color("60"))
 	assertColor(t, "ColorMuted", theme.ColorMuted, lipgloss.Color("245"))
 	assertColor(t, "ColorOnSolid", theme.ColorOnSolid, lipgloss.Color("0"))
 
@@ -58,17 +57,13 @@ func TestDefaultTheme_HasSemanticRoles(t *testing.T) {
 
 	// RowFocus is distinct from business RowSelected.
 	if theme.RowFocus.GetReverse() == theme.RowSelected.GetReverse() &&
-		colorsEqual(theme.RowFocus.GetBackground(), theme.RowSelected.GetBackground()) &&
 		colorsEqual(theme.RowFocus.GetForeground(), theme.RowSelected.GetForeground()) &&
 		theme.RowFocus.GetBold() == theme.RowSelected.GetBold() {
 		t.Fatal("RowFocus must be visually distinct from RowSelected")
 	}
-	if !theme.RowFocus.GetReverse() && isNoColor(theme.RowFocus.GetForeground()) &&
-		isNoColor(theme.RowFocus.GetBackground()) && !theme.RowFocus.GetBold() {
-		t.Fatal("RowFocus should apply reverse, foreground, background, or bold")
+	if !theme.RowFocus.GetReverse() && isNoColor(theme.RowFocus.GetForeground()) && !theme.RowFocus.GetBold() {
+		t.Fatal("RowFocus should apply reverse, foreground, or bold")
 	}
-	// RowFocus now fills the row background (issue #46) instead of reverse video.
-	assertStyleBG(t, "RowFocus", theme.RowFocus, theme.ColorFocusBg)
 }
 
 func assertColor(t *testing.T, name string, got, want color.Color) {
@@ -83,14 +78,6 @@ func assertStyleFG(t *testing.T, name string, style lipgloss.Style, want color.C
 	got := style.GetForeground()
 	if !colorsEqual(got, want) {
 		t.Fatalf("%s foreground: got %#v want %#v", name, got, want)
-	}
-}
-
-func assertStyleBG(t *testing.T, name string, style lipgloss.Style, want color.Color) {
-	t.Helper()
-	got := style.GetBackground()
-	if !colorsEqual(got, want) {
-		t.Fatalf("%s background: got %#v want %#v", name, got, want)
 	}
 }
 


### PR DESCRIPTION
## 变更内容

撤销 `19389ec`（`feat(tui): 选中行改用对比色背景渲染（替代纯反白）`）的全部改动，恢复 `RowFocus` 原有的纯反白渲染。

该提交把原本的纯白背景改成了固定灰色背景，同时没有作用到实际需要调整的对象，因此先完整回退，后续正确修改另行处理。

## 类型

- [ ] feat: 新功能
- [x] fix: Bug 修复
- [ ] refactor: 重构
- [ ] docs: 文档
- [ ] test: 测试
- [ ] chore: 构建/工具

## 检查清单

- [ ] `go test -race ./...` 通过
- [ ] `go vet ./...` 通过
- [ ] `gofmt -l cmd internal` 无输出
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] 未修改 `internal/control/protocol` 契约、CLI 输出/退出码或跨平台行为

## 其他

- `go test ./...` 通过。
- 已确认相关文件与 `19389ec^` 完全一致。