### PR TITLE
fix(tui): mihomo 重启时保持 daemon 连接状态

### DIFF
--- a/internal/tui/pages/system/model.go
+++ b/internal/tui/pages/system/model.go
@@ -266,6 +266,11 @@ type actionResultMsg struct {
 	err     error
 }
 
+type coreLoadResultMsg struct {
+	core protocol.CoreStatus
+	err  error
+}
+
 // Err implements the shell's action-outcome contract so core update/restart
 // actions are classified Succeeded/Failed in the Recent operations ledger.
 func (m actionResultMsg) Err() error { return m.err }
@@ -638,6 +643,11 @@ func (m *Model) Update(message tea.Msg) (ui.Page, tea.Cmd) {
 		return m, nil
 	case ui.CoreObservedMsg:
 		m.core = typed.Core
+		return m, nil
+	case coreLoadResultMsg:
+		if typed.err == nil {
+			m.core = typed.core
+		}
 		return m, nil
 	case ui.ActionPendingMsg:
 		m.beginRowPending(typed.Action)
@@ -1804,10 +1814,7 @@ func (m *Model) loadCore() tea.Cmd {
 	}
 	return func() tea.Msg {
 		core, err := m.client.Core(m.ctx)
-		if err != nil {
-			return actionResultMsg{err: err}
-		}
-		return ui.CoreObservedMsg{Core: core}
+		return coreLoadResultMsg{core: core, err: err}
 	}
 }
 

--- a/internal/tui/pages/system/model_test.go
+++ b/internal/tui/pages/system/model_test.go
@@ -48,6 +48,7 @@ type fakeClient struct {
 	onboardingCalls int
 	coreCalls       int
 	coreStatus      protocol.CoreStatus
+	coreErr         error
 
 	systemProxy       protocol.SystemProxyStatus
 	systemProxyCalls  int
@@ -117,6 +118,9 @@ func (f *fakeClient) Onboarding(context.Context) (protocol.OnboardingStatus, err
 }
 func (f *fakeClient) Core(context.Context) (protocol.CoreStatus, error) {
 	f.coreCalls++
+	if f.coreErr != nil {
+		return protocol.CoreStatus{}, f.coreErr
+	}
 	if f.coreStatus.Schema != "" {
 		return f.coreStatus, nil
 	}
@@ -2089,6 +2093,75 @@ func TestSystemCoreChannelEnterSwitchesToOtherChannel(t *testing.T) {
 			}
 			if client.lastMutation.OperationID != "system-op" {
 				t.Fatalf("operation=%q", client.lastMutation.OperationID)
+			}
+		})
+	}
+}
+
+func TestSystemCoreChannelSwitchStaysPendingUntilSuccessAndShowsTargetChannel(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		from string
+		to   string
+	}{
+		{name: "stable to alpha", from: "stable", to: "alpha"},
+		{name: "alpha to stable", from: "alpha", to: "stable"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			client := &fakeClient{onboarding: protocol.OnboardingStatus{Revision: 11}}
+			model := New(client, func() string { return "system-op" })
+			status := protocol.Status{Revision: 11, Capabilities: []string{protocol.CapabilityCore}}
+			model.SetSnapshot(status, protocol.CoreStatus{
+				Revision: 11, Status: "running", Version: "v1.19.0", Channel: test.from,
+			})
+			model.SetMutationsEnabled(true)
+
+			updated, _ := model.Update(ui.ActionPendingMsg{Action: ui.ActionSwitchCoreChannel})
+			model = updated.(*Model)
+			if !model.pending || model.pendingRow != rowCoreChannel || !model.mutationsEnabled {
+				t.Fatalf("pending=%v row=%q mutations=%v", model.pending, model.pendingRow, model.mutationsEnabled)
+			}
+			if view := model.View(); !strings.Contains(view, ui.CoreProgressSwitching) {
+				t.Fatalf("pending channel switch is not visible:\n%s", view)
+			}
+
+			client.coreErr = errors.New("mihomo controller unavailable")
+			updated, command := model.Update(actionResultMsg{
+				kind:    actionSwitchChannel,
+				install: protocol.CoreInstallResult{Schema: "mihari/v1", Revision: 12, Version: "v1.20.0", Updated: true},
+			})
+			model = updated.(*Model)
+			batch, ok := command().(tea.BatchMsg)
+			if !ok {
+				t.Fatalf("success follow-up=%T want tea.BatchMsg", command())
+			}
+			for _, followUp := range batch {
+				message := followUp()
+				switch message.(type) {
+				case actionResultMsg, coreLoadResultMsg:
+					updated, _ = model.Update(message)
+					model = updated.(*Model)
+				}
+			}
+			if model.pending || model.outcomeRow != rowCoreChannel || !model.outcomeOK {
+				t.Fatalf("temporary core refresh replaced mutation success: pending=%v outcome row=%q ok=%v", model.pending, model.outcomeRow, model.outcomeOK)
+			}
+
+			client.coreErr = nil
+			client.coreStatus = protocol.CoreStatus{
+				Schema: "mihari/v1", Revision: 12, Status: "running", Version: "v1.20.0", Channel: test.to,
+			}
+			updated, _ = model.Update(model.loadCore()())
+			model = updated.(*Model)
+			status.Revision = 12
+			model.status = status
+
+			if model.pending || model.outcomeRow != rowCoreChannel || !model.outcomeOK {
+				t.Fatalf("pending=%v outcome row=%q ok=%v", model.pending, model.outcomeRow, model.outcomeOK)
+			}
+			view := model.View()
+			if !strings.Contains(view, ui.DoneLabel) || !strings.Contains(view, test.to) {
+				t.Fatalf("successful switch did not converge to Done and %q:\n%s", test.to, view)
 			}
 		})
 	}

--- a/internal/tui/session/session.go
+++ b/internal/tui/session/session.go
@@ -153,16 +153,10 @@ func (s *Session) supervise(ctx context.Context) {
 		if !putOrdered(ctx, s.control, Event{Kind: EventStatus, Status: status}) {
 			return
 		}
-		if err := s.poll(ctx, status); err != nil {
-			if ctx.Err() != nil {
-				return
-			}
-			attempt++
-			if !putOrdered(ctx, s.control, Event{Kind: EventReconnecting, Attempt: attempt, Err: err}) || !waitBackoff(ctx, s.options.Backoff(attempt)) {
-				return
-			}
-			continue
-		}
+		// Status is the daemon transport health boundary. Capability snapshots
+		// backed by mihomo may fail while its controller starts or restarts; keep
+		// the daemon connected and retry those snapshots during supervision.
+		_ = s.poll(ctx, status)
 		if !putOrdered(ctx, s.control, Event{Kind: EventConnected}) {
 			return
 		}
@@ -179,8 +173,8 @@ func (s *Session) supervise(ctx context.Context) {
 }
 
 // poll pulls one snapshot of every capability-backed resource and forwards it
-// as ordered events. It returns the first error; callers decide whether to
-// reconnect (errors from putOrdered are surfaced as the context error).
+// as ordered events. It returns the first error so callers can retain the last
+// observed snapshot and retry without changing daemon transport state.
 func (s *Session) poll(ctx context.Context, status protocol.Status) error {
 	if slices.Contains(status.Capabilities, protocol.CapabilityCore) {
 		coreStatus, err := s.client.Core(ctx)
@@ -248,21 +242,35 @@ func (s *Session) poll(ctx context.Context, status protocol.Status) error {
 	return nil
 }
 
-// superviseStreams keeps the push streams resident for the whole connected
-// session while re-polling state snapshots on PollInterval. It returns when a
-// stream fails or a poll fails (callers reconnect), or nil when the session
-// context is cancelled.
+// superviseStreams keeps the push streams resident for the whole daemon
+// session while re-polling state snapshots on PollInterval. A controller
+// stream may end while mihomo restarts even though the daemon's local control
+// transport remains healthy, so only a failed Status probe returns an error to
+// the daemon-level supervisor.
 func (s *Session) superviseStreams(ctx context.Context) error {
 	streamCtx, cancelStreams := context.WithCancel(ctx)
 	defer cancelStreams()
 	streamErr := make(chan error, 1)
-	go func() { streamErr <- s.runStreams(streamCtx) }()
+	streamHealthy := make(chan struct{}, 1)
+	startStreams := func() {
+		// runStreams joins every old producer before reporting its error, so any
+		// buffered health signal here belongs to the completed generation.
+		select {
+		case <-streamHealthy:
+		default:
+		}
+		go func() { streamErr <- s.runStreams(streamCtx, streamHealthy) }()
+	}
+	startStreams()
+	streamAttempt := 0
 	ticker := time.NewTicker(s.options.PollInterval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
+		case <-streamHealthy:
+			streamAttempt = 0
 		case err := <-streamErr:
 			if ctx.Err() != nil {
 				return nil
@@ -270,7 +278,23 @@ func (s *Session) superviseStreams(ctx context.Context) error {
 			if err == nil {
 				err = errors.New("control streams ended")
 			}
-			return err
+			status, statusErr := s.client.Status(streamCtx)
+			if statusErr != nil {
+				return errors.Join(err, statusErr)
+			}
+			if !putOrdered(streamCtx, s.control, Event{Kind: EventStatus, Status: status}) {
+				return streamCtx.Err()
+			}
+			streamAttempt++
+			if !waitBackoff(streamCtx, s.options.Backoff(streamAttempt)) {
+				return nil
+			}
+			startStreams()
+			// Snapshot endpoints backed by the mihomo controller can remain
+			// temporarily unavailable after Status proves the daemon is alive.
+			// Reopen streams first, retain the last observed snapshot, and let
+			// this or the next periodic poll refresh it when mihomo is ready.
+			_ = s.poll(streamCtx, status)
 		case <-ticker.C:
 			status, err := s.client.Status(streamCtx)
 			if err != nil {
@@ -279,14 +303,15 @@ func (s *Session) superviseStreams(ctx context.Context) error {
 			if !putOrdered(streamCtx, s.control, Event{Kind: EventStatus, Status: status}) {
 				return streamCtx.Err()
 			}
-			if err := s.poll(streamCtx, status); err != nil {
-				return err
-			}
+			// Status is the daemon transport health boundary. A snapshot error
+			// after it succeeds may only mean the restarted controller is not
+			// ready yet and must not mark the daemon stale.
+			_ = s.poll(streamCtx, status)
 		}
 	}
 }
 
-func (s *Session) runStreams(parent context.Context) error {
+func (s *Session) runStreams(parent context.Context, healthy chan<- struct{}) error {
 	ctx, cancel := context.WithCancel(parent)
 	defer cancel()
 	errCh := make(chan error, 1)
@@ -314,6 +339,10 @@ func (s *Session) runStreams(parent context.Context) error {
 					if !putOrdered(ctx, s.ordered, event) {
 						return ctx.Err()
 					}
+				}
+				select {
+				case healthy <- struct{}{}:
+				default:
 				}
 				return nil
 			})

--- a/internal/tui/session/session_test.go
+++ b/internal/tui/session/session_test.go
@@ -81,6 +81,140 @@ func TestSession_ReportsReconnectBeforeConnected(t *testing.T) {
 	waitForEvent(t, events, EventConnected)
 }
 
+func TestSession_SnapshotFailureDoesNotReportDaemonReconnect(t *testing.T) {
+	fake := newFakeClient()
+	fake.status = protocol.Status{Schema: "mihari/v1", Capabilities: []string{protocol.CapabilityCore}}
+	fake.failNextCore()
+	session := New(fake, Options{Backoff: func(int) time.Duration { return 0 }, PollInterval: 20 * time.Millisecond})
+	events := session.Start(context.Background())
+	defer session.Close()
+
+	deadline := time.After(3 * time.Second)
+	connected := false
+	for {
+		select {
+		case event, open := <-events:
+			if !open {
+				t.Fatal("events closed before snapshot recovery")
+			}
+			if event.Kind == EventReconnecting {
+				t.Fatalf("snapshot failure was promoted to daemon reconnect: %v", event.Err)
+			}
+			if event.Kind == EventConnected {
+				connected = true
+			}
+			if connected && event.Kind == EventCore {
+				return
+			}
+		case <-deadline:
+			t.Fatal("core snapshot was not retried")
+		}
+	}
+}
+
+func TestSession_CoreRestartReconnectsStreamsWithoutDaemonReconnect(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		from string
+		to   string
+	}{
+		{name: "stable to alpha", from: "stable", to: "alpha"},
+		{name: "alpha to stable", from: "alpha", to: "stable"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fake := newFakeClient()
+			fake.emitOnReconnect = true
+			fake.status = protocol.Status{Schema: "mihari/v1", Capabilities: []string{protocol.CapabilityCore}}
+			fake.core = protocol.CoreStatus{Schema: "mihari/v1", Status: "running", Channel: test.from}
+			session := New(fake, Options{Backoff: func(int) time.Duration { return 0 }, PollInterval: 20 * time.Millisecond})
+			events := session.Start(context.Background())
+			defer session.Close()
+
+			initial := waitForEvent(t, events, EventCore)
+			if initial.Core.Channel != test.from {
+				t.Fatalf("initial channel=%q want %q", initial.Core.Channel, test.from)
+			}
+			waitForEvent(t, events, EventConnected)
+			waitForStreamStarts(t, fake.started, 4)
+
+			fake.setCoreChannel(test.to)
+			fake.failNextCore()
+			close(fake.streamBreak)
+
+			restarted := make(map[string]bool)
+			delivered := make(map[EventKind]bool)
+			observedTarget := false
+			deadline := time.After(3 * time.Second)
+			for len(restarted) < 4 || len(delivered) < 4 || !observedTarget {
+				select {
+				case event, open := <-events:
+					if !open {
+						t.Fatal("events closed while streams were reconnecting")
+					}
+					if event.Kind == EventReconnecting {
+						t.Fatalf("controller stream interruption was promoted to daemon reconnect: %v", event.Err)
+					}
+					if event.Kind == EventCore && event.Core.Channel == test.to {
+						observedTarget = true
+					}
+					switch event.Kind {
+					case EventTraffic, EventMemory, EventLog, EventConnections:
+						delivered[event.Kind] = true
+					}
+				case kind := <-fake.started:
+					if fake.streamCallCount(kind) >= 2 {
+						restarted[kind] = true
+					}
+				case <-deadline:
+					t.Fatalf("streams=%v delivered=%v target channel observed=%v calls=%v", restarted, delivered, observedTarget, fake.streamCallCounts())
+				}
+			}
+		})
+	}
+}
+
+func TestSession_StreamFailureReportsReconnectWhenDaemonStatusFails(t *testing.T) {
+	fake := newFakeClient()
+	session := New(fake, Options{Backoff: func(int) time.Duration { return 0 }, PollInterval: time.Hour})
+	events := session.Start(context.Background())
+	defer session.Close()
+	waitForEvent(t, events, EventConnected)
+	waitForStreamStarts(t, fake.started, 4)
+
+	fake.failNextStatus()
+	close(fake.streamBreak)
+	waitForEvent(t, events, EventReconnecting)
+}
+
+func TestSession_ConsecutiveStreamFailuresIncreaseBackoffUntilStreamDataRecovers(t *testing.T) {
+	fake := newFakeClient()
+	attempts := make(chan int, 4)
+	session := New(fake, Options{
+		Backoff: func(attempt int) time.Duration {
+			attempts <- attempt
+			return 0
+		},
+		PollInterval: 10 * time.Millisecond,
+	})
+	events := session.Start(context.Background())
+	defer session.Close()
+	waitForEvent(t, events, EventConnected)
+	waitForStreamStarts(t, fake.started, 4)
+
+	close(fake.streamBreak)
+	if attempt := waitForAttempt(t, attempts); attempt != 1 {
+		t.Fatalf("first stream retry attempt=%d want 1", attempt)
+	}
+	waitForStreamStarts(t, fake.started, 4)
+	statusCalls := fake.statusCallCount()
+	waitForStatusCallAfter(t, fake, statusCalls)
+
+	close(fake.secondStreamBreak)
+	if attempt := waitForAttempt(t, attempts); attempt != 2 {
+		t.Fatalf("second stream retry attempt=%d want 2", attempt)
+	}
+}
+
 func TestSession_LoadsCapabilitySnapshotsBeforeConnected(t *testing.T) {
 	fake := newFakeClient()
 	fake.status = protocol.Status{Schema: "mihari/v1", Capabilities: []string{
@@ -158,23 +292,70 @@ func waitForEvent(t *testing.T, events <-chan Event, want EventKind) Event {
 	}
 }
 
+func waitForAttempt(t *testing.T, attempts <-chan int) int {
+	t.Helper()
+	select {
+	case attempt := <-attempts:
+		return attempt
+	case <-time.After(3 * time.Second):
+		t.Fatal("stream retry did not request backoff")
+		return 0
+	}
+}
+
+func waitForStreamStarts(t *testing.T, started <-chan string, count int) {
+	t.Helper()
+	deadline := time.After(3 * time.Second)
+	for range count {
+		select {
+		case <-started:
+		case <-deadline:
+			t.Fatalf("received fewer than %d stream starts", count)
+		}
+	}
+}
+
+func waitForStatusCallAfter(t *testing.T, fake *fakeClient, previous int) {
+	t.Helper()
+	deadline := time.After(3 * time.Second)
+	for fake.statusCallCount() <= previous {
+		select {
+		case <-time.After(time.Millisecond):
+		case <-deadline:
+			t.Fatalf("status calls did not advance beyond %d", previous)
+		}
+	}
+}
+
 type fakeClient struct {
-	mu             sync.Mutex
-	statusFailures int
-	coreCalls      int
-	streamCalls    map[string]int
-	started        chan string
-	status         protocol.Status
-	preferences    protocol.TUIPreferences
+	mu                sync.Mutex
+	statusFailures    int
+	statusCalls       int
+	coreFailures      int
+	coreCalls         int
+	streamCalls       map[string]int
+	started           chan string
+	streamBreak       chan struct{}
+	secondStreamBreak chan struct{}
+	emitOnReconnect   bool
+	status            protocol.Status
+	core              protocol.CoreStatus
+	preferences       protocol.TUIPreferences
 }
 
 func newFakeClient() *fakeClient {
-	return &fakeClient{streamCalls: make(map[string]int), started: make(chan string, 16)}
+	return &fakeClient{
+		streamCalls:       make(map[string]int),
+		started:           make(chan string, 16),
+		streamBreak:       make(chan struct{}),
+		secondStreamBreak: make(chan struct{}),
+	}
 }
 
 func (f *fakeClient) Status(context.Context) (protocol.Status, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.statusCalls++
 	if f.statusFailures > 0 {
 		f.statusFailures--
 		return protocol.Status{}, errors.New("offline")
@@ -187,8 +368,15 @@ func (f *fakeClient) Status(context.Context) (protocol.Status, error) {
 
 func (f *fakeClient) Core(context.Context) (protocol.CoreStatus, error) {
 	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.coreCalls++
-	f.mu.Unlock()
+	if f.coreFailures > 0 {
+		f.coreFailures--
+		return protocol.CoreStatus{}, errors.New("mihomo controller unavailable")
+	}
+	if f.core.Schema != "" {
+		return f.core, nil
+	}
 	return protocol.CoreStatus{Schema: "mihari/v1", Status: "running"}, nil
 }
 
@@ -216,11 +404,36 @@ func (f *fakeClient) WebGUI(context.Context) (protocol.WebGUIStatus, error) {
 	return protocol.WebGUIStatus{Schema: "mihari/v1", GatewayAddr: "127.0.0.1:9191", GatewayHealth: "healthy"}, nil
 }
 
-func (f *fakeClient) Stream(ctx context.Context, kind string, _ func(protocol.StreamEvent) error) error {
+func (f *fakeClient) Stream(ctx context.Context, kind string, receive func(protocol.StreamEvent) error) error {
 	f.mu.Lock()
 	f.streamCalls[kind]++
+	call := f.streamCalls[kind]
+	streamBreak := f.streamBreak
+	secondStreamBreak := f.secondStreamBreak
+	emitOnReconnect := f.emitOnReconnect
 	f.mu.Unlock()
 	f.started <- kind
+	if call == 1 {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-streamBreak:
+			return errors.New("mihomo controller unavailable")
+		}
+	}
+	if call == 2 {
+		if emitOnReconnect {
+			if err := receive(protocol.StreamEvent{Schema: "mihari/v1", Stream: kind, Data: []byte("{}")}); err != nil {
+				return err
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-secondStreamBreak:
+			return errors.New("mihomo controller unavailable")
+		}
+	}
 	<-ctx.Done()
 	return ctx.Err()
 }
@@ -229,4 +442,38 @@ func (f *fakeClient) streamCallCount(kind string) int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.streamCalls[kind]
+}
+
+func (f *fakeClient) streamCallCounts() map[string]int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	counts := make(map[string]int, len(f.streamCalls))
+	for kind, count := range f.streamCalls {
+		counts[kind] = count
+	}
+	return counts
+}
+
+func (f *fakeClient) statusCallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.statusCalls
+}
+
+func (f *fakeClient) setCoreChannel(channel string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.core.Channel = channel
+}
+
+func (f *fakeClient) failNextStatus() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.statusFailures++
+}
+
+func (f *fakeClient) failNextCore() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.coreFailures++
 }


### PR DESCRIPTION
﻿## 变更内容

- 将 `GET /v1/status` 明确为 TUI session 的 daemon transport 健康边界
- mihomo 重启导致 traffic、memory、logs、connections 代理流中断时，保持 daemon Connected 并按退避重建全部 streams
- controller-backed snapshot 暂时失败时保留最后观测值，恢复后自动刷新，不再提升为 daemon-level reconnecting/stale
- 将 Core 只读刷新结果与 mutation 结果分离，避免成功的通道切换被临时 Core 查询错误覆盖成 Failed
- 仅在恢复后的 stream 成功投递数据后重置重试退避

## 类型

- [ ] feat: 新功能
- [x] fix: Bug 修复
- [ ] refactor: 重构
- [ ] docs: 文档
- [x] test: 测试
- [ ] chore: 构建/工具

## 检查清单

- [x] `go test ./...` 通过
- [x] `go test -race ./...` 通过
- [x] `go vet ./...` 通过
- [x] `gofmt -l cmd internal` 无输出
- [x] `golangci-lint v2.12.2 run ./...` 通过（0 issues）
- [x] Windows/Linux/macOS amd64/arm64 `CGO_ENABLED=0` 构建通过
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] 未修改 `internal/control/protocol`、CLI/JSON 契约、持久化格式或跨平台行为

## 测试覆盖

- stable → alpha 与 alpha → stable
- 四条 upstream streams 同时中断且 `/v1/status` 始终成功
- controller snapshot 暂时不可用时不产生 `EventReconnecting`
- 四条 streams 重建并实际投递 traffic、memory、logs、connections 事件
- mutation 保持 Pending，成功后保留 Done，并在 controller 恢复后显示目标通道
- 真正的 daemon Status/IPC 失败仍产生 reconnecting；既有 root TUI 测试继续验证 stale 与 mutation 禁用
- 连续 stream 失败维持指数退避，成功投递后才重置

## 相关 Issues

Fixes #61
