### PR TITLE
fix(tui): 修复 Windows 自更新后的终端争用

### DIFF
--- a/docs/superpowers/plans/2026-08-13-windows-tui-relaunch-lifecycle.md
+++ b/docs/superpowers/plans/2026-08-13-windows-tui-relaunch-lifecycle.md
@@ -1,0 +1,360 @@
+# Windows TUI Relaunch Lifecycle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 修复 Windows TUI 自更新后旧 Mihari 提前退出、导致新版 TUI 与外部 shell 争用同一控制台的问题。
+
+**Architecture:** 保持 Bubble Tea 先退出并恢复终端的现有顺序，只在 Windows 平台适配器中把“启动后立即 Release”改为“启动后同步 Wait”。用不导出的最小进程接口隔离 `os.Process`，使单元测试能精确验证等待、标准流继承和等待失败后的句柄清理；Unix `syscall.Exec` 路径不变。
+
+**Execution Status:** Tasks 1-3 and Task 4 local verification/review are complete. Commit, PR creation, and Actions monitoring remain pending until their corresponding steps execute.
+
+**Tech Stack:** Go 1.26、标准库 `os`/`errors`、Windows build tags、Go testing
+
+**Spec:** `docs/superpowers/specs/2026-08-13-windows-tui-relaunch-lifecycle-design.md`
+
+## Global Constraints
+
+- 不改变 `platform.Relaunch(binary string, args, env []string) error` 签名。
+- 不改变 CLI/JSON 契约、持久化格式、daemon 边界或 Unix relaunch 行为。
+- 不新增依赖，不启动真实新 TUI，不访问公网，不修改系统服务或用户配置。
+- 保持 `CGO_ENABLED=0`，Windows amd64/arm64、Linux amd64、macOS arm64 可构建。
+- 所有测试使用 channel 握手而不是固定 `time.Sleep`；替换包级 seam 的测试不得 `t.Parallel`。
+- 当前修复不传播新版 Windows 子进程的非零退出码。
+
+---
+
+### Task 1: 行为不变地建立可测试进程边界
+
+**Files:**
+- Modify: `internal/platform/relaunch_windows.go`
+- Modify: `internal/platform/relaunch_windows_test.go`
+
+**Interfaces:**
+- Consumes: 当前 `Relaunch` 与 `os.StartProcess`。
+- Produces: 私有 `replacementProcess` 接口和返回该接口的 `startProcess` seam，仍保持旧行为 `Wait=0, Release=1`。
+
+- [x] **Step 1: 增加行为不变的生产 seam**
+
+```go
+type replacementProcess interface {
+	Wait() (*os.ProcessState, error)
+	Release() error
+}
+
+var startProcess = func(name string, argv []string, attr *os.ProcAttr) (replacementProcess, error) {
+	return os.StartProcess(name, argv, attr)
+}
+```
+
+此步骤只改变 seam 类型；`Relaunch` 仍在启动成功后立即调用 `Release`。
+
+- [x] **Step 2: 用 fake 适配既有测试并锁定旧行为**
+
+增加实现上述接口的 fake，将既有启动测试改为返回 fake，并断言 `waitCalls == 0`、`releaseCalls == 1`。保留 binary、args、env 和标准流断言。替换包级 seam 时用 `t.Cleanup` 恢复，且不使用 `t.Parallel`。
+
+- [x] **Step 3: 格式化并确认准备重构保持 GREEN**
+
+```console
+gofmt -w internal/platform/relaunch_windows.go internal/platform/relaunch_windows_test.go
+go test -run '^TestRelaunch' ./internal/platform
+```
+
+Expected: PASS。不得把编译错误当作 Red。
+
+---
+
+### Task 2: 用失败测试锁定 Windows replacement 生命周期
+
+**Files:**
+- Modify: `internal/platform/relaunch_windows_test.go`
+
+**Interfaces:**
+- Consumes: Task 1 的 `replacementProcess` 与包级 `startProcess` seam。
+- Produces: 对私有 `replacementProcess` 接口的测试约束：`Wait() (*os.ProcessState, error)`、`Release() error`。
+
+- [x] **Step 1: 将测试启动 seam 改为返回可控 fake process**
+
+在测试文件中增加：
+
+```go
+type fakeReplacementProcess struct {
+	waitEntered  chan struct{}
+	waitUnblock  chan struct{}
+	waitErr      error
+	releaseErr   error
+	waitCalls    int
+	releaseCalls int
+}
+
+func (process *fakeReplacementProcess) Wait() (*os.ProcessState, error) {
+	process.waitCalls++
+	if process.waitEntered != nil {
+		close(process.waitEntered)
+	}
+	if process.waitUnblock != nil {
+		<-process.waitUnblock
+	}
+	return nil, process.waitErr
+}
+
+func (process *fakeReplacementProcess) Release() error {
+	process.releaseCalls++
+	return process.releaseErr
+}
+```
+
+每个替换 `startProcess` 的测试保存旧值并用 `t.Cleanup` 恢复。
+
+- [x] **Step 2: 写等待成功路径的回归测试**
+
+把现有 `TestRelaunchStartsWithConsoleInheritedFiles` 改为让 `startProcess` 捕获 `name`、`argv`、`ProcAttr` 并返回 fake。断言 `Relaunch` 返回 nil、`waitCalls == 1`、`releaseCalls == 0`，并保留 binary、args、env 和 stdin/stdout/stderr 的现有断言。
+
+- [x] **Step 3: 写阻塞语义回归测试**
+
+新增 `TestRelaunchWaitsForReplacementBeforeReturning`：在 goroutine 中调用 `Relaunch`，fake `Wait` 关闭 `entered` 后阻塞在 `unblock`。等待 `entered` 本身必须有 timeout，使旧实现以明确断言失败而不是永久挂起：
+
+```go
+select {
+case <-entered:
+case err := <-result:
+	t.Fatalf("Relaunch returned without waiting for replacement: %v", err)
+case <-time.After(time.Second):
+	t.Fatal("Relaunch did not call replacement Wait")
+}
+```
+
+随后执行非阻塞断言：
+
+```go
+select {
+case err := <-result:
+	t.Fatalf("Relaunch returned before replacement exited: %v", err)
+default:
+}
+close(unblock)
+select {
+case err := <-result:
+	if err != nil {
+		t.Fatal(err)
+	}
+case <-time.After(time.Second):
+	t.Fatal("Relaunch did not return after replacement exited")
+}
+```
+
+timeout 只防止测试永久挂起，不用于同步行为。
+
+- [x] **Step 4: 写等待错误与清理错误测试**
+
+新增：
+
+```go
+func TestRelaunchReleasesProcessAfterWaitFailure(t *testing.T)
+func TestRelaunchPreservesWaitAndReleaseErrors(t *testing.T)
+```
+
+第一个 fake 返回 `waitErr`，断言错误含 `wait for updated Mihari`、`errors.Is(err, waitErr)` 且 `releaseCalls == 1`。第二个同时返回 `waitErr` 与 `releaseErr`，断言 `errors.Is` 可找到两者，错误文本分别包含等待与等待失败后释放的操作上下文。
+
+- [x] **Step 5: 运行最小测试并确认 RED**
+
+```console
+go test -run '^TestRelaunch' ./internal/platform
+```
+
+Expected: 测试编译成功，但生命周期断言失败，因为 `Relaunch` 仍立即 `Release` 而不等待。不得接受编译错误或测试自身 hang。
+
+---
+
+### Task 3: 实现最小 Windows 等待与错误清理
+
+**Files:**
+- Modify: `internal/platform/relaunch_windows.go`
+- Test: `internal/platform/relaunch_windows_test.go`
+
+**Interfaces:**
+- Consumes: Task 1 定义的测试期望。
+- Produces: 不导出的 `replacementProcess` 接口；`startProcess func(string, []string, *os.ProcAttr) (replacementProcess, error)`；公开 `Relaunch` 签名保持不变。
+
+- [x] **Step 1: 用 Wait 替代成功后的立即 Release**
+
+启动参数与 `ProcAttr` 保持原样。启动成功后实现：
+
+```go
+if _, err := process.Wait(); err != nil {
+	waitErr := fmt.Errorf("wait for updated Mihari: %w", err)
+	if releaseErr := process.Release(); releaseErr != nil {
+		return errors.Join(waitErr, fmt.Errorf("release updated Mihari after wait failure: %w", releaseErr))
+	}
+	return waitErr
+}
+return nil
+```
+
+导入标准库 `errors`。成功路径不再调用 `Release`，因为 `Wait` 已释放资源。
+
+- [x] **Step 2: 格式化修改文件**
+
+```console
+gofmt -w internal/platform/relaunch_windows.go internal/platform/relaunch_windows_test.go
+```
+
+- [x] **Step 3: 运行最小测试并确认 GREEN**
+
+```console
+go test -run '^TestRelaunch' ./internal/platform
+```
+
+Expected: PASS。
+
+- [x] **Step 4: 运行直接相关回归测试**
+
+```console
+go test ./internal/platform ./internal/tui ./cmd/mihari
+```
+
+Expected: PASS，证明平台修复未改变 TUI relaunch 请求顺序和默认启动参数。
+
+---
+
+### Task 4: 完整验证、审查与交付
+
+**Files:**
+- Verify: `internal/platform/relaunch_windows.go`
+- Verify: `internal/platform/relaunch_windows_test.go`
+- Verify: `docs/superpowers/specs/2026-08-13-windows-tui-relaunch-lifecycle-design.md`
+- Verify: `docs/superpowers/plans/2026-08-13-windows-tui-relaunch-lifecycle.md`
+
+**Interfaces:**
+- Consumes: Task 2 的 Windows relaunch 行为。
+- Produces: 可提交、可跨平台构建并可由 CI 验证的 issue #55 修复。
+
+- [x] **Step 1: 运行全仓测试**
+
+```console
+go test ./...
+```
+
+Expected: PASS。
+
+- [x] **Step 2: 运行 race、静态检查和格式检查**
+
+```console
+go test -race ./...
+go vet ./...
+gofmt -l cmd internal
+```
+
+Expected: 前两条 PASS；`gofmt -l` 无输出。
+
+- [x] **Step 3: 执行无 CGO 跨平台编译**
+
+输出到经过显式解析的系统临时子目录，完成后只删除该子目录：
+
+```powershell
+$previousCGO = $env:CGO_ENABLED
+$previousGOOS = $env:GOOS
+$previousGOARCH = $env:GOARCH
+$tempRoot = (Resolve-Path -LiteralPath ([System.IO.Path]::GetTempPath())).Path
+$buildDir = Join-Path $tempRoot ('mihari-issue55-' + [guid]::NewGuid())
+New-Item -ItemType Directory -Path $buildDir | Out-Null
+$resolvedBuildDir = (Resolve-Path -LiteralPath $buildDir).Path
+if ([System.IO.Path]::GetDirectoryName($resolvedBuildDir) -ne $tempRoot) { throw 'unexpected build directory parent' }
+try {
+  $env:CGO_ENABLED='0'
+  $env:GOOS='windows'; $env:GOARCH='amd64'; go build -o (Join-Path $resolvedBuildDir 'mihari-windows-amd64.exe') ./cmd/mihari
+  if ($LASTEXITCODE -ne 0) { throw "windows/amd64 build failed with exit code $LASTEXITCODE" }
+  $env:GOOS='windows'; $env:GOARCH='arm64'; go build -o (Join-Path $resolvedBuildDir 'mihari-windows-arm64.exe') ./cmd/mihari
+  if ($LASTEXITCODE -ne 0) { throw "windows/arm64 build failed with exit code $LASTEXITCODE" }
+  $env:GOOS='linux';   $env:GOARCH='amd64'; go build -o (Join-Path $resolvedBuildDir 'mihari-linux-amd64') ./cmd/mihari
+  if ($LASTEXITCODE -ne 0) { throw "linux/amd64 build failed with exit code $LASTEXITCODE" }
+  $env:GOOS='darwin';  $env:GOARCH='arm64'; go build -o (Join-Path $resolvedBuildDir 'mihari-darwin-arm64') ./cmd/mihari
+  if ($LASTEXITCODE -ne 0) { throw "darwin/arm64 build failed with exit code $LASTEXITCODE" }
+} finally {
+  $env:CGO_ENABLED = $previousCGO
+  $env:GOOS = $previousGOOS
+  $env:GOARCH = $previousGOARCH
+  Remove-Item -LiteralPath $resolvedBuildDir -Recurse -Force
+}
+```
+
+Expected: 四个构建均成功，且只清理显式创建并解析过的临时子目录。
+
+- [x] **Step 4: 检查精确变更范围并请求独立代码审查**
+
+```console
+git status --short
+git diff --check
+git diff --stat
+git diff -- internal/platform docs/superpowers/specs/2026-08-13-windows-tui-relaunch-lifecycle-design.md docs/superpowers/plans/2026-08-13-windows-tui-relaunch-lifecycle.md
+```
+
+Expected: 只有计划内的 Windows 平台实现、测试、设计与计划文档；无临时产物或无关文件。
+
+审查若发现同步等待扩大了资源生命周期，必须在提交前补充 TUI cleanup 顺序测试，并确保旧 control session 在 relaunch 回调前关闭。实现使用 `sync.Once` 包装 cleanup，同时保留 defer 兜底。
+
+- [ ] **Step 5: 创建单一签名提交**
+
+```console
+git add internal/platform/relaunch_windows.go internal/platform/relaunch_windows_test.go docs/superpowers/specs/2026-08-13-windows-tui-relaunch-lifecycle-design.md docs/superpowers/plans/2026-08-13-windows-tui-relaunch-lifecycle.md
+git commit -s -m "fix(tui): 修复 Windows 自更新后的终端争用"
+```
+
+- [ ] **Step 6: 推送并创建 PR**
+
+```console
+git push -u origin fix/issue-55-tui-relaunch
+```
+
+读取 `.github/PULL_REQUEST_TEMPLATE.md` 后，用完整正文直接调用 `gh pr create --body`。正文必须包含：`Fixes #55`、根因、父进程同步等待 replacement 的修复方式、全部实际运行的验证命令、模板检查项，以及“真实 Windows TUI 自更新/控制台 Ctrl+C 未在自动化中执行”的明确说明。例如：
+
+```powershell
+$prBody = @'
+## 变更内容
+
+- wait for the replacement Mihari process on Windows so the invoking shell does not resume early
+- preserve inherited console streams and clean up the process handle after wait failures
+- add lifecycle regression tests
+
+## 类型
+
+- [ ] feat: 新功能
+- [x] fix: Bug 修复
+- [ ] refactor: 重构
+- [x] docs: 文档
+- [x] test: 测试
+- [ ] chore: 构建/工具
+
+## 检查清单
+
+- [x] `go test -race ./...` 通过
+- [x] `go vet ./...` 通过
+- [x] `gofmt -l cmd internal` 无输出
+- [x] 提交包含 `Signed-off-by`（DCO 签名）
+- [x] 跨平台行为影响已在本 PR 描述：Windows relaunch 现在等待 replacement；Unix 行为不变
+
+## 相关 Issues
+
+Fixes #55
+
+## 其他
+
+本地验证：
+
+- `go test ./...`
+- `go test -race ./...`
+- `go vet ./...`
+- `gofmt -l cmd internal`
+- CGO-free cross-builds: windows/amd64, windows/arm64, linux/amd64, darwin/arm64
+
+未执行真实的管理员 Windows TUI 自更新与控制台 Ctrl+C 流程；它们需要另行 testenv 授权。
+'@
+gh pr create --repo mihari-proxy/mihari --base main --head fix/issue-55-tui-relaunch --title "fix(tui): 修复 Windows 自更新后的终端争用" --body $prBody
+```
+
+- [ ] **Step 7: 持续监控 Actions**
+
+```console
+gh pr checks <pr-number> --watch --interval 15
+```
+
+Expected: 所有非 skipped checks 均为 success，而不只是 required checks。若失败，读取失败 job 日志，按 systematic debugging 回到根因调查，修复后重新完成相关本地验证、创建签名提交并推送，再次 watch。最后运行一次不带 `--watch` 的 `gh pr checks <pr-number>`，保存全部 Actions 已绿色的静态终态证据。

--- a/docs/superpowers/specs/2026-08-13-windows-tui-relaunch-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-08-13-windows-tui-relaunch-lifecycle-design.md
@@ -1,0 +1,130 @@
+# Windows TUI 自更新进程交接修复设计
+
+日期：2026-08-13
+状态：已实施，待 Pull Request
+关联 Issue：#55
+目标分支：`fix/issue-55-tui-relaunch`
+
+## 1. 问题
+
+Windows 上从 TUI 完成 Mihari 自更新后，旧进程通过 `os.StartProcess` 启动新版 Mihari，并立即对新进程调用 `Release`。旧进程随后从 `tui.Run`、Cobra 根命令和 `main` 返回，使启动旧进程的外部 shell 认为前台命令已经结束并恢复提示符。
+
+新进程仍继承旧进程的标准输入、标准输出和标准错误，并附着于同一控制台。因此外部 shell 与新版 TUI 同时读写同一控制台，造成界面叠加、输入争用以及 `Ctrl+C` 无法按预期退出当前会话。
+
+Bubble Tea v2.0.8 的 `Program.Run` 在返回前会停止输入循环、停止 renderer 并恢复终端状态。问题不在 Bubble Tea 退出顺序，而在 Windows relaunch 启动新进程后过早结束旧前台进程。
+
+Unix 使用 `syscall.Exec` 原位替换进程，外部 shell 始终等待同一进程身份，不受此问题影响。
+
+## 2. 目标
+
+- Windows 自更新后只允许新版 Mihari TUI 与控制台交互。
+- 外部 shell 必须在新版 TUI 退出后才恢复提示符。
+- 新版进程继续继承当前标准流、环境和默认 TUI 启动参数。
+- 启动失败或等待失败时返回带操作上下文的错误。
+- 不改变 `platform.Relaunch` 签名、CLI/JSON 契约、持久化格式或 Unix 行为。
+- 保持 `CGO_ENABLED=0` 和现有 Windows amd64/arm64 支持。
+
+## 3. 方案比较
+
+### 3.1 采用：旧 Windows 进程等待新版进程
+
+旧进程在 `os.StartProcess` 成功后调用 `Process.Wait`，直到新版 TUI 退出。等待期间旧进程不再运行 Bubble Tea，也不读取或写入控制台；它只保留外部 shell 正在等待的前台进程生命周期。新版进程独占继承的标准流。新版进程退出后，旧进程返回，外部 shell 才恢复提示符。
+
+该方案只修改 Windows 平台适配器，直接修复错误的生命周期边界，且不需要 shell、脚本或新协议。
+
+### 3.2 不采用：为新进程创建独立进程组
+
+独立进程组可改变控制事件分发，但不会阻止外部 shell 在旧进程退出后恢复并与新版 TUI共享控制台。它不能解决核心的前台生命周期问题，还可能改变 `Ctrl+C` 语义。
+
+### 3.3 不采用：通过 `cmd.exe` 或 PowerShell 包装启动
+
+使用 shell 的 `start /wait` 或等价命令会引入额外的命令行转义、路径、环境和宿主差异，并扩大跨 shell 测试矩阵。Go 已提供所需的进程启动与等待能力，无需外部包装器。
+
+## 4. 详细设计
+
+### 4.1 Windows 平台适配器
+
+`internal/platform/relaunch_windows.go` 保持现有输入校验和 `os.ProcAttr`：
+
+- `Env` 原样传递调用方环境；
+- `Files` 仍为 `os.Stdin`、`os.Stdout`、`os.Stderr`；
+- 不设置 `CREATE_NEW_CONSOLE`、`DETACHED_PROCESS` 或新进程组标志。
+
+启动成功后不再立即调用 `Process.Release`，而是同步等待新进程退出。正常退出（无论子进程退出码为何）表示进程交接已经完成；只有操作系统等待本身失败时，`Relaunch` 才返回 `wait for updated Mihari: ...` 错误。
+
+平台文件定义不导出的最小进程接口：
+
+```go
+type replacementProcess interface {
+	Wait() (*os.ProcessState, error)
+	Release() error
+}
+```
+
+包级启动函数返回该接口；生产默认实现调用 `os.StartProcess`，其 `*os.Process` 直接满足接口。测试返回受控 fake，而不手工构造内部句柄无效的 `*os.Process`。
+
+测试通过 fake 证明：
+
+1. 启动成功后一定等待同一个进程；
+2. 等待完成前 `Relaunch` 不返回；
+3. 等待错误得到包装并返回；
+4. 正常路径不再走立即 `Release` 式的脱离路径；
+5. 等待失败时 best-effort 调用 `Release` 清理仍可能持有的 Windows process handle。
+
+若等待与清理都失败，使用 `errors.Join` 同时保留 `wait for updated Mihari` 与 `release updated Mihari after wait failure` 上下文；等待错误始终是主要失败原因。注入点只服务 Windows 平台边界测试，不形成导出 API。
+
+### 4.2 TUI 与装配层
+
+`internal/tui.Run` 保持 Bubble Tea 先退出的顺序：`Program.Run` 完成 shutdown 与终端恢复后，立即关闭旧 control session，再由 `finishRun` 调用 relaunch 回调。session cleanup 使用 `sync.Once` 包装，并保留 defer 作为 panic 或提前返回的兜底，避免旧进程在同步等待新版 TUI 期间继续持有 WebSocket streams、轮询 goroutine 和 daemon 活动。
+
+`cmd/mihari` 继续向回调传入当前可执行文件、默认 TUI 参数和当前环境。由于 `platform.Relaunch` 在 Windows 上等待新版进程，`RunTUI`、Cobra 和旧 `main` 也会自然等待新版 TUI 生命周期结束。
+
+不向 `context.Context` 添加新的等待取消逻辑。新版 TUI 进入 Bubble Tea raw mode 后，`Ctrl+C` 按既有 TUI 按键语义处理；在启动或退出过渡期，Windows 仍可能把控制事件广播到同一控制台的多个进程。即使旧进程的 signal context 被取消，无 context 的 `Process.Wait` 也不会因此提前返回或重新暴露外部 shell。
+
+## 5. 错误处理
+
+- 参数无效：保持现有 `relaunch Mihari: binary and arguments are required`。
+- 新进程启动失败：保持现有 `start updated Mihari: ...`。
+- 等待新进程失败：返回 `wait for updated Mihari: ...`。
+- 新版 Mihari 自身的普通非零退出码不视为 Windows API 等待失败。旧进程随后保持当前的零退出行为，因此 Windows 外层进程不会传播新版进程的非零退出码。本修复只修复前台生命周期，不扩大范围实现与 Unix `exec` 相同的退出码传播；如需统一语义，应另行设计。
+- 等待失败时尝试释放进程句柄；清理失败与等待失败一并返回，不覆盖原始等待错误。
+
+## 6. 测试
+
+### 6.1 Windows 单元测试
+
+- 保留参数校验测试。
+- 更新标准流继承测试，使伪启动返回实现最小接口的 fake，并断言该 fake 的 `Wait` 被调用。
+- 用 `entered`、`unblock` 和结果 channel 握手，证明等待完成前 `Relaunch` 不会返回；不使用固定 `time.Sleep`。
+- 注入等待错误并断言错误包含 `wait for updated Mihari`、可通过 `errors.Is` 找到原始错误，并调用一次 `Release`。
+- 注入等待与清理双重错误，断言两个原始错误均可通过 `errors.Is` 找到。
+- 所有替换包级启动函数的测试使用 `t.Cleanup` 恢复，不调用 `t.Parallel`。
+- TUI 运行边界测试证明 control session cleanup 在可能阻塞的 relaunch 回调之前完成。
+
+测试不得启动真实新 TUI、访问公网、修改系统服务或用户配置。
+
+### 6.2 回归验证
+
+按风险执行：
+
+```console
+go test ./internal/platform
+go test ./internal/tui ./cmd/mihari
+go test ./...
+go test -race ./...
+go vet ./...
+gofmt -l cmd internal
+```
+
+执行 `CGO_ENABLED=0` 的 Windows amd64/arm64、Linux amd64 和 macOS arm64 编译检查，证明 Windows 专用注入点未泄漏到其他平台。
+
+真实 TUI 自更新、真实 Windows 控制台 `Ctrl+C`、管理员权限、服务重启和真实 GitHub Release 下载不进入自动测试；它们仍属于需用户单独授权的 testenv 范围。CI 证明等待与调用链，不声称验证真实控制台交互。
+
+## 7. 验收标准
+
+- Windows 更新完成后，旧进程在新版 Mihari 退出前保持存活但不访问控制台。
+- 外部 shell 在新版 TUI 退出前不会恢复提示符。
+- 新版 TUI 继续使用同一控制台和标准流，`Ctrl+C`/`q` 可按既有 TUI 行为退出。
+- 启动和等待错误具有稳定、无敏感信息的操作上下文。
+- Unix relaunch、公开 CLI/JSON 契约、持久化语义和 daemon 边界不变。
+- 本地测试、race、vet、格式化和受影响的无 CGO 跨平台构建通过。

--- a/internal/platform/relaunch_windows.go
+++ b/internal/platform/relaunch_windows.go
@@ -3,13 +3,21 @@
 package platform
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 )
 
+type replacementProcess interface {
+	Wait() (*os.ProcessState, error)
+	Release() error
+}
+
 // startProcess starts a process and is replaced in tests to avoid spawning binaries.
-var startProcess = os.StartProcess
+var startProcess = func(name string, argv []string, attr *os.ProcAttr) (replacementProcess, error) {
+	return os.StartProcess(name, argv, attr)
+}
 
 // Relaunch starts the replacement Mihari binary attached to the current console.
 func Relaunch(binary string, args, env []string) error {
@@ -23,8 +31,12 @@ func Relaunch(binary string, args, env []string) error {
 	if err != nil {
 		return fmt.Errorf("start updated Mihari: %w", err)
 	}
-	if err := process.Release(); err != nil {
-		return fmt.Errorf("release updated Mihari process: %w", err)
+	if _, err := process.Wait(); err != nil {
+		waitErr := fmt.Errorf("wait for updated Mihari: %w", err)
+		if releaseErr := process.Release(); releaseErr != nil {
+			return errors.Join(waitErr, fmt.Errorf("release updated Mihari after wait failure: %w", releaseErr))
+		}
+		return waitErr
 	}
 	return nil
 }

--- a/internal/platform/relaunch_windows_test.go
+++ b/internal/platform/relaunch_windows_test.go
@@ -6,13 +6,40 @@ import (
 	"errors"
 	"os"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
+
+type fakeReplacementProcess struct {
+	waitEntered  chan struct{}
+	waitUnblock  chan struct{}
+	waitErr      error
+	releaseErr   error
+	waitCalls    int
+	releaseCalls int
+}
+
+func (process *fakeReplacementProcess) Wait() (*os.ProcessState, error) {
+	process.waitCalls++
+	if process.waitEntered != nil {
+		close(process.waitEntered)
+	}
+	if process.waitUnblock != nil {
+		<-process.waitUnblock
+	}
+	return nil, process.waitErr
+}
+
+func (process *fakeReplacementProcess) Release() error {
+	process.releaseCalls++
+	return process.releaseErr
+}
 
 func TestRelaunchRequiresBinaryAndArgs(t *testing.T) {
 	prev := startProcess
 	t.Cleanup(func() { startProcess = prev })
-	startProcess = func(string, []string, *os.ProcAttr) (*os.Process, error) {
+	startProcess = func(string, []string, *os.ProcAttr) (replacementProcess, error) {
 		t.Fatal("startProcess should not run for invalid input")
 		return nil, nil
 	}
@@ -34,20 +61,21 @@ func TestRelaunchStartsWithConsoleInheritedFiles(t *testing.T) {
 		gotArgs []string
 		gotAttr *os.ProcAttr
 	)
-	startProcess = func(name string, argv []string, attr *os.ProcAttr) (*os.Process, error) {
+	process := &fakeReplacementProcess{}
+	startProcess = func(name string, argv []string, attr *os.ProcAttr) (replacementProcess, error) {
 		gotName = name
 		gotArgs = append([]string(nil), argv...)
 		gotAttr = attr
-		// Process with Pid 0 cannot Release successfully on Windows; return a
-		// synthetic error path is not needed because we only inspect attr construction.
-		// Returning an error after capturing args proves no real process spawn.
-		return nil, errors.New("injected start failure")
+		return process, nil
 	}
 
 	env := []string{"MIHARI_DATA=C:\\data", "PATH=C:\\Windows"}
 	err := Relaunch(`C:\Program Files\mihari\mihari.exe`, []string{`C:\Program Files\mihari\mihari.exe`, "daemon"}, env)
-	if err == nil || !strings.Contains(err.Error(), "start updated Mihari") {
+	if err != nil {
 		t.Fatalf("err=%v", err)
+	}
+	if process.waitCalls != 1 || process.releaseCalls != 0 {
+		t.Fatalf("waitCalls=%d releaseCalls=%d", process.waitCalls, process.releaseCalls)
 	}
 	if gotName != `C:\Program Files\mihari\mihari.exe` {
 		t.Fatalf("name=%q", gotName)
@@ -63,5 +91,89 @@ func TestRelaunchStartsWithConsoleInheritedFiles(t *testing.T) {
 	}
 	if len(gotAttr.Files) != 3 || gotAttr.Files[0] != os.Stdin || gotAttr.Files[1] != os.Stdout || gotAttr.Files[2] != os.Stderr {
 		t.Fatalf("files=%v want stdin/stdout/stderr inheritance", gotAttr.Files)
+	}
+}
+
+func TestRelaunchWaitsForReplacementBeforeReturning(t *testing.T) {
+	prev := startProcess
+	t.Cleanup(func() { startProcess = prev })
+
+	entered := make(chan struct{})
+	unblock := make(chan struct{})
+	var unblockOnce sync.Once
+	unblockWait := func() { unblockOnce.Do(func() { close(unblock) }) }
+	t.Cleanup(unblockWait)
+	process := &fakeReplacementProcess{waitEntered: entered, waitUnblock: unblock}
+	startProcess = func(string, []string, *os.ProcAttr) (replacementProcess, error) {
+		return process, nil
+	}
+
+	result := make(chan error, 1)
+	go func() {
+		result <- Relaunch(`C:\mihari.exe`, []string{`C:\mihari.exe`}, nil)
+	}()
+
+	select {
+	case <-entered:
+	case err := <-result:
+		t.Fatalf("Relaunch returned without waiting for replacement: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("Relaunch did not call replacement Wait")
+	}
+	select {
+	case err := <-result:
+		t.Fatalf("Relaunch returned before replacement exited: %v", err)
+	default:
+	}
+	unblockWait()
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Relaunch did not return after replacement exited")
+	}
+}
+
+func TestRelaunchReleasesProcessAfterWaitFailure(t *testing.T) {
+	prev := startProcess
+	t.Cleanup(func() { startProcess = prev })
+
+	waitErr := errors.New("injected wait failure")
+	process := &fakeReplacementProcess{waitErr: waitErr}
+	startProcess = func(string, []string, *os.ProcAttr) (replacementProcess, error) {
+		return process, nil
+	}
+
+	err := Relaunch(`C:\mihari.exe`, []string{`C:\mihari.exe`}, nil)
+	if !errors.Is(err, waitErr) || !strings.Contains(err.Error(), "wait for updated Mihari") {
+		t.Fatalf("err=%v", err)
+	}
+	if process.releaseCalls != 1 {
+		t.Fatalf("releaseCalls=%d want=1", process.releaseCalls)
+	}
+}
+
+func TestRelaunchPreservesWaitAndReleaseErrors(t *testing.T) {
+	prev := startProcess
+	t.Cleanup(func() { startProcess = prev })
+
+	waitErr := errors.New("injected wait failure")
+	releaseErr := errors.New("injected release failure")
+	process := &fakeReplacementProcess{waitErr: waitErr, releaseErr: releaseErr}
+	startProcess = func(string, []string, *os.ProcAttr) (replacementProcess, error) {
+		return process, nil
+	}
+
+	err := Relaunch(`C:\mihari.exe`, []string{`C:\mihari.exe`}, nil)
+	if !errors.Is(err, waitErr) || !errors.Is(err, releaseErr) {
+		t.Fatalf("err=%v", err)
+	}
+	if !strings.Contains(err.Error(), "wait for updated Mihari") || !strings.Contains(err.Error(), "release updated Mihari after wait failure") {
+		t.Fatalf("err=%v", err)
+	}
+	if process.waitCalls != 1 || process.releaseCalls != 1 {
+		t.Fatalf("waitCalls=%d releaseCalls=%d", process.waitCalls, process.releaseCalls)
 	}
 }

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 
 	tea "charm.land/bubbletea/v2"
 	controlclient "github.com/mihari-proxy/mihari/internal/control/client"
@@ -30,10 +31,18 @@ type Options struct {
 func Run(ctx context.Context, options Options) error {
 	model := NewModel()
 	var controlSession *session.Session
+	var closeSessionOnce sync.Once
+	closeSession := func() {
+		closeSessionOnce.Do(func() {
+			if controlSession != nil {
+				controlSession.Close()
+			}
+		})
+	}
+	defer closeSession()
 	if options.Client != nil {
 		controlSession = session.New(options.Client, session.Options{})
 		model = newModelWithClientContext(ctx, controlSession.Start(ctx), options.Client)
-		defer controlSession.Close()
 	}
 	if options.Service != nil {
 		model.SetServiceController(options.Service)
@@ -46,10 +55,13 @@ func Run(ctx context.Context, options Options) error {
 		tea.WithOutput(options.Output),
 	)
 	final, err := program.Run()
-	return finishRun(final, err, options.Output, options.Relaunch)
+	return finishRun(final, err, options.Output, options.Relaunch, closeSession)
 }
 
-func finishRun(final tea.Model, runErr error, warningWriter io.Writer, relaunch func() error) error {
+func finishRun(final tea.Model, runErr error, warningWriter io.Writer, relaunch func() error, cleanup func()) error {
+	if cleanup != nil {
+		cleanup()
+	}
 	if runErr != nil {
 		return runErr
 	}

--- a/internal/tui/run_test.go
+++ b/internal/tui/run_test.go
@@ -22,15 +22,34 @@ func TestFinishRunRelaunchesOnlyWhenRequested(t *testing.T) {
 			t.Fatal("relaunch ran before warning was written")
 		}
 		return nil
-	})
+	}, nil)
 	if err != nil || calls != 1 {
 		t.Fatalf("calls=%d err=%v", calls, err)
 	}
 }
 
+func TestFinishRunCleansUpSessionBeforeRelaunch(t *testing.T) {
+	model := NewModel()
+	model.relaunchRequested = true
+	cleaned := false
+
+	err := finishRun(model, nil, io.Discard, func() error {
+		if !cleaned {
+			t.Fatal("relaunch ran before control session cleanup")
+		}
+		return nil
+	}, func() { cleaned = true })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cleaned {
+		t.Fatal("control session cleanup did not run")
+	}
+}
+
 func TestFinishRunNormalExitDoesNotRelaunch(t *testing.T) {
 	calls := 0
-	if err := finishRun(NewModel(), nil, io.Discard, func() error { calls++; return nil }); err != nil || calls != 0 {
+	if err := finishRun(NewModel(), nil, io.Discard, func() error { calls++; return nil }, nil); err != nil || calls != 0 {
 		t.Fatalf("calls=%d err=%v", calls, err)
 	}
 }
@@ -40,7 +59,7 @@ func TestFinishRunProgramErrorPreventsRelaunch(t *testing.T) {
 	model.relaunchRequested = true
 	runErr := errors.New("program failed")
 	calls := 0
-	err := finishRun(model, runErr, io.Discard, func() error { calls++; return nil })
+	err := finishRun(model, runErr, io.Discard, func() error { calls++; return nil }, nil)
 	if !errors.Is(err, runErr) || calls != 0 {
 		t.Fatalf("calls=%d err=%v", calls, err)
 	}
@@ -50,7 +69,7 @@ func TestFinishRunReturnsRelaunchError(t *testing.T) {
 	model := NewModel()
 	model.relaunchRequested = true
 	relaunchErr := errors.New("start replacement failed")
-	err := finishRun(model, nil, io.Discard, func() error { return relaunchErr })
+	err := finishRun(model, nil, io.Discard, func() error { return relaunchErr }, nil)
 	if !errors.Is(err, relaunchErr) {
 		t.Fatalf("err=%v", err)
 	}
@@ -70,7 +89,7 @@ func TestFinishRunWarningWriteFailureStillRelaunches(t *testing.T) {
 	err := finishRun(model, nil, failingWriter{err: writeErr}, func() error {
 		calls++
 		return nil
-	})
+	}, nil)
 	if err != nil || calls != 1 {
 		t.Fatalf("calls=%d err=%v", calls, err)
 	}
@@ -83,7 +102,7 @@ func TestFinishRunPreservesWarningAndRelaunchErrors(t *testing.T) {
 	writeErr := errors.New("terminal is closed")
 	relaunchErr := errors.New("start replacement failed")
 
-	err := finishRun(model, nil, failingWriter{err: writeErr}, func() error { return relaunchErr })
+	err := finishRun(model, nil, failingWriter{err: writeErr}, func() error { return relaunchErr }, nil)
 	if !errors.Is(err, writeErr) || !errors.Is(err, relaunchErr) {
 		t.Fatalf("err=%v", err)
 	}


### PR DESCRIPTION
## 变更内容

- Windows 自更新重启时，旧 Mihari 同步等待 replacement 进程退出，避免外部 shell 提前恢复并与新版 TUI 争用同一控制台
- 保持继承当前 stdin/stdout/stderr；等待失败时 best-effort 释放进程句柄并保留等待与清理错误
- 在进入可能阻塞的 relaunch 前关闭旧 control session，避免祖先进程继续保留 streams、轮询 goroutine 与 daemon 活动
- 增加阻塞生命周期、错误清理、标准流继承和 session cleanup 顺序回归测试，并记录设计与实施计划

## 类型

- [ ] feat: 新功能
- [x] fix: Bug 修复
- [ ] refactor: 重构
- [x] docs: 文档
- [x] test: 测试
- [ ] chore: 构建/工具

## 检查清单

- [x] `go test -race ./...` 通过
- [x] `go vet ./...` 通过
- [x] `gofmt -l cmd internal` 无输出
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] 跨平台行为影响已说明：Windows relaunch 现在等待 replacement；Unix `exec` 行为不变

## 相关 Issues

Fixes #55

## 其他

本地验证：

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `gofmt -l cmd internal`
- `go test -count=100 -run '^TestRelaunch' ./internal/platform`
- `CGO_ENABLED=0` cross-build：windows/amd64、windows/arm64、linux/amd64、darwin/arm64

未执行真实的管理员 Windows TUI 自更新与控制台 Ctrl+C 流程；它们需要另行 testenv 授权。