### PR TITLE
fix(update): self-update 后同步已安装 service 的二进制

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Specifically:
 - **Subscription profiles**: per-subscription independent caches, offline switching, per-profile refresh intervals, and validated atomic config generation with rollback.
 - **Web panels**: one-click install / update / activate / rollback for zashboard and MetaCubeXD, served behind a loopback Web gateway with its own access credential.
 - **System proxy & TUN**: cross-platform system proxy control and managed TUN, both daemon-owned and persisted.
-- **In-TUI Mihari updates**: the System page checks GitHub Releases on entry, shows `current · latest available` or `current · Up to date`, and—when Mihari was started with administrator/root privileges—replaces the binary and automatically enters the updated TUI.
+- **In-TUI Mihari updates**: the System page checks GitHub Releases on entry, shows `current · latest available` or `current · Up to date`, and—when Mihari was started with administrator/root privileges—replaces the binary, synchronizes and restarts an installed OS-service copy, verifies its daemon version, and automatically enters the updated TUI.
 - **Core channel**: the System page can switch the mihomo core between `stable` and `alpha`.
 
 A single CGO-free static binary (< 15 MB) contains everything, with built-in GitHub Releases self-update and local GeoIP resolution.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,7 +31,7 @@ Mihari 是一款全新的、独立的 [mihomo](https://github.com/MetaCubeX/miho
 - **订阅配置**:每个订阅独立缓存、离线切换、按配置独立的刷新间隔,以及经过校验的原子化配置生成与回滚。
 - **Web 面板**:一键安装 / 更新 / 激活 / 回滚 zashboard 与 MetaCubeXD,置于带独立访问凭据的回环 Web 网关之后。
 - **系统代理与 TUN**:跨平台的系统代理控制与托管 TUN,均由守护进程持有并持久化。
-- **TUI 内更新 Mihari**:System 页面进入时检查 GitHub Releases,显示 `当前版本 · 最新版本 available` 或 `当前版本 · Up to date`;以管理员/root 权限启动时可替换二进制并自动进入更新后的 TUI。
+- **TUI 内更新 Mihari**：System 页面进入时检查 GitHub Releases，显示 `当前版本 · 最新版本 available` 或 `当前版本 · Up to date`；以管理员/root 权限启动时可替换二进制、同步并重启已安装的系统服务副本、验证 daemon 版本，并自动进入更新后的 TUI。
 - **内核通道**:System 页面可在 mihomo 的 `stable` / `alpha` 通道之间切换。
 
 单个无 CGO 的静态二进制(< 15 MB)即包含全部功能,内置 GitHub Releases 自动更新与本地 GeoIP 解析。

--- a/cmd/mihari/main.go
+++ b/cmd/mihari/main.go
@@ -2,11 +2,9 @@ package main
 
 import (
 	"context"
-	"errors"
 	"os"
 	"os/signal"
 	"path/filepath"
-	"strings"
 
 	"github.com/mihari-proxy/mihari/internal/app"
 	"github.com/mihari-proxy/mihari/internal/buildinfo"
@@ -73,12 +71,8 @@ func main() {
 		}
 		return runDaemonBody(ctx)
 	}
-	selfUpdater := update.SelfUpdater{
-		AfterReplace: func(ctx context.Context, _ string) error {
-			// Best-effort restart when service is installed; ignore not-installed.
-			return restartServiceAfterReplace(serviceManager.Restart)
-		},
-	}
+	selfUpdateCompletion := app.NewSelfUpdateServiceCompletion(serviceManager, localClient)
+	selfUpdater := update.SelfUpdater{AfterReplace: selfUpdateCompletion.AfterReplace}
 	executable, executableError := os.Executable()
 	dependencies := cli.Dependencies{
 		StatusClient:       localClient,
@@ -113,18 +107,6 @@ func main() {
 		RunDaemon: runDaemon,
 	}
 	os.Exit(cli.Execute(ctx, os.Args[1:], os.Stdout, os.Stderr, dependencies))
-}
-
-func restartServiceAfterReplace(restart func() error) error {
-	err := restart()
-	if err == nil {
-		return nil
-	}
-	var api protocol.APIError
-	if errors.As(err, &api) && api.Code == protocol.CodeInvalidState && strings.Contains(strings.ToLower(api.Message), "not installed") {
-		return nil
-	}
-	return err
 }
 
 func tuiRelaunchArgs(binary string) []string {

--- a/cmd/mihari/main_test.go
+++ b/cmd/mihari/main_test.go
@@ -1,12 +1,9 @@
 package main
 
 import (
-	"errors"
 	"os"
 	"slices"
 	"testing"
-
-	"github.com/mihari-proxy/mihari/internal/control/protocol"
 )
 
 func TestTUIRelaunchArgsStartsDefaultTUI(t *testing.T) {
@@ -29,18 +26,5 @@ func TestInteractiveTerminal_RejectsRedirectedStreams(t *testing.T) {
 	t.Cleanup(func() { _ = output.Close() })
 	if isInteractiveTerminal(input, output) {
 		t.Fatal("regular files must not be treated as an interactive terminal")
-	}
-}
-
-func TestRestartServiceAfterReplaceIgnoresOnlyNotInstalled(t *testing.T) {
-	notInstalled := protocol.APIError{Code: protocol.CodeInvalidState, Message: "mihari service is not installed"}
-	if err := restartServiceAfterReplace(func() error { return notInstalled }); err != nil {
-		t.Fatalf("not-installed error=%v", err)
-	}
-
-	restartFailed := protocol.APIError{Code: protocol.CodeInvalidState, Message: "service failed to start in time"}
-	err := restartServiceAfterReplace(func() error { return restartFailed })
-	if !errors.As(err, &restartFailed) {
-		t.Fatalf("restart failure was suppressed: %v", err)
 	}
 }

--- a/internal/app/self_update.go
+++ b/internal/app/self_update.go
@@ -1,0 +1,95 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/mihari-proxy/mihari/internal/control/protocol"
+)
+
+const (
+	selfUpdateServiceTimeout = 15 * time.Second
+	selfUpdatePollInterval   = 100 * time.Millisecond
+)
+
+// InstalledServiceUpdater synchronizes and restarts an installed Mihari OS
+// service. The boolean result reports whether a service installation exists.
+type InstalledServiceUpdater interface {
+	UpdateInstalledBinary() (bool, error)
+}
+
+// DaemonVersionClient reads the daemon version through the local control API.
+type DaemonVersionClient interface {
+	Status(context.Context) (protocol.Status, error)
+}
+
+// SelfUpdateServiceCompletion coordinates the post-replacement service update
+// and verifies that the restarted daemon reports the new Mihari version.
+type SelfUpdateServiceCompletion struct {
+	service InstalledServiceUpdater
+	client  DaemonVersionClient
+	timeout time.Duration
+	wait    func(context.Context) error
+}
+
+// NewSelfUpdateServiceCompletion returns a post-replacement service coordinator.
+func NewSelfUpdateServiceCompletion(service InstalledServiceUpdater, client DaemonVersionClient) *SelfUpdateServiceCompletion {
+	return &SelfUpdateServiceCompletion{
+		service: service,
+		client:  client,
+		timeout: selfUpdateServiceTimeout,
+		wait: func(ctx context.Context) error {
+			timer := time.NewTimer(selfUpdatePollInterval)
+			defer timer.Stop()
+			select {
+			case <-timer.C:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+	}
+}
+
+// AfterReplace updates an installed service and waits until its daemon reports
+// version. A missing service is a successful no-op.
+func (c *SelfUpdateServiceCompletion) AfterReplace(ctx context.Context, version string) error {
+	installed, err := c.service.UpdateInstalledBinary()
+	if err != nil {
+		var apiError protocol.APIError
+		if errors.As(err, &apiError) {
+			return apiError
+		}
+		return protocol.APIError{
+			Code:    protocol.CodeInvalidState,
+			Message: "Mihari updated, but the installed service could not be synchronized",
+		}
+	}
+	if !installed {
+		return nil
+	}
+
+	verifyCtx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+	for {
+		status, statusErr := c.client.Status(verifyCtx)
+		if statusErr == nil && sameVersion(status.DaemonVersion, version) {
+			return nil
+		}
+		if err := c.wait(verifyCtx); err != nil {
+			return protocol.APIError{
+				Code:    protocol.CodeInvalidState,
+				Message: "Mihari updated and synchronized the installed service, but the daemon did not report version " + version,
+			}
+		}
+	}
+}
+
+func sameVersion(left, right string) bool {
+	normalize := func(value string) string {
+		return strings.TrimPrefix(strings.ToLower(strings.TrimSpace(value)), "v")
+	}
+	return normalize(left) == normalize(right)
+}

--- a/internal/app/self_update_test.go
+++ b/internal/app/self_update_test.go
@@ -1,0 +1,129 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/mihari-proxy/mihari/internal/control/protocol"
+)
+
+type fakeInstalledServiceUpdater struct {
+	installed bool
+	err       error
+	calls     int
+}
+
+func (f *fakeInstalledServiceUpdater) UpdateInstalledBinary() (bool, error) {
+	f.calls++
+	return f.installed, f.err
+}
+
+type statusResult struct {
+	status protocol.Status
+	err    error
+}
+
+type fakeDaemonVersionClient struct {
+	results []statusResult
+	calls   int
+}
+
+func (f *fakeDaemonVersionClient) Status(context.Context) (protocol.Status, error) {
+	index := f.calls
+	f.calls++
+	if index >= len(f.results) {
+		index = len(f.results) - 1
+	}
+	return f.results[index].status, f.results[index].err
+}
+
+func TestSelfUpdateServiceCompletionWaitsForNewDaemonVersion(t *testing.T) {
+	service := &fakeInstalledServiceUpdater{installed: true}
+	client := &fakeDaemonVersionClient{results: []statusResult{
+		{err: errors.New("daemon restarting")},
+		{status: protocol.Status{DaemonVersion: "v0.5.2"}},
+		{status: protocol.Status{DaemonVersion: "v0.6.0"}},
+	}}
+	completion := NewSelfUpdateServiceCompletion(service, client)
+
+	if err := completion.AfterReplace(context.Background(), "v0.6.0"); err != nil {
+		t.Fatal(err)
+	}
+	if service.calls != 1 || client.calls != 3 {
+		t.Fatalf("service calls=%d status calls=%d", service.calls, client.calls)
+	}
+}
+
+func TestSelfUpdateServiceCompletionSkipsVersionCheckWhenNotInstalled(t *testing.T) {
+	service := &fakeInstalledServiceUpdater{installed: false}
+	client := &fakeDaemonVersionClient{}
+	completion := NewSelfUpdateServiceCompletion(service, client)
+
+	if err := completion.AfterReplace(context.Background(), "v0.6.0"); err != nil {
+		t.Fatal(err)
+	}
+	if service.calls != 1 || client.calls != 0 {
+		t.Fatalf("service calls=%d status calls=%d", service.calls, client.calls)
+	}
+}
+
+func TestSelfUpdateServiceCompletionReturnsRedactedSyncWarning(t *testing.T) {
+	service := &fakeInstalledServiceUpdater{installed: true, err: errors.New(`copy C:\Users\secret\mihari.exe failed`)}
+	completion := NewSelfUpdateServiceCompletion(service, &fakeDaemonVersionClient{})
+
+	err := completion.AfterReplace(context.Background(), "v0.6.0")
+	var api protocol.APIError
+	if !errors.As(err, &api) {
+		t.Fatalf("err=%v", err)
+	}
+	if strings.Contains(api.Message, "secret") || strings.Contains(api.Message, `C:\Users`) {
+		t.Fatalf("unsafe message=%q", api.Message)
+	}
+}
+
+func TestSelfUpdateServiceCompletionPreservesSafeServiceWarning(t *testing.T) {
+	warning := protocol.APIError{
+		Code:    protocol.CodeDataFailure,
+		Message: "Mihari updated, but the installed service binary could not be synchronized",
+	}
+	service := &fakeInstalledServiceUpdater{installed: true, err: warning}
+	completion := NewSelfUpdateServiceCompletion(service, &fakeDaemonVersionClient{})
+
+	err := completion.AfterReplace(context.Background(), "v0.6.0")
+	var api protocol.APIError
+	if !errors.As(err, &api) || api.Code != warning.Code || api.Message != warning.Message {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestSelfUpdateServiceCompletionCancellationReportsUnverifiedVersion(t *testing.T) {
+	service := &fakeInstalledServiceUpdater{installed: true}
+	client := &fakeDaemonVersionClient{results: []statusResult{{status: protocol.Status{DaemonVersion: "v0.5.2"}}}}
+	completion := NewSelfUpdateServiceCompletion(service, client)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := completion.AfterReplace(ctx, "v0.6.0")
+	var api protocol.APIError
+	if !errors.As(err, &api) || api.Code != protocol.CodeInvalidState || !strings.Contains(api.Message, "v0.6.0") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestSelfUpdateServiceCompletionReportsVersionMismatch(t *testing.T) {
+	service := &fakeInstalledServiceUpdater{installed: true}
+	client := &fakeDaemonVersionClient{results: []statusResult{{status: protocol.Status{DaemonVersion: "v0.5.2"}}}}
+	completion := NewSelfUpdateServiceCompletion(service, client)
+	completion.wait = func(context.Context) error { return context.DeadlineExceeded }
+
+	err := completion.AfterReplace(context.Background(), "v0.6.0")
+	var api protocol.APIError
+	if !errors.As(err, &api) || api.Code != protocol.CodeInvalidState {
+		t.Fatalf("err=%v", err)
+	}
+	if !strings.Contains(api.Message, "v0.6.0") || strings.Contains(api.Message, "v0.5.2") {
+		t.Fatalf("message=%q", api.Message)
+	}
+}

--- a/internal/integration/self_update_service_test.go
+++ b/internal/integration/self_update_service_test.go
@@ -1,0 +1,124 @@
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/mihari-proxy/mihari/internal/app"
+	controlclient "github.com/mihari-proxy/mihari/internal/control/client"
+	"github.com/mihari-proxy/mihari/internal/control/protocol"
+	"github.com/mihari-proxy/mihari/internal/platform"
+	"github.com/mihari-proxy/mihari/internal/service"
+	"github.com/mihari-proxy/mihari/internal/update"
+)
+
+type selfUpdateServiceController struct {
+	status service.StatusKind
+	stops  int
+	starts int
+}
+
+func (*selfUpdateServiceController) Install() error   { return nil }
+func (*selfUpdateServiceController) Uninstall() error { return nil }
+func (c *selfUpdateServiceController) Start() error {
+	c.starts++
+	return nil
+}
+func (c *selfUpdateServiceController) Stop() error {
+	c.stops++
+	return nil
+}
+func (*selfUpdateServiceController) Restart() error { return nil }
+func (c *selfUpdateServiceController) Status() (service.StatusKind, error) {
+	return c.status, nil
+}
+func (*selfUpdateServiceController) Run() error { return nil }
+
+func TestSelfUpdateSynchronizesDifferentServiceBinaryAndVerifiesDaemonVersion(t *testing.T) {
+	installRoot := t.TempDir()
+	t.Setenv("MIHARI_INSTALL_ROOT", installRoot)
+	tuiBinary := filepath.Join(t.TempDir(), platform.InstalledBinaryName())
+	if err := os.WriteFile(tuiBinary, []byte("old-tui"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	serviceBinary, err := platform.AbsoluteInstalledBinaryPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(serviceBinary, []byte("old-service"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	controller := &selfUpdateServiceController{status: service.StatusRunning}
+	serviceManager := service.New(service.Options{
+		Executable: tuiBinary,
+		NewController: func(service.RunFunc, string, []string) (service.Controller, error) {
+			return controller, nil
+		},
+	})
+	statusRequests := 0
+	statusServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/status" {
+			http.NotFound(w, r)
+			return
+		}
+		statusRequests++
+		_ = json.NewEncoder(w).Encode(protocol.Status{DaemonVersion: "v9.9.9"})
+	}))
+	defer statusServer.Close()
+	completion := app.NewSelfUpdateServiceCompletion(
+		serviceManager,
+		controlclient.NewHTTP(statusServer.URL, "test-token", statusServer.Client()),
+	)
+
+	payload := []byte("new-mihari")
+	assetName := "mihari-" + runtime.GOOS + "-" + runtime.GOARCH
+	if runtime.GOOS == "windows" {
+		assetName += ".exe"
+	}
+	var releaseServer *httptest.Server
+	releaseServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/mihari-proxy/mihari/releases/latest":
+			_ = json.NewEncoder(w).Encode(update.Release{
+				TagName: "v9.9.9",
+				Assets:  []update.Asset{{Name: assetName, URL: releaseServer.URL + "/asset", Size: int64(len(payload))}},
+			})
+		case "/asset":
+			_, _ = w.Write(payload)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer releaseServer.Close()
+
+	updater := update.SelfUpdater{
+		HTTPClient:   releaseServer.Client(),
+		APIBase:      releaseServer.URL,
+		GOOS:         runtime.GOOS,
+		GOARCH:       runtime.GOARCH,
+		AfterReplace: completion.AfterReplace,
+	}
+	result, err := updater.Update(context.Background(), tuiBinary, "v1.0.0")
+	if err != nil || !result.Updated || result.Version != "v9.9.9" {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+	for name, path := range map[string]string{"TUI": tuiBinary, "service": serviceBinary} {
+		got, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatalf("read %s binary: %v", name, readErr)
+		}
+		if string(got) != string(payload) {
+			t.Fatalf("%s binary=%q want=%q", name, got, payload)
+		}
+	}
+	if controller.stops != 1 || controller.starts != 1 || statusRequests != 1 {
+		t.Fatalf("stops=%d starts=%d status requests=%d", controller.stops, controller.starts, statusRequests)
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -57,7 +57,8 @@ type Options struct {
 
 // Manager is the production entry for service control.
 type Manager struct {
-	opts Options
+	opts        Options
+	stageBinary func(string) (string, error)
 }
 
 // New returns a Manager with defaults.
@@ -68,7 +69,7 @@ func New(opts Options) *Manager {
 	if opts.NewController == nil {
 		opts.NewController = newKardianosController
 	}
-	return &Manager{opts: opts}
+	return &Manager{opts: opts, stageBinary: platform.StageInstalledBinary}
 }
 
 func (m *Manager) controller(run RunFunc) (Controller, error) {
@@ -95,7 +96,7 @@ func (m *Manager) stageServiceBinary() (string, error) {
 			return "", protocol.APIError{Code: protocol.CodeInternal, Message: "resolve mihari executable path"}
 		}
 	}
-	dest, err := platform.StageInstalledBinary(src)
+	dest, err := m.stageBinary(src)
 	if err != nil {
 		return "", protocol.APIError{
 			Code:    protocol.CodeDataFailure,
@@ -104,6 +105,48 @@ func (m *Manager) stageServiceBinary() (string, error) {
 		}
 	}
 	return dest, nil
+}
+
+// UpdateInstalledBinary synchronizes the current executable into the machine
+// install directory and restarts an existing OS service from that copy. It
+// reports whether a service installation was found. A missing service is a
+// successful no-op.
+func (m *Manager) UpdateInstalledBinary() (bool, error) {
+	status, err := m.Status()
+	if err != nil {
+		return false, protocol.APIError{
+			Code:    protocol.CodeInvalidState,
+			Message: "Mihari updated, but the installed service status could not be determined",
+		}
+	}
+	if status == StatusNotInstalled {
+		return false, nil
+	}
+	if err := m.Stop(); err != nil && !isIgnorableStopError(err) {
+		return true, protocol.APIError{
+			Code:    protocol.CodeInvalidState,
+			Message: "Mihari updated, but the installed service could not be stopped",
+		}
+	}
+	if _, err := m.stageServiceBinary(); err != nil {
+		if restartErr := m.Start(); restartErr != nil {
+			return true, protocol.APIError{
+				Code:    protocol.CodeInvalidState,
+				Message: "Mihari updated, but service synchronization failed and the previous service could not be restarted",
+			}
+		}
+		return true, protocol.APIError{
+			Code:    protocol.CodeDataFailure,
+			Message: "Mihari updated, but the installed service binary could not be synchronized",
+		}
+	}
+	if err := m.Start(); err != nil {
+		return true, protocol.APIError{
+			Code:    protocol.CodeInvalidState,
+			Message: "Mihari updated and synchronized the installed service binary, but the service could not be restarted",
+		}
+	}
+	return true, nil
 }
 
 // Install copies mihari into the machine install directory, then registers the

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -21,30 +21,53 @@ type fakeController struct {
 	status     StatusKind
 	statusErr  error
 	controlErr error
+	startErr   error
+	stopErr    error
+	events     *[]string
+}
+
+func (f *fakeController) record(event string) {
+	if f.events != nil {
+		*f.events = append(*f.events, event)
+	}
 }
 
 func (f *fakeController) Install() error {
+	f.record("install")
 	f.installs++
 	return f.controlErr
 }
 func (f *fakeController) Uninstall() error {
+	f.record("uninstall")
 	f.uninstalls++
 	return f.controlErr
 }
 func (f *fakeController) Start() error {
+	f.record("start")
 	f.starts++
+	if f.startErr != nil {
+		return f.startErr
+	}
 	return f.controlErr
 }
 func (f *fakeController) Stop() error {
+	f.record("stop")
 	f.stops++
+	if f.stopErr != nil {
+		return f.stopErr
+	}
 	return f.controlErr
 }
 func (f *fakeController) Restart() error {
+	f.record("restart")
 	f.restarts++
 	return f.controlErr
 }
-func (f *fakeController) Status() (StatusKind, error) { return f.status, f.statusErr }
-func (f *fakeController) Run() error                  { return nil }
+func (f *fakeController) Status() (StatusKind, error) {
+	f.record("status")
+	return f.status, f.statusErr
+}
+func (f *fakeController) Run() error { return nil }
 
 func writeTempBinary(t *testing.T, dir, name string) string {
 	t.Helper()
@@ -103,6 +126,254 @@ func TestManagerInstallStartStopStatus(t *testing.T) {
 	}
 	if fake.stops != 2 {
 		t.Fatalf("uninstall should stop first: stops=%d", fake.stops)
+	}
+}
+
+func TestManagerUpdateInstalledBinaryCopiesBeforeRestart(t *testing.T) {
+	installRoot := t.TempDir()
+	t.Setenv("MIHARI_INSTALL_ROOT", installRoot)
+	source := writeTempBinary(t, t.TempDir(), "mihari-new")
+	installed, err := platform.AbsoluteInstalledBinaryPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(installed, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	events := []string{}
+	fake := &fakeController{status: StatusRunning, events: &events}
+	manager := New(Options{
+		Executable: source,
+		NewController: func(RunFunc, string, []string) (Controller, error) {
+			return fake, nil
+		},
+	})
+	manager.stageBinary = func(path string) (string, error) {
+		events = append(events, "sync")
+		return platform.StageInstalledBinary(path)
+	}
+
+	updated, err := manager.UpdateInstalledBinary()
+	if err != nil || !updated {
+		t.Fatalf("updated=%v err=%v", updated, err)
+	}
+	if got, want := strings.Join(events, ","), "status,stop,sync,start"; got != want {
+		t.Fatalf("events=%q want=%q", got, want)
+	}
+	payload, err := os.ReadFile(installed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(payload), "payload"; got != want {
+		t.Fatalf("installed payload=%q want=%q", got, want)
+	}
+}
+
+func TestManagerUpdateInstalledBinarySkipsMissingService(t *testing.T) {
+	t.Setenv("MIHARI_INSTALL_ROOT", t.TempDir())
+	events := []string{}
+	fake := &fakeController{status: StatusNotInstalled, events: &events}
+	manager := New(Options{
+		Executable: writeTempBinary(t, t.TempDir(), "mihari-new"),
+		NewController: func(RunFunc, string, []string) (Controller, error) {
+			return fake, nil
+		},
+	})
+	manager.stageBinary = func(string) (string, error) {
+		events = append(events, "sync")
+		return "", nil
+	}
+
+	updated, err := manager.UpdateInstalledBinary()
+	if err != nil || updated {
+		t.Fatalf("updated=%v err=%v", updated, err)
+	}
+	if got, want := strings.Join(events, ","), "status"; got != want {
+		t.Fatalf("events=%q want=%q", got, want)
+	}
+}
+
+func TestManagerUpdateInstalledBinaryStatusFailureIsRedacted(t *testing.T) {
+	events := []string{}
+	fake := &fakeController{
+		statusErr: errors.New(`query C:\Users\secret\mihari.exe: failed`),
+		events:    &events,
+	}
+	manager := New(Options{
+		Executable: "mihari-new",
+		NewController: func(RunFunc, string, []string) (Controller, error) {
+			return fake, nil
+		},
+	})
+
+	installed, err := manager.UpdateInstalledBinary()
+	if installed || err == nil {
+		t.Fatalf("installed=%v err=%v", installed, err)
+	}
+	var api protocol.APIError
+	if !errors.As(err, &api) || api.Code != protocol.CodeInvalidState {
+		t.Fatalf("err=%v", err)
+	}
+	if strings.Contains(api.Message, "secret") || strings.Contains(api.Message, `C:\Users`) {
+		t.Fatalf("unsafe message=%q", api.Message)
+	}
+	if got, want := strings.Join(events, ","), "status"; got != want {
+		t.Fatalf("events=%q want=%q", got, want)
+	}
+}
+
+func TestManagerUpdateInstalledBinarySamePathDoesNotCorruptBinary(t *testing.T) {
+	installRoot := t.TempDir()
+	t.Setenv("MIHARI_INSTALL_ROOT", installRoot)
+	installed, err := platform.AbsoluteInstalledBinaryPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(installed, []byte("new-version"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fake := &fakeController{status: StatusRunning}
+	manager := New(Options{
+		Executable: installed,
+		NewController: func(RunFunc, string, []string) (Controller, error) {
+			return fake, nil
+		},
+	})
+
+	updated, err := manager.UpdateInstalledBinary()
+	if err != nil || !updated {
+		t.Fatalf("updated=%v err=%v", updated, err)
+	}
+	payload, err := os.ReadFile(installed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(payload), "new-version"; got != want {
+		t.Fatalf("installed payload=%q want=%q", got, want)
+	}
+	if fake.stops != 1 || fake.starts != 1 {
+		t.Fatalf("stops=%d starts=%d", fake.stops, fake.starts)
+	}
+}
+
+func TestManagerUpdateInstalledBinarySyncFailureRestartsPreviousService(t *testing.T) {
+	raw := errors.New(`copy C:\Users\secret\mihari.exe: access denied`)
+	events := []string{}
+	fake := &fakeController{status: StatusRunning, events: &events}
+	manager := New(Options{
+		Executable: "mihari-new",
+		NewController: func(RunFunc, string, []string) (Controller, error) {
+			return fake, nil
+		},
+	})
+	manager.stageBinary = func(string) (string, error) {
+		events = append(events, "sync")
+		return "", raw
+	}
+
+	updated, err := manager.UpdateInstalledBinary()
+	if !updated || err == nil {
+		t.Fatalf("updated=%v err=%v", updated, err)
+	}
+	var api protocol.APIError
+	if !errors.As(err, &api) || api.Code != protocol.CodeDataFailure {
+		t.Fatalf("err=%v", err)
+	}
+	if strings.Contains(api.Message, "secret") || strings.Contains(api.Message, "access denied") {
+		t.Fatalf("unsafe message=%q", api.Message)
+	}
+	if got, want := strings.Join(events, ","), "status,stop,sync,start"; got != want {
+		t.Fatalf("events=%q want=%q", got, want)
+	}
+}
+
+func TestManagerUpdateInstalledBinaryStopFailureDoesNotTouchInstalledCopy(t *testing.T) {
+	raw := errors.New(`stop C:\Users\secret\mihari.exe: access denied`)
+	events := []string{}
+	fake := &fakeController{status: StatusRunning, stopErr: raw, events: &events}
+	manager := New(Options{
+		Executable: "mihari-new",
+		NewController: func(RunFunc, string, []string) (Controller, error) {
+			return fake, nil
+		},
+	})
+	manager.stageBinary = func(string) (string, error) {
+		events = append(events, "sync")
+		return "", nil
+	}
+
+	installed, err := manager.UpdateInstalledBinary()
+	if !installed || err == nil {
+		t.Fatalf("installed=%v err=%v", installed, err)
+	}
+	var api protocol.APIError
+	if !errors.As(err, &api) || api.Code != protocol.CodeInvalidState {
+		t.Fatalf("err=%v", err)
+	}
+	if strings.Contains(api.Message, "secret") || strings.Contains(api.Message, "access denied") {
+		t.Fatalf("unsafe message=%q", api.Message)
+	}
+	if got, want := strings.Join(events, ","), "status,stop"; got != want {
+		t.Fatalf("events=%q want=%q", got, want)
+	}
+}
+
+func TestManagerUpdateInstalledBinaryStartFailureReportsSynchronizedPartialSuccess(t *testing.T) {
+	raw := errors.New(`start C:\Users\secret\mihari.exe: timed out`)
+	events := []string{}
+	fake := &fakeController{status: StatusRunning, startErr: raw, events: &events}
+	manager := New(Options{
+		Executable: "mihari-new",
+		NewController: func(RunFunc, string, []string) (Controller, error) {
+			return fake, nil
+		},
+	})
+	manager.stageBinary = func(string) (string, error) {
+		events = append(events, "sync")
+		return "installed-mihari", nil
+	}
+
+	installed, err := manager.UpdateInstalledBinary()
+	if !installed || err == nil {
+		t.Fatalf("installed=%v err=%v", installed, err)
+	}
+	var api protocol.APIError
+	if !errors.As(err, &api) || api.Code != protocol.CodeInvalidState || !strings.Contains(api.Message, "synchronized") {
+		t.Fatalf("err=%v", err)
+	}
+	if strings.Contains(api.Message, "secret") || strings.Contains(api.Message, "timed out") {
+		t.Fatalf("unsafe message=%q", api.Message)
+	}
+	if got, want := strings.Join(events, ","), "status,stop,sync,start"; got != want {
+		t.Fatalf("events=%q want=%q", got, want)
+	}
+}
+
+func TestManagerUpdateInstalledBinarySyncAndRecoveryFailureReportsBoth(t *testing.T) {
+	events := []string{}
+	fake := &fakeController{status: StatusRunning, startErr: errors.New("recovery failed"), events: &events}
+	manager := New(Options{
+		Executable: "mihari-new",
+		NewController: func(RunFunc, string, []string) (Controller, error) {
+			return fake, nil
+		},
+	})
+	manager.stageBinary = func(string) (string, error) {
+		events = append(events, "sync")
+		return "", errors.New("sync failed")
+	}
+
+	installed, err := manager.UpdateInstalledBinary()
+	if !installed || err == nil {
+		t.Fatalf("installed=%v err=%v", installed, err)
+	}
+	var api protocol.APIError
+	if !errors.As(err, &api) || !strings.Contains(api.Message, "synchronization failed") || !strings.Contains(api.Message, "previous service") {
+		t.Fatalf("err=%v", err)
+	}
+	if got, want := strings.Join(events, ","), "status,stop,sync,start"; got != want {
+		t.Fatalf("events=%q want=%q", got, want)
 	}
 }
 

--- a/internal/tui/ui/strings.go
+++ b/internal/tui/ui/strings.go
@@ -293,7 +293,7 @@ const (
 	UnmanagedLabel               = "unmanaged"
 	UpdateCoreTitle              = "Update mihomo core"
 	UpdateMihariTitle            = "Update Mihari"
-	UpdateMihariImpact           = "The Mihari binary will be replaced, the installed service will be restarted, and this terminal will enter the updated TUI."
+	UpdateMihariImpact           = "The Mihari binary will be replaced, an installed service copy will be synchronized and restarted, its daemon version will be verified, and this terminal will enter the updated TUI."
 	UpdateMihariRollback         = "The current TUI stays open if replacement does not complete."
 	UpdateMihariUpToDate         = "Up to date"
 	UpdateMihariAvailable        = "available"


### PR DESCRIPTION
Closes #60

## 背景

Self-update 后前台 TUI 已运行新版本，但已安装的 OS service 仍可能从服务安装目录启动旧版 daemon，导致 TUI 与 daemon 版本不一致（实测 TUI `v0.5.2` / daemon `v0.4.0`，需手动 Reinstall service 才恢复）。

**根因**：`SelfUpdater.Update` 只替换当前 TUI 的 `os.Executable()`，`AfterReplace` 仅调用 `service.Restart()`；`Restart` 不同步服务安装目录的二进制，也不更新 ImagePath。TUI 路径与服务安装路径不同时 restart 仍启动旧副本。

## 改动

- **`internal/app/self_update.go`**（新增）：`SelfUpdateServiceCompletion` 作为 `AfterReplace` 回调。service 已安装时把当前可执行文件同步到安装目录再安全重启，并轮询 `daemon_version` 直至与新版本一致；未安装则 no-op。失败给脱敏的部分成功提示。
- **`internal/service/service.go`**：新增 `Manager.UpdateInstalledBinary()` 封装 `stop → stage → start` 流程，失败路径回滚并降级；`stageBinary` 改为可注入字段以便测试。
- **`cmd/mihari/main.go`**：装配 `SelfUpdateServiceCompletion` 作为 self-update 的 `AfterReplace`。

## 验收（对照 #60）

- [x] service 安装目录同步新版本
- [x] 重启后 `daemon_version` 与 TUI 一致（轮询 + `sameVersion` 归一化）
- [x] service 未安装 → no-op
- [x] 同路径不破坏性自复制（`TestManagerUpdateInstalledBinarySamePathDoesNotCorruptBinary`）
- [x] 失败给脱敏部分成功提示
- [x] 跨平台一致（kardianos 抽象）
- [x] 回归测试覆盖（service/app/integration）

## 本地验证

- `go build ./...` ✅
- `go test ./internal/service ./internal/app ./internal/update ./internal/integration` ✅
- `gofmt -l .` ✅
- `golangci-lint run` 0 issues ✅