### PR TITLE
fix(tui): 固定状态栏上传下载槽宽

### DIFF
--- a/docs/superpowers/specs/2026-08-13-statusbar-fixed-rate-width-design.md
+++ b/docs/superpowers/specs/2026-08-13-statusbar-fixed-rate-width-design.md
@@ -1,0 +1,124 @@
+# TUI 顶部状态栏固定上传/下载槽宽设计
+
+日期：2026-08-13
+状态：已实施，待 Pull Request
+关联 issue：mihari-proxy/mihari#67
+目标分支：`fix/issue-67-statusbar-rate-width`
+
+## 1. 问题
+
+TUI 最上方状态栏 `RenderStatusBar`（`internal/tui/ui/statusbar.go`）用 `PriorityBar` 按实测宽度做优先级裁剪：宽度不够时按 版本(1) → 内存(2) → 订阅(3) → conn/速率(5) → Core(5) → Title(6) 丢字段。
+
+上传 / 下载速率当前是变宽字符串：
+
+| 模式 | 空闲 | 高峰 | 速率段宽度差 |
+|---|---|---|---|
+| Full | `↑0 B/s  ↓0 B/s`（14 列） | `↑999.9 MiB/s  ↓999.9 MiB/s`（26 列） | 12 列 |
+| Compact | `↑0/s ↓0/s`（9 列） | `↑999.9M/s ↓999.9T/s`（19 列） | 10 列 |
+
+临界宽度下，版本、内存、订阅会随流量反复出现或消失。
+
+Full 变宽来自 `FormatRate` / `formatIEC`：字节档用 `%d`（`0 B/s`…`1023 B/s`），更高档用 `%.1f`（`1.0 KiB/s`…`999.9 MiB/s`）。Compact 变宽来自 `formatCompactIEC`（`0`…`999.9M`）。
+
+## 2. 目标
+
+- 上传、下载各自占用固定列宽，数值在槽内右对齐，不随位数或单位切换改变占用宽度。
+- 同一终端宽度下，仅因速率从 `0 B/s` 涨到 `12.3 MiB/s` 不得改变状态栏可见字段数量，也不应让其余字段左右抖动。
+- Full 与 Compact 两种状态栏都要稳定。
+- 不改动 `FormatRate` / `FormatBytes` 的全局契约，不影响 overview、connections 表格和连接详情。
+
+## 3. 非目标
+
+- 不固定 `N conn` / `Nc`、内存、订阅用量（慢变量，不是本抖动源）。
+- 不改 overview / connections 表格 / 连接详情的速率渲染。
+- 不改 `PriorityBar` 丢段算法或优先级数字。
+- 不改控制协议、持久化、CLI。
+
+## 4. 方案比较
+
+### 4.1 采用：只在状态栏把 ↑ / ↓ 各自垫成固定槽宽
+
+用现成的 `PadCell(..., AlignRight)`，在 `RenderStatusBar` 的速率 segment 内垫齐。`FormatRate` / `formatCompactIEC` 本身不变。
+
+优点：改动局部，直接消掉 `PriorityBar` 的测量抖动。代价：空闲时速率段永久占满槽宽，部分终端会比现在更早丢掉版本/内存。这是稳定换出来的，可接受。
+
+### 4.2 不采用：改全局 `FormatRate`
+
+overview、connections 列、连接详情都会变。Connections 已有 `RenderTrafficSlot`，会重复或互相打架。
+
+### 4.3 不采用：只提高速率段优先级、永不丢弃
+
+字段数量可能稳一点，但左侧字段仍会被变宽的速率挤掉，抖动还在。
+
+## 5. 详细设计
+
+### 5.1 槽宽
+
+右对齐垫到本格式的最大常见宽度（覆盖到 `999.9 XiB/s` / `999.9T`）：
+
+| 模式 | 每个方向槽宽 | 依据 | 整段恒定宽 |
+|---|---|---|---|
+| Full | 11 | `999.9 MiB/s` | `↑`+11+`  `+`↓`+11 = 26 |
+| Compact | 6 | `999.9M`（`/s` 仍在槽外） | `↑`+6+`/s `+`↓`+6+`/s` = 19 |
+
+超出槽宽时走现有 `PadCell` 截断（`…`）。家用代理到不了 `1000 TiB/s`，可接受。
+
+右对齐后 `/s` 齐，数字往左长：
+
+```text
+↑     0 B/s  ↓     0 B/s
+↑  1.2 KiB/s  ↓ 12.3 MiB/s
+↑999.9 MiB/s  ↓999.9 MiB/s
+```
+
+Compact：
+
+```text
+↑     0/s ↓     0/s
+↑   1.2K/s ↓    84M/s
+↑999.9M/s ↓999.9M/s
+```
+
+### 5.2 实现
+
+只改 `internal/tui/ui/statusbar.go`：
+
+```go
+const (
+    statusRateWidth        = 11 // "999.9 MiB/s"
+    statusCompactRateWidth = 6  // "999.9M"
+)
+
+func statusRateLabel(value int64, compact bool) string {
+    if compact {
+        return PadCell(formatCompactIEC(value), statusCompactRateWidth, AlignRight)
+    }
+    return PadCell(FormatRate(value), statusRateWidth, AlignRight)
+}
+```
+
+速率 segment 改为：
+
+- Full：`fmt.Sprintf("↑%s  ↓%s", statusRateLabel(up, false), statusRateLabel(down, false))`
+- Compact：`fmt.Sprintf("↑%s/s ↓%s/s", statusRateLabel(up, true), statusRateLabel(down, true))`
+
+不改 `FormatRate`、`FormatBytes`、`PriorityBar`、connections 的 `RenderTrafficSlot`。
+
+### 5.3 对现有丢段金句的影响
+
+`TestStatusBar_SegmentDropTiers` 的速率段会变宽（例如 Full `↑3.0 MiB/s  ↓12.0 MiB/s` → `↑  3.0 MiB/s  ↓ 12.0 MiB/s`）。同一 `width` 可能少显示一档低优先级字段，丢弃顺序不变。实现时按新的恒定宽度重算金句。
+
+## 6. 测试策略
+
+行为变更采用 Red–Green–Refactor。测试加在 `internal/tui/ui/statusbar_test.go`。
+
+1. Full / Compact 下，`0` 与约 `12.3 MiB/s` 的速率段可见宽度相同。
+2. 选接近丢段阈值的宽度（Full 无 badge 约 88 列；Compact 带 badge 约 93 列）：空闲与高峰的可见字段集合相同。
+3. 更新 `TestStatusBar_SegmentDropTiers` 金句，使垫齐后的恒定宽度与丢段顺序一致。
+
+## 7. 验收标准
+
+- 同一终端宽度下，仅改变上传/下载速率不得改变可见字段集合。
+- Full 速率段恒为 26 列，Compact 速率段恒为 19 列（在字段未被丢掉时）。
+- `FormatRate` 既有单测与 connections / overview 渲染不受影响。
+- 不引入凭据、订阅 URL 或 controller 地址泄露。

--- a/internal/tui/testdata/compact/logs.golden
+++ b/internal/tui/testdata/compact/logs.golden
@@ -1,4 +1,4 @@
- Mihari  ·  ●  ·  0c  ·  ↑0/s ↓0/s  ·  0                        Offline 
+ Mihari  ·  ●  ·  0c  ·  ↑     0/s ↓     0/s  ·  0              Offline 
     1          ╭───Controls───────────────────────────────────────────╮ 
  Overview      │ Level: ALL  Wrap: ● Off  Pause: ● Off                │ 
     2 Proxies  │ / Search…                                            │ 

--- a/internal/tui/testdata/full/connections-detail.golden
+++ b/internal/tui/testdata/full/connections-detail.golden
@@ -1,4 +1,4 @@
- Mihari  ·  ●  ·  1 conn  ·  ↑0 B/s  ↓0 B/s  ·  0 B                                         Offline 
+ Mihari  ·  ●  ·  1 conn  ·  ↑      0 B/s  ↓      0 B/s  ·  0 B                             Offline 
     1 Overview   ╭───Controls─────────────────────────────────────────────────────────────────────╮ 
     2 Proxies    │ [Active 1 | Closed 0]  [Source IP: All]  [Columns]  [Pause]                    │ 
   › 3 Conns      │  / Search…                                                                     │ 

--- a/internal/tui/testdata/full/overview.golden
+++ b/internal/tui/testdata/full/overview.golden
@@ -1,4 +1,4 @@
- Mihari  ·  ● running  ·  v1.19.0  ·  Main  ·  0 conn  ·  ↑0 B/s  ↓0 B/s  ·  0 B            Offline 
+ Mihari  ·  ● running  ·  Main  ·  0 conn  ·  ↑      0 B/s  ↓      0 B/s  ·  0 B            Offline 
   › 1 Overview    ██████   ██████  ███  █████                           ███                         
     2 Proxies    ░░██████ ██████  ░░░  ░░███                           ░░░                          
     3 Conns       ░███░█████░███  ████  ░███████    ██████   ████████  ████                         

--- a/internal/tui/testdata/full/proxies.golden
+++ b/internal/tui/testdata/full/proxies.golden
@@ -1,4 +1,4 @@
- Mihari  ·  ●  ·  0 conn  ·  ↑0 B/s  ↓0 B/s  ·  0 B                                         Offline 
+ Mihari  ·  ●  ·  0 conn  ·  ↑      0 B/s  ↓      0 B/s  ·  0 B                             Offline 
     1 Overview   ╭───GLOBAL · SELECTOR · 2────────────────────────────────────────────────────────╮ 
   › 2 Proxies    │ › ▸  Now: node-a                                                               │ 
     3 Conns      ╰────────────────────────────────────────────────────────────────────────────────╯ 

--- a/internal/tui/testdata/states/stale.golden
+++ b/internal/tui/testdata/states/stale.golden
@@ -1,4 +1,4 @@
- Mihari  ·  ● running  ·  v1.19.0  ·  0 conn  ·  ↑0 B/s  ↓0 B/s  ·  0 B                Reconnecting 
+ Mihari  ·  ● running  ·  v1.19.0  ·  0 conn  ·  ↑      0 B/s  ↓      0 B/s  ·  0 B    Reconnecting 
   › 1 Overview    ██████   ██████  ███  █████                           ███                         
     2 Proxies    ░░██████ ██████  ░░░  ░░███                           ░░░                          
     3 Conns       ░███░█████░███  ████  ░███████    ██████   ████████  ████                         

--- a/internal/tui/testdata/states/unavailable-web-gui.golden
+++ b/internal/tui/testdata/states/unavailable-web-gui.golden
@@ -1,4 +1,4 @@
- Mihari  ·  ●  ·  0 conn  ·  ↑0 B/s  ↓0 B/s  ·  0 B                                         Offline 
+ Mihari  ·  ●  ·  0 conn  ·  ↑      0 B/s  ↓      0 B/s  ·  0 B                             Offline 
     1 Overview   ╭───Web GUI──────────────────────────────────────────────────────────────────────╮ 
     2 Proxies    │ Unavailable: Web GUI lifecycle is not available in this build.                 │ 
     3 Conns      ╰────────────────────────────────────────────────────────────────────────────────╯ 

--- a/internal/tui/ui/statusbar.go
+++ b/internal/tui/ui/statusbar.go
@@ -30,10 +30,12 @@ type StatusBarData struct {
 }
 
 const (
-	statusSep           = "  ·  "
-	statusCoreRunning   = "●"
-	statusCoreOffline   = "○"
-	statusCoreReconnect = "◌"
+	statusSep              = "  ·  "
+	statusCoreRunning      = "●"
+	statusCoreOffline      = "○"
+	statusCoreReconnect    = "◌"
+	statusRateWidth        = 11 // "999.9 MiB/s"
+	statusCompactRateWidth = 6  // "999.9M"
 )
 
 // RenderStatusBar builds the top status-shell bar (Full or Compact).
@@ -65,7 +67,7 @@ func RenderStatusBar(theme Theme, data StatusBarData, width int, compact bool) s
 		segments = append(segments,
 			PrioritySegment{Priority: 5, Render: func() string { return fmt.Sprintf("%dc", data.Connections) }},
 			PrioritySegment{Priority: 5, Render: func() string {
-				return fmt.Sprintf("↑%s/s ↓%s/s", formatCompactIEC(data.UploadRate), formatCompactIEC(data.DownloadRate))
+				return fmt.Sprintf("↑%s/s ↓%s/s", statusRateLabel(data.UploadRate, true), statusRateLabel(data.DownloadRate, true))
 			}},
 			PrioritySegment{Priority: 2, Render: func() string { return formatCompactIEC(data.MemoryInUse) }},
 		)
@@ -73,7 +75,7 @@ func RenderStatusBar(theme Theme, data StatusBarData, width int, compact bool) s
 		segments = append(segments,
 			PrioritySegment{Priority: 5, Render: func() string { return fmt.Sprintf("%d conn", data.Connections) }},
 			PrioritySegment{Priority: 5, Render: func() string {
-				return fmt.Sprintf("↑%s  ↓%s", FormatRate(data.UploadRate), FormatRate(data.DownloadRate))
+				return fmt.Sprintf("↑%s  ↓%s", statusRateLabel(data.UploadRate, false), statusRateLabel(data.DownloadRate, false))
 			}},
 			PrioritySegment{Priority: 2, Render: func() string { return FormatBytes(data.MemoryInUse) }},
 		)
@@ -164,6 +166,13 @@ func coreStatusGlyph(theme Theme, status string, stale bool) (string, lipgloss.S
 		style = ToneStyle(theme, ToneCaution)
 	}
 	return glyph, style
+}
+
+func statusRateLabel(value int64, compact bool) string {
+	if compact {
+		return PadCell(formatCompactIEC(value), statusCompactRateWidth, AlignRight)
+	}
+	return PadCell(FormatRate(value), statusRateWidth, AlignRight)
 }
 
 // formatCompactIEC renders a short IEC magnitude for compact status (e.g. 1.2M, 84M).

--- a/internal/tui/ui/statusbar_test.go
+++ b/internal/tui/ui/statusbar_test.go
@@ -159,15 +159,15 @@ func TestStatusBar_SegmentDropTiers(t *testing.T) {
 		rightStatus string
 		want        string // plain segment sequence in positional order
 	}{
-		// Budget 70: version/memory/subscription dropped, rates kept.
-		{"full-100-badge", 100, false, "Service running · Connected", "Mihari  ·  ● running  ·  3 conn  ·  ↑3.0 MiB/s  ↓12.0 MiB/s"},
+		// Budget 70: version/memory/subscription dropped, padded rates kept.
+		{"full-100-badge", 100, false, "Service running · Connected", "Mihari  ·  ● running  ·  3 conn  ·  ↑  3.0 MiB/s  ↓ 12.0 MiB/s"},
 		// Budget 98: only version and memory dropped.
-		{"full-100-nobadge", 100, false, "", "Mihari  ·  ● running  ·  Main · 9.0 GiB/100.0 GiB  ·  3 conn  ·  ↑3.0 MiB/s  ↓12.0 MiB/s"},
-		// Budget 64: subscription kept (compact), memory dropped.
-		{"compact-94-badge", 94, true, "Service running · Connected", "Mihari  ·  ● running  ·  Main · 9G/100G  ·  3c  ·  ↑3M/s ↓12M/s"},
-		// Budget 44: subscription dropped, rates kept.
-		{"compact-74-badge", 74, true, "Service running · Connected", "Mihari  ·  ● running  ·  3c  ·  ↑3M/s ↓12M/s"},
-		// Budget 40: rates dropped too.
+		{"full-100-nobadge", 100, false, "", "Mihari  ·  ● running  ·  Main · 9.0 GiB/100.0 GiB  ·  3 conn  ·  ↑  3.0 MiB/s  ↓ 12.0 MiB/s"},
+		// Budget 64: padded compact rates leave no room for subscription.
+		{"compact-94-badge", 94, true, "Service running · Connected", "Mihari  ·  ● running  ·  3c  ·  ↑    3M/s ↓   12M/s"},
+		// Budget 51: subscription dropped, padded rates kept.
+		{"compact-81-badge", 81, true, "Service running · Connected", "Mihari  ·  ● running  ·  3c  ·  ↑    3M/s ↓   12M/s"},
+		// Budget 42: rates dropped too.
 		{"compact-72-badge", 72, true, "Service running · Connected", "Mihari  ·  ● running  ·  3c"},
 	}
 	for _, tc := range cases {
@@ -180,6 +180,117 @@ func TestStatusBar_SegmentDropTiers(t *testing.T) {
 			left = strings.TrimSpace(left)
 			if left != tc.want {
 				t.Fatalf("width=%d compact=%v got:\n%q\nwant:\n%q", tc.width, tc.compact, left, tc.want)
+			}
+		})
+	}
+}
+
+func statusBarRateSegment(plain string) string {
+	start := strings.Index(plain, "↑")
+	if start < 0 {
+		return ""
+	}
+	rest := plain[start:]
+	if i := strings.Index(rest, "  ·  "); i >= 0 {
+		return rest[:i]
+	}
+	return strings.TrimRight(rest, " ")
+}
+
+func statusBarFieldSet(plain string, compact bool) string {
+	var parts []string
+	if strings.Contains(plain, AppName) {
+		parts = append(parts, "title")
+	}
+	if strings.Contains(plain, "running") {
+		parts = append(parts, "core")
+	}
+	if strings.Contains(plain, "v1.19.0") {
+		parts = append(parts, "version")
+	}
+	if strings.Contains(plain, "Main") {
+		parts = append(parts, "sub")
+	}
+	if compact {
+		if strings.Contains(plain, "3c") {
+			parts = append(parts, "conn")
+		}
+		if strings.Contains(plain, "256M") {
+			parts = append(parts, "mem")
+		}
+	} else {
+		if strings.Contains(plain, "3 conn") {
+			parts = append(parts, "conn")
+		}
+		if strings.Contains(plain, "256.0 MiB") {
+			parts = append(parts, "mem")
+		}
+	}
+	if strings.Contains(plain, "↑") {
+		parts = append(parts, "rate")
+	}
+	return strings.Join(parts, ",")
+}
+
+func TestStatusBar_RateSegmentWidthStable(t *testing.T) {
+	theme := DefaultTheme()
+	base := StatusBarData{
+		CoreStatus:          "running",
+		CoreVersion:         "v1.19.0",
+		Subscription:        "Main · 9.0 GiB/100.0 GiB",
+		SubscriptionCompact: "Main · 9G/100G",
+		Connections:         3,
+		MemoryInUse:         256 * 1024 * 1024,
+	}
+	const width = 160
+	idle := base
+	busy := base
+	busy.UploadRate = 12*1024*1024 + 300*1024
+	busy.DownloadRate = 12*1024*1024 + 300*1024
+	for _, compact := range []bool{false, true} {
+		idleSeg := statusBarRateSegment(stripANSI(RenderStatusBar(theme, idle, width, compact)))
+		busySeg := statusBarRateSegment(stripANSI(RenderStatusBar(theme, busy, width, compact)))
+		if idleSeg == "" || busySeg == "" {
+			t.Fatalf("compact=%v missing rate segment idle=%q busy=%q", compact, idleSeg, busySeg)
+		}
+		if got, want := lipgloss.Width(idleSeg), lipgloss.Width(busySeg); got != want {
+			t.Fatalf("compact=%v rate width idle=%d (%q) busy=%d (%q)", compact, got, idleSeg, want, busySeg)
+		}
+	}
+}
+
+func TestStatusBar_RateChangeDoesNotDropFields(t *testing.T) {
+	theme := DefaultTheme()
+	data := StatusBarData{
+		CoreStatus:          "running",
+		CoreVersion:         "v1.19.0",
+		Subscription:        "Main · 9.0 GiB/100.0 GiB",
+		SubscriptionCompact: "Main · 9G/100G",
+		Connections:         3,
+		MemoryInUse:         256 * 1024 * 1024,
+	}
+	cases := []struct {
+		name    string
+		width   int
+		compact bool
+		badge   string
+	}{
+		// Full no-badge budget 86: idle keeps subscription, busy 12 MiB/s drops it.
+		{"full-88-nobadge", 88, false, ""},
+		// Compact with badge budget 63: idle keeps subscription, busy 12 MiB/s drops it.
+		{"compact-93-badge", 93, true, "Service running · Connected"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			idle := data
+			idle.RightStatus = tc.badge
+			busy := idle
+			busy.UploadRate = 12 * 1024 * 1024
+			busy.DownloadRate = 12 * 1024 * 1024
+			idleSet := statusBarFieldSet(stripANSI(RenderStatusBar(theme, idle, tc.width, tc.compact)), tc.compact)
+			busySet := statusBarFieldSet(stripANSI(RenderStatusBar(theme, busy, tc.width, tc.compact)), tc.compact)
+			if idleSet != busySet {
+				t.Fatalf("field set changed with rate: idle=%s busy=%s", idleSet, busySet)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Fixes #67. TUI 顶部状态栏的 ↑/↓ 速率改为固定槽宽，避免流量数字变长时 `PriorityBar` 反复丢掉版本 / 内存 / 订阅。

- Full：每个方向 11 列（`999.9 MiB/s`），整段恒为 26 列
- Compact：每个方向 6 列（`999.9M`），整段恒为 19 列
- 只垫状态栏，不改全局 `FormatRate`

## Test plan

- [x] `go test ./internal/tui/ui`（含新增宽度稳定与字段集合测试）
- [x] `go test ./internal/tui`（已更新 golden）
- [x] `go test ./...`
- [x] `go test -race ./internal/tui/ui ./internal/tui`
- [x] `go vet ./...`
- [x] `gofmt -l .`

## Design

`docs/superpowers/specs/2026-08-13-statusbar-fixed-rate-width-design.md`