### PR TITLE
feat(install): AIO 安装包支持并发分段下载

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,11 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - name: Test AIO parallel downloader
+        run: python scripts/install/test_parallel_download.py -v
       - name: Test
         run: go test -count=1 ./...
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -41,7 +41,7 @@ curl -fsSL https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/insta
 
 1. 下载根目录 `index.txt`（固定公开直链，永久有效），解析出最新版本号与本平台的整合包公开直链 + sha256；
 2. 询问确认（`--yes` / `-y` 可跳过；stdin 非 tty 时读 `/dev/tty`）；
-3. 下载整合包 → `Downloads/mihari-aio/` → sha256 校验；
+3. 下载整合包 → `Downloads/mihari-aio/`：源站支持 HTTP Range 时默认使用 4 个并发分段，否则自动回退单流；随后执行 sha256 校验；
 4. 解压到 `Downloads/mihari-aio/`；
 5. 调用包内的本地安装器（脚本2），传入 bundle 目录；
 6. 提示重启终端，运行 `mihari`。

--- a/scripts/install/install-aio-remote.ps1
+++ b/scripts/install/install-aio-remote.ps1
@@ -41,10 +41,9 @@ function Confirm($p) {
   $ans = Read-Host ((FixEncoding $p) + ' [y/N]')
   return $ans -match '^[Yy]'
 }
-# Download with a Write-Progress bar. HttpClient streaming keeps FixEncoding in
-# main scope (event-based WebClient callbacks can't reach it reliably) and shows
-# downloaded/total MB + percent. Replaces IWR -OutFile, which has no progress.
-function Download-FileWithProgress($url, $dest) {
+# Stream one response to disk with progress. This is also the compatibility
+# fallback when the origin does not provide a reliable byte-range contract.
+function Download-SingleFileWithProgress($url, $dest) {
   Add-Type -AssemblyName System.Net.Http
   $client = New-Object System.Net.Http.HttpClient
   $client.Timeout = [TimeSpan]::FromMinutes(30)
@@ -69,8 +68,114 @@ function Download-FileWithProgress($url, $dest) {
         }
       }
     } finally { $outStream.Dispose() }
-  } finally { $client.Dispose() }
+  } finally {
+    if ($resp) { $resp.Dispose() }
+    $client.Dispose()
+  }
   Write-Progress -Activity (FixEncoding '下载 mihari 安装包') -Completed
+}
+
+# Return the remote length only when a bytes=0-0 probe proves strict Range
+# support. A 200 response (or an incomplete Content-Range) deliberately selects
+# the single-stream compatibility path.
+function Get-RangeDownloadLength($url) {
+  Add-Type -AssemblyName System.Net.Http
+  $client = New-Object System.Net.Http.HttpClient
+  $client.Timeout = [TimeSpan]::FromSeconds(30)
+  $request = New-Object System.Net.Http.HttpRequestMessage([System.Net.Http.HttpMethod]::Get, $url)
+  $request.Headers.Range = New-Object System.Net.Http.Headers.RangeHeaderValue(0, 0)
+  try {
+    $response = $client.SendAsync($request, [System.Net.Http.HttpCompletionOption]::ResponseHeadersRead).GetAwaiter().GetResult()
+    if ([int]$response.StatusCode -ne 206) { return 0L }
+    $range = $response.Content.Headers.ContentRange
+    if (-not $range -or $range.From -ne 0 -or $range.To -ne 0 -or -not $range.Length -or $range.Length -le 0) { return 0L }
+    return [long]$range.Length
+  } catch {
+    return 0L
+  } finally {
+    if ($response) { $response.Dispose() }
+    $request.Dispose()
+    $client.Dispose()
+  }
+}
+
+function Download-FileWithProgress($url, $dest) {
+  $total = Get-RangeDownloadLength $url
+  $segments = 4
+  if ($total -lt $segments) {
+    Download-SingleFileWithProgress $url $dest
+    return
+  }
+
+  $partsDir = $dest + '.parts-' + [guid]::NewGuid().ToString('N')
+  New-Item -ItemType Directory -Path $partsDir | Out-Null
+  $pool = [runspacefactory]::CreateRunspacePool(1, $segments)
+  $pool.Open()
+  $workers = @()
+  $workerScript = {
+    param($DownloadUrl, $PartPath, [long]$Start, [long]$End, [long]$WholeLength)
+    Add-Type -AssemblyName System.Net.Http
+    $client = New-Object System.Net.Http.HttpClient
+    $client.Timeout = [TimeSpan]::FromMinutes(30)
+    $request = New-Object System.Net.Http.HttpRequestMessage([System.Net.Http.HttpMethod]::Get, $DownloadUrl)
+    $request.Headers.Range = New-Object System.Net.Http.Headers.RangeHeaderValue($Start, $End)
+    try {
+      $response = $client.SendAsync($request, [System.Net.Http.HttpCompletionOption]::ResponseHeadersRead).GetAwaiter().GetResult()
+      $range = $response.Content.Headers.ContentRange
+      if ([int]$response.StatusCode -ne 206 -or -not $range -or $range.From -ne $Start -or $range.To -ne $End -or $range.Length -ne $WholeLength) {
+        throw "invalid range response for bytes=$Start-$End"
+      }
+      $input = $response.Content.ReadAsStreamAsync().GetAwaiter().GetResult()
+      $output = [IO.File]::Create($PartPath)
+      try { $input.CopyTo($output) } finally { $output.Dispose(); $input.Dispose() }
+      $expected = $End - $Start + 1
+      if ((Get-Item -LiteralPath $PartPath).Length -ne $expected) {
+        throw "invalid segment length for bytes=$Start-$End"
+      }
+    } finally {
+      if ($response) { $response.Dispose() }
+      $request.Dispose()
+      $client.Dispose()
+    }
+  }
+
+  try {
+    $baseSize = [long][Math]::Floor($total / $segments)
+    for ($index = 0; $index -lt $segments; $index++) {
+      $start = $index * $baseSize
+      $end = if ($index -eq $segments - 1) { $total - 1 } else { $start + $baseSize - 1 }
+      $partPath = Join-Path $partsDir ('part-{0:D2}' -f $index)
+      $powershell = [powershell]::Create()
+      $powershell.RunspacePool = $pool
+      [void]$powershell.AddScript($workerScript).AddArgument($url).AddArgument($partPath).AddArgument($start).AddArgument($end).AddArgument($total)
+      $workers += [pscustomobject]@{ PowerShell = $powershell; Handle = $powershell.BeginInvoke(); Path = $partPath }
+    }
+
+    while (($workers | Where-Object { -not $_.Handle.IsCompleted }).Count -gt 0) {
+      $read = [long](($workers | ForEach-Object { if (Test-Path -LiteralPath $_.Path) { (Get-Item -LiteralPath $_.Path).Length } else { 0 } } | Measure-Object -Sum).Sum)
+      $pct = [int]($read * 100 / $total)
+      Write-Progress -Activity (FixEncoding '下载 mihari 安装包') -Status (FixEncoding ('已下载 {0:N1} / {1:N1} MB' -f ($read/1MB), ($total/1MB))) -PercentComplete $pct
+      Start-Sleep -Milliseconds 100
+    }
+    foreach ($worker in $workers) { $worker.PowerShell.EndInvoke($worker.Handle) | Out-Null }
+
+    $output = [IO.File]::Create($dest)
+    try {
+      foreach ($worker in $workers) {
+        $input = [IO.File]::OpenRead($worker.Path)
+        try { $input.CopyTo($output) } finally { $input.Dispose() }
+      }
+    } finally { $output.Dispose() }
+    if ((Get-Item -LiteralPath $dest).Length -ne $total) { throw 'merged download length mismatch' }
+  } catch {
+    Remove-Item -LiteralPath $dest -Force -ErrorAction SilentlyContinue
+    throw
+  } finally {
+    foreach ($worker in $workers) { $worker.PowerShell.Dispose() }
+    $pool.Dispose()
+    Remove-Item -LiteralPath $partsDir -Recurse -Force -ErrorAction SilentlyContinue
+    Write-Progress -Activity (FixEncoding '下载 mihari 安装包') -Completed
+  }
 }
 # Print a short install plan + what's affected, then confirm. Runs once before the
 # download, unifying the per-branch confirms that used to scatter the version block.
@@ -88,6 +193,10 @@ function Show-InstallPlan {
   Write-Host (FixEncoding "  不影响   : mihari.yaml / 订阅 / 面板状态 等用户配置")
   Write-Host ''
 }
+
+# Tests dot-source this standalone script to exercise the real downloader
+# against a local HTTP server without running the installation flow.
+if ($env:MIHARI_INSTALL_TEST_MODE -eq '1') { return }
 
 # Detect platform (mirrors install.ps1).
 $arch = switch ($env:PROCESSOR_ARCHITECTURE) {

--- a/scripts/install/install-aio-remote.sh
+++ b/scripts/install/install-aio-remote.sh
@@ -48,31 +48,135 @@ confirm() {
   esac
 }
 
-# Detect platform (mirrors install.sh).
-os="$(uname -s)"
-case "$os" in
-  Linux) os="linux" ;;
-  Darwin) os="darwin" ;;
-  *) err "unsupported OS: $os" ;;
-esac
-arch="$(uname -m)"
-case "$arch" in
-  x86_64|amd64) arch="amd64" ;;
-  aarch64|arm64) arch="arm64" ;;
-  *) err "unsupported architecture: $arch" ;;
-esac
-platform="${os}-${arch}"
+# Detect platform (mirrors install.sh). Test mode loads only the downloader and
+# therefore also works under Git Bash on the Windows CI runner.
+if [ "${MIHARI_INSTALL_TEST_MODE:-}" != "1" ]; then
+  os="$(uname -s)"
+  case "$os" in
+    Linux) os="linux" ;;
+    Darwin) os="darwin" ;;
+    *) err "unsupported OS: $os" ;;
+  esac
+  arch="$(uname -m)"
+  case "$arch" in
+    x86_64|amd64) arch="amd64" ;;
+    aarch64|arm64) arch="arm64" ;;
+    *) err "unsupported architecture: $arch" ;;
+  esac
+  platform="${os}-${arch}"
+fi
 
 # Downloader: dl writes to a file, fetch writes to stdout (mirrors install.sh).
 if command -v curl >/dev/null 2>&1; then
+  downloader="curl"
   dl() { curl -fsSL "$1" -o "$2"; }
   fetch() { curl -fsSL "$1"; }
 elif command -v wget >/dev/null 2>&1; then
+  downloader="wget"
   dl() { wget -qO "$2" "$1"; }
   fetch() { wget -qO- "$1"; }
 else
   err "need curl or wget"
 fi
+
+download_file_with_progress() {
+  url="$1"
+  dest="$2"
+  if [ "$downloader" != "curl" ]; then
+    dl "$url" "$dest"
+    return
+  fi
+
+  probe_headers="${dest}.probe-headers-$$"
+  probe_body="${dest}.probe-body-$$"
+  probe_status="${dest}.probe-status-$$"
+  parts_dir=""
+  pids=""
+  cancel_download() {
+    trap - HUP INT TERM
+    for cancel_pid in $pids; do kill "$cancel_pid" 2>/dev/null || true; done
+    for cancel_pid in $pids; do wait "$cancel_pid" 2>/dev/null || true; done
+    [ -z "$parts_dir" ] || rm -rf "$parts_dir"
+    rm -f "$probe_headers" "$probe_body" "$probe_status" "$dest"
+    exit 1
+  }
+  trap 'cancel_download' HUP INT TERM
+  curl -fsSL -H 'Range: bytes=0-0' -D "$probe_headers" -o "$probe_body" -w '%{http_code}' "$url" >"$probe_status" 2>/dev/null &
+  pids="$!"
+  wait "$pids" 2>/dev/null || true
+  pids=""
+  status="$(cat "$probe_status" 2>/dev/null || true)"
+  content_range="$(tr -d '\r' <"$probe_headers" | awk 'tolower($1) == "content-range:" {print $2 " " $3}' | tail -n 1)"
+  rm -f "$probe_headers" "$probe_body" "$probe_status"
+  total="$(printf '%s\n' "$content_range" | sed -n 's#^bytes 0-0/\([0-9][0-9]*\)$#\1#p')"
+  if [ "$status" != "206" ] || [ -z "$total" ] || [ "$total" -lt 4 ]; then
+    trap - HUP INT TERM
+    dl "$url" "$dest"
+    return
+  fi
+
+  parts_dir="$(mktemp -d "${dest}.parts-XXXXXX")"
+  failed=0
+  base_size=$((total / 4))
+  index=0
+  while [ "$index" -lt 4 ]; do
+    start=$((index * base_size))
+    if [ "$index" -eq 3 ]; then end=$((total - 1)); else end=$((start + base_size - 1)); fi
+    part="${parts_dir}/part-$(printf '%02d' "$index")"
+    header="${part}.headers"
+    curl -fsSL --range "${start}-${end}" -D "$header" -o "$part" -w '%{http_code}' "$url" >"${part}.status" &
+    pids="$pids $!"
+    index=$((index + 1))
+  done
+
+  while :; do
+    running=0
+    for pid in $pids; do kill -0 "$pid" 2>/dev/null && running=1; done
+    [ "$running" = 1 ] || break
+    downloaded=0
+    for progress_part in "$parts_dir"/part-[0-9][0-9]; do
+      [ -f "$progress_part" ] || continue
+      progress_size="$(wc -c <"$progress_part" | tr -d ' ')"
+      downloaded=$((downloaded + progress_size))
+    done
+    percent=$((downloaded * 100 / total))
+    printf '\r  downloaded %.1f / %.1f MB (%d%%)' "$(awk "BEGIN {print $downloaded/1048576}")" "$(awk "BEGIN {print $total/1048576}")" "$percent"
+    sleep 0.1
+  done
+  for pid in $pids; do wait "$pid" || failed=1; done
+  printf '\n'
+
+  if [ "$failed" = 0 ]; then
+    index=0
+    while [ "$index" -lt 4 ]; do
+      part="${parts_dir}/part-$(printf '%02d' "$index")"
+      start=$((index * base_size))
+      if [ "$index" -eq 3 ]; then end=$((total - 1)); else end=$((start + base_size - 1)); fi
+      got_range="$(tr -d '\r' <"${part}.headers" | awk 'tolower($1) == "content-range:" {print $2 " " $3}' | tail -n 1)"
+      [ "$(cat "${part}.status")" = "206" ] || failed=1
+      [ "$got_range" = "bytes ${start}-${end}/${total}" ] || failed=1
+      [ "$(wc -c <"$part" | tr -d ' ')" = "$((end - start + 1))" ] || failed=1
+      index=$((index + 1))
+    done
+  fi
+
+  if [ "$failed" = 0 ]; then
+    : >"$dest"
+    index=0
+    while [ "$index" -lt 4 ]; do
+      part="${parts_dir}/part-$(printf '%02d' "$index")"
+      cat "$part" >>"$dest" || failed=1
+      index=$((index + 1))
+    done
+    [ "$(wc -c <"$dest" | tr -d ' ')" = "$total" ] || failed=1
+  fi
+  rm -rf "$parts_dir"
+  trap - HUP INT TERM
+  if [ "$failed" != 0 ]; then
+    rm -f "$dest"
+    return 1
+  fi
+}
 
 checksum() {
   if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | cut -d' ' -f1
@@ -80,6 +184,10 @@ checksum() {
   else err "need sha256sum or shasum"
   fi
 }
+
+# Tests source this standalone script to exercise the real downloader against
+# a local HTTP server without running the installation flow.
+[ "${MIHARI_INSTALL_TEST_MODE:-}" = "1" ] && return 0
 
 # Resolve bundle URL + expected sha256 + latest version.
 latest=""
@@ -140,7 +248,7 @@ workdir="${HOME}/Downloads/mihari-aio"
 mkdir -p "$workdir"
 archive="${workdir}/mihari-all-in-one-${platform}.tar.gz"
 info "下载 ${bundle_url} …"
-dl "$bundle_url" "$archive" || err "下载失败: $bundle_url"
+download_file_with_progress "$bundle_url" "$archive" || err "下载失败: $bundle_url"
 if [ -n "$want_sum" ]; then
   got="$(checksum "$archive")"
   [ "$got" = "$want_sum" ] || err "sha256 校验失败：期望 $want_sum，实际 $got。"

--- a/scripts/install/test_parallel_download.py
+++ b/scripts/install/test_parallel_download.py
@@ -1,0 +1,296 @@
+import glob
+import os
+from pathlib import Path
+import re
+import select
+import socket
+import subprocess
+import tempfile
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+PAYLOAD = bytes(range(256)) * 8192
+
+
+class RangeServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self):
+        super().__init__(("127.0.0.1", 0), RangeHandler)
+        self.active = 0
+        self.max_active = 0
+        self.range_headers = []
+        self.lock = threading.Lock()
+
+    def reset(self):
+        with self.lock:
+            self.active = 0
+            self.max_active = 0
+            self.range_headers = []
+
+    def handle_error(self, _request, _client_address):
+        # Range probes intentionally dispose a one-byte response without
+        # consuming the body; Windows may reset that keep-alive connection.
+        pass
+
+
+class RangeHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, _format, *args):
+        pass
+
+    def do_GET(self):
+        range_header = self.headers.get("Range")
+        with self.server.lock:
+            self.server.range_headers.append(range_header)
+
+        if self.path == "/ignore" or not range_header:
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(PAYLOAD)))
+            self.end_headers()
+            self.wfile.write(PAYLOAD)
+            return
+
+        match = re.fullmatch(r"bytes=(\d+)-(\d+)", range_header)
+        if not match:
+            self.send_error(416)
+            return
+        start, end = (int(value) for value in match.groups())
+        if start < 0 or end < start or end >= len(PAYLOAD):
+            self.send_error(416)
+            return
+
+        if self.path == "/slow-probe" and start == 0 and end == 0:
+            with self.server.lock:
+                self.server.active += 1
+                self.server.max_active = max(self.server.max_active, self.server.active)
+            try:
+                deadline = time.monotonic() + 10
+                while time.monotonic() < deadline:
+                    readable, _, _ = select.select([self.connection], [], [], 0.05)
+                    if readable and not self.connection.recv(1, socket.MSG_PEEK):
+                        return
+                self.send_response(206)
+                self.send_header("Content-Range", f"bytes 0-0/{len(PAYLOAD)}")
+                self.send_header("Content-Length", "1")
+                self.end_headers()
+                self.wfile.write(PAYLOAD[:1])
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            finally:
+                with self.server.lock:
+                    self.server.active -= 1
+            return
+
+        if self.path == "/bad" and start > 0:
+            self.send_response(206)
+            self.send_header("Content-Range", f"bytes {start}-{end}/{len(PAYLOAD)}")
+            self.send_header("Content-Length", str(end - start))
+            self.end_headers()
+            self.wfile.write(PAYLOAD[start:end])
+            return
+
+        chunk = PAYLOAD[start : end + 1]
+        with self.server.lock:
+            self.server.active += 1
+            self.server.max_active = max(self.server.max_active, self.server.active)
+        try:
+            self.send_response(206)
+            header_name = "CONTENT-RANGE" if self.path == "/uppercase" else "Content-Range"
+            self.send_header(header_name, f"bytes {start}-{end}/{len(PAYLOAD)}")
+            self.send_header("Content-Length", str(len(chunk)))
+            self.end_headers()
+            if end > start:
+                time.sleep(2 if self.path == "/slow" else 0.2)
+            try:
+                self.wfile.write(chunk)
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+        finally:
+            with self.server.lock:
+                self.server.active -= 1
+
+
+class ParallelDownloadTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.server = RangeServer()
+        cls.server_thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.server_thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.server.server_close()
+        cls.server_thread.join(timeout=5)
+
+    def setUp(self):
+        self.server.reset()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+
+    def downloader_command(self, url, destination):
+        force_shell = os.environ.get("MIHARI_TEST_UNIX_SHELL") == "1"
+        if os.name == "nt" and not force_shell:
+            script = SCRIPT_DIR / "install-aio-remote.ps1"
+            command = (
+                "$ErrorActionPreference='Stop'; "
+                "$env:MIHARI_INSTALL_TEST_MODE='1'; "
+                f". ([scriptblock]::Create([IO.File]::ReadAllText('{script}'))); "
+                f"Download-FileWithProgress -url '{url}' -dest '{destination}'"
+            )
+            return ["powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", command]
+
+        script = (SCRIPT_DIR / "install-aio-remote.sh").as_posix()
+        destination = Path(destination).as_posix()
+        command = (
+            "set -eu; MIHARI_INSTALL_TEST_MODE=1; export MIHARI_INSTALL_TEST_MODE; "
+            f". '{script}'; download_file_with_progress '{url}' '{destination}'"
+        )
+        shell = os.environ.get("MIHARI_TEST_SHELL", "sh")
+        return [shell, "-c", command]
+
+    def run_downloader(self, endpoint, destination):
+        url = f"http://127.0.0.1:{self.server.server_port}/{endpoint}"
+        return subprocess.run(
+            self.downloader_command(url, destination),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            errors="replace",
+            timeout=30,
+        )
+
+    def assert_no_parts(self, destination):
+        self.assertEqual([], glob.glob(str(destination) + ".parts-*"))
+
+    def assert_no_download_artifacts(self, destination):
+        self.assert_no_parts(destination)
+        self.assertEqual([], glob.glob(str(destination) + ".probe-*"))
+
+    def test_range_download_uses_four_concurrent_segments(self):
+        destination = Path(self.temp_dir.name) / "bundle.bin"
+
+        result = self.run_downloader("range", destination)
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(PAYLOAD, destination.read_bytes())
+        segment_requests = [header for header in self.server.range_headers if header != "bytes=0-0"]
+        self.assertEqual(4, len(segment_requests))
+        self.assertGreaterEqual(self.server.max_active, 2)
+        self.assert_no_parts(destination)
+
+    def test_server_without_range_support_falls_back_to_single_stream(self):
+        destination = Path(self.temp_dir.name) / "bundle.bin"
+
+        result = self.run_downloader("ignore", destination)
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(PAYLOAD, destination.read_bytes())
+        self.assertEqual(["bytes=0-0", None], self.server.range_headers)
+        self.assert_no_parts(destination)
+
+    def test_content_range_header_name_is_case_insensitive(self):
+        destination = Path(self.temp_dir.name) / "bundle.bin"
+
+        result = self.run_downloader("uppercase", destination)
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(PAYLOAD, destination.read_bytes())
+        segment_requests = [header for header in self.server.range_headers if header != "bytes=0-0"]
+        self.assertEqual(4, len(segment_requests))
+
+    @unittest.skipIf(os.name == "nt", "POSIX signal semantics are tested on Linux and macOS CI")
+    def test_unix_cancellation_stops_segments_and_removes_files(self):
+        destination = Path(self.temp_dir.name) / "bundle.bin"
+        url = f"http://127.0.0.1:{self.server.server_port}/slow"
+        process = subprocess.Popen(
+            self.downloader_command(url, destination),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            errors="replace",
+        )
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            with self.server.lock:
+                active = self.server.active
+            if active >= 2:
+                break
+            time.sleep(0.05)
+        else:
+            process.kill()
+            self.fail("parallel segment requests did not start")
+
+        process.terminate()
+        process.communicate(timeout=10)
+        deadline = time.monotonic() + 3
+        while time.monotonic() < deadline:
+            with self.server.lock:
+                active = self.server.active
+            if active == 0:
+                break
+            time.sleep(0.05)
+
+        self.assertEqual(0, active, "segment requests remained active after cancellation")
+        self.assertFalse(destination.exists())
+        self.assert_no_download_artifacts(destination)
+
+    @unittest.skipIf(os.name == "nt", "POSIX signal semantics are tested on Linux and macOS CI")
+    def test_unix_cancellation_stops_range_probe_and_removes_files(self):
+        destination = Path(self.temp_dir.name) / "bundle.bin"
+        url = f"http://127.0.0.1:{self.server.server_port}/slow-probe"
+        process = subprocess.Popen(
+            self.downloader_command(url, destination),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            errors="replace",
+        )
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            with self.server.lock:
+                active = self.server.active
+            if active == 1:
+                break
+            time.sleep(0.05)
+        else:
+            process.kill()
+            self.fail("range probe did not start")
+
+        process.terminate()
+        try:
+            process.communicate(timeout=3)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.communicate(timeout=3)
+            self.fail("downloader did not stop while the range probe was active")
+        deadline = time.monotonic() + 3
+        while time.monotonic() < deadline:
+            with self.server.lock:
+                active = self.server.active
+            if active == 0:
+                break
+            time.sleep(0.05)
+
+        self.assertEqual(0, active, "range probe remained active after cancellation")
+        self.assertFalse(destination.exists())
+        self.assert_no_download_artifacts(destination)
+
+    def test_invalid_segment_length_fails_without_leaving_files(self):
+        destination = Path(self.temp_dir.name) / "bundle.bin"
+
+        result = self.run_downloader("bad", destination)
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertFalse(destination.exists())
+        self.assert_no_parts(destination)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更内容

- 为 Windows PowerShell 5.1 AIO 远程安装器增加 4 路 HTTP Range 并发下载
- 为 Linux/macOS AIO 远程安装器增加基于 `curl` 的 4 路并发下载；`wget` 与不支持 Range 的源站保留单流回退
- 严格校验 `206`、`Content-Range`、分段长度与合并长度，继续执行现有 SHA-256 校验
- 在探测、分段失败或 POSIX 信号取消时终止并回收下载进程，清理所有临时文件
- 新增本地 HTTP 服务器驱动的跨平台行为测试并接入 Windows、Ubuntu、macOS CI
- 更新分发文档

## 类型

- [x] feat: 新功能
- [ ] fix: Bug 修复
- [ ] refactor: 重构
- [x] docs: 文档
- [x] test: 测试
- [ ] chore: 构建/工具

## 检查清单

- [ ] `go test -race ./...` 通过（本机受已运行的 mihari/mihomo 进程影响，既有 Windows 集成用例无法清理临时 mihomo.exe；由 PR 的干净 Windows runner 验证）
- [x] `go test -count=1 ./...` 通过
- [x] `go vet ./...` 通过
- [x] `gofmt -l .` 无输出
- [x] PowerShell 5.1 下载行为测试通过（4 项适用测试）
- [x] Linux/WSL 下载行为测试通过（6 项，含探测和分段取消）
- [x] POSIX `sh -n` 与 `git diff --check` 通过
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] 跨平台行为影响已说明：AIO 远程下载优先 4 路 Range，不满足严格条件时回退单流

## 相关 Issues

Closes #56

## 其他

无新增运行时依赖。并发数固定为保守的 4；Windows 使用系统自带 .NET/runspace，Unix 使用现有 `curl`。