### PR TITLE
fix(tui): 控件焦点改用白底高亮

### DIFF
--- a/internal/tui/ui/controlstrip.go
+++ b/internal/tui/ui/controlstrip.go
@@ -7,8 +7,8 @@ import (
 )
 
 // RenderControlStrip joins navigable control chips with sep.
-// When contentFocused is true, activeIndex uses the ControlActive look (bold accent,
-// no padding so multi-chip layout stays stable); other chips use Muted.
+// When contentFocused is true, activeIndex uses a black-on-white focus surface
+// (no padding so multi-chip layout stays stable); other chips use Muted.
 // When contentFocused is false, chips stay plain so the rail can own focus chrome.
 func RenderControlStrip(theme Theme, parts []string, activeIndex int, contentFocused bool, sep string) string {
 	if len(parts) == 0 {
@@ -18,7 +18,7 @@ func RenderControlStrip(theme Theme, parts []string, activeIndex int, contentFoc
 	for index, part := range parts {
 		switch {
 		case contentFocused && index == activeIndex:
-			styled[index] = controlActiveChip(theme).Render(part)
+			styled[index] = controlFocusSurface(theme).Render(part)
 		case contentFocused:
 			styled[index] = theme.Muted.Render(part)
 		default:
@@ -26,6 +26,13 @@ func RenderControlStrip(theme Theme, parts []string, activeIndex int, contentFoc
 		}
 	}
 	return strings.Join(styled, sep)
+}
+
+// controlFocusSurface is the explicit light keyboard-focus surface used by
+// controls and search. Applying it outside an already-colored span lets that
+// span keep its semantic foreground while inheriting the white background.
+func controlFocusSurface(theme Theme) lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(theme.ColorOnSolid).Background(lipgloss.Color("15"))
 }
 
 // controlActiveChip matches ControlActive colors without horizontal padding so

--- a/internal/tui/ui/controlstrip_test.go
+++ b/internal/tui/ui/controlstrip_test.go
@@ -3,6 +3,8 @@ package ui
 import (
 	"strings"
 	"testing"
+
+	lipgloss "charm.land/lipgloss/v2"
 )
 
 func TestRenderControlStrip_HighlightsActiveWhenContentFocused(t *testing.T) {
@@ -24,15 +26,37 @@ func TestRenderControlStrip_HighlightsActiveWhenContentFocused(t *testing.T) {
 	if !strings.Contains(focused, "\x1b[") {
 		t.Fatalf("content-focused strip should emit ANSI: %q", focused)
 	}
-	// Active chip should match ControlActive colors (bold + accent).
-	wantActive := controlActiveChip(theme).Render("[B]")
+	// Active control focus is a literal light surface: ordinary text becomes
+	// black while the focused cell gets a white background.
+	wantActive := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("0")).
+		Background(lipgloss.Color("15")).
+		Render("[B]")
 	if !strings.Contains(focused, wantActive) {
-		t.Fatalf("active chip missing ControlActive style\ngot=%q\nwant substring=%q", focused, wantActive)
+		t.Fatalf("active chip missing black-on-white focus style\ngot=%q\nwant substring=%q", focused, wantActive)
 	}
 	// Inactive chips are muted.
 	wantMuted := theme.Muted.Render("[A]")
 	if !strings.Contains(focused, wantMuted) {
 		t.Fatalf("inactive chip missing Muted style\ngot=%q\nwant substring=%q", focused, wantMuted)
+	}
+}
+
+func TestRenderControlStrip_ActiveChipPreservesSemanticForeground(t *testing.T) {
+	theme := DefaultTheme()
+	semantic := theme.Warning.Render("WARN")
+	part := "Level: " + semantic
+
+	got := RenderControlStrip(theme, []string{part}, 0, true, "  ")
+	if !strings.Contains(got, semantic) {
+		t.Fatalf("active chip changed semantic foreground\ngot=%q\nwant semantic span=%q", got, semantic)
+	}
+	want := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("0")).
+		Background(lipgloss.Color("15")).
+		Render(part)
+	if got != want {
+		t.Fatalf("active chip should put the complete mixed-color value on the focus surface\ngot=%q\nwant=%q", got, want)
 	}
 }
 

--- a/internal/tui/ui/searchbar.go
+++ b/internal/tui/ui/searchbar.go
@@ -9,9 +9,9 @@ import (
 // RenderSearchBar draws the independent search strip used between a control strip
 // and a table header (Connections, Rules, Logs).
 // Empty query shows "/ " + placeholder; non-empty shows "/ " + query.
-// When focused, a reverse-video cursor is drawn at cursor (rune offset in query;
+// When focused, an underlined cursor is drawn at cursor (rune offset in query;
 // empty query places the cursor at the start of the placeholder).
-// Focused styling matches ControlActive (bold accent); unfocused uses Muted.
+// Focused styling uses the controls' black-on-white surface; unfocused uses Muted.
 // When width > 0 the line is clamped with MaxWidth.
 func RenderSearchBar(theme Theme, query, placeholder string, focused bool, cursor, width int) string {
 	text := query
@@ -25,11 +25,11 @@ func RenderSearchBar(theme Theme, query, placeholder string, focused bool, curso
 
 	var styled string
 	if focused {
-		// Compose bold-accent segments so reverse cursor works without
-		// re-styling an already-colored string. Match ControlActive padding.
-		active := lipgloss.NewStyle().Bold(true).Foreground(theme.ColorAccent)
+		// Render every segment on the same explicit surface. Keeping padding as
+		// styled cells avoids black gaps at either end of the focused search bar.
+		active := controlFocusSurface(theme)
 		inner := active.Render("/ ") + renderCursorText(text, bodyCursor, active)
-		styled = lipgloss.NewStyle().Padding(0, 1).Render(inner)
+		styled = active.Render(" ") + inner + active.Render(" ")
 	} else {
 		styled = theme.Muted.Render("/ " + text)
 	}
@@ -40,8 +40,8 @@ func RenderSearchBar(theme Theme, query, placeholder string, focused bool, curso
 	return lipgloss.NewStyle().MaxWidth(width).Render(styled)
 }
 
-// renderCursorText inserts a reverse-video cursor into text at the given rune offset.
-// When cursor is at the end, a reverse space is appended. Non-cursor segments use active.
+// renderCursorText inserts an underlined cursor into text at the given rune offset.
+// When cursor is at the end, an underlined space is appended. Non-cursor segments use active.
 func renderCursorText(text string, cursor int, active lipgloss.Style) string {
 	runes := []rune(text)
 	if cursor < 0 {
@@ -50,11 +50,18 @@ func renderCursorText(text string, cursor int, active lipgloss.Style) string {
 	if cursor > len(runes) {
 		cursor = len(runes)
 	}
-	rev := active.Reverse(true)
+	cursorStyle := active.Underline(true)
 	if cursor < len(runes) {
-		return active.Render(string(runes[:cursor])) + rev.Render(string(runes[cursor])) + active.Render(string(runes[cursor+1:]))
+		var before, after string
+		if cursor > 0 {
+			before = active.Render(string(runes[:cursor]))
+		}
+		if cursor+1 < len(runes) {
+			after = active.Render(string(runes[cursor+1:]))
+		}
+		return before + cursorStyle.Render(string(runes[cursor])) + after
 	}
-	return active.Render(text) + rev.Render(" ")
+	return active.Render(text) + cursorStyle.Render(" ")
 }
 
 // ClampSearchCursor returns cursor clamped to the query rune length.

--- a/internal/tui/ui/searchbar_test.go
+++ b/internal/tui/ui/searchbar_test.go
@@ -44,9 +44,9 @@ func TestSearchBar_ViewShowsQuery(t *testing.T) {
 
 func TestSearchBar_FocusedShowsCursor(t *testing.T) {
 	theme := DefaultTheme()
-	// Cursor mid-query: reverse-video on that rune.
+	// Cursor mid-query stays on the same white focus surface. It must not use
+	// reverse video, which would turn the cursor cell black again.
 	got := RenderSearchBar(theme, "ab", "Search…", true, 1, 0)
-	// Unfocused never embeds reverse.
 	plain := stripANSI(got)
 	if !strings.Contains(plain, "ab") {
 		t.Fatalf("query missing: %q", plain)
@@ -54,11 +54,47 @@ func TestSearchBar_FocusedShowsCursor(t *testing.T) {
 	if !strings.Contains(got, "\x1b[") {
 		t.Fatalf("focused bar should embed style codes for cursor: %q", got)
 	}
-	// Cursor at end appends a reverse space.
+	if hasReverseSGR(got) {
+		t.Fatalf("focused search cursor should not reverse the white surface: %q", got)
+	}
+	focusSurface := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("0")).
+		Background(lipgloss.Color("15"))
+	want := focusSurface.Render(" ") +
+		focusSurface.Render("/ ") +
+		focusSurface.Render("a") +
+		focusSurface.Underline(true).Render("b") +
+		focusSurface.Render(" ")
+	if got != want {
+		t.Fatalf("focused search should keep padding, text, and cursor on the white surface\ngot=%q\nwant=%q", got, want)
+	}
+	// Cursor at end appends an underlined space.
 	atEnd := RenderSearchBar(theme, "ab", "Search…", true, 2, 0)
-	if lipgloss.Width(stripANSI(atEnd)) < lipgloss.Width(stripANSI(got)) {
+	if lipgloss.Width(stripANSI(atEnd)) <= lipgloss.Width(stripANSI(got)) {
 		t.Fatalf("end cursor should add a cell: end=%q mid=%q", stripANSI(atEnd), stripANSI(got))
 	}
+}
+
+func hasReverseSGR(value string) bool {
+	for start := 0; start < len(value); start++ {
+		if value[start] != '\x1b' || start+2 >= len(value) || value[start+1] != '[' {
+			continue
+		}
+		end := start + 2
+		for end < len(value) && value[end] != 'm' {
+			end++
+		}
+		if end == len(value) {
+			return false
+		}
+		for _, parameter := range strings.Split(value[start+2:end], ";") {
+			if parameter == "7" {
+				return true
+			}
+		}
+		start = end
+	}
+	return false
 }
 
 func TestSearchBar_TruncatesToWidth(t *testing.T) {


### PR DESCRIPTION
## 变更内容

- Connections、Rules、Logs 顶部 Controls 当前焦点项改为白底、普通文字黑色。
- 聚焦搜索栏使用相同白底黑字表面，光标改用下划线，避免再次反转为黑底。
- 控制项内部已有的状态/语义前景色保持原色并继承白色背景。
- Proxies group、数据行与表头高亮路径保持不变。

## 类型

- [ ] feat: 新功能
- [x] fix: Bug 修复
- [ ] refactor: 重构
- [ ] docs: 文档
- [x] test: 测试
- [ ] chore: 构建/工具

## 检查清单

- [x] `go test -race ./...` 通过
- [x] `go vet ./...` 通过
- [x] `gofmt -l cmd internal` 无输出
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] 未修改 `internal/control/protocol` 契约、CLI 输出/退出码或跨平台行为

## 测试

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `gofmt -l cmd internal`
- `git diff --check`

采用 Red–Green–Refactor：先验证旧的蓝色 Controls/反白搜索光标使新测试失败，再实现显式白底焦点表面并验证全仓通过。