### PR TITLE
fix: 收紧 panel 归档展开与 release 超时

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,29 @@ jobs:
             [ "$result" = "success" ] || { echo "unit matrix result: $result"; exit 1; }
           done
 
+  # Observe-only: never required, never in the test fan-in.
+  govulncheck:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+      - name: Observe govulncheck
+        run: |
+          set +e
+          go run golang.org/x/vuln/cmd/govulncheck@latest -version | tee -a "$GITHUB_STEP_SUMMARY"
+          go run golang.org/x/vuln/cmd/govulncheck@latest ./... | tee -a "$GITHUB_STEP_SUMMARY"
+          status=${PIPESTATUS[0]}
+          case "$status" in
+            0) result=clean ;;
+            3) result=vulns ;;
+            *) result=tool_error ;;
+          esac
+          echo "RESULT=$result" | tee -a "$GITHUB_STEP_SUMMARY"
+          exit 0
+
   race:
     runs-on: windows-latest
     steps:

--- a/docs/code-quality-audit-2026-08-13.md
+++ b/docs/code-quality-audit-2026-08-13.md
@@ -113,7 +113,7 @@
 
 **建议：** 在读取前累计 `UncompressedSize64`，同时在实际 copy 时累计真实写入量；设置总展开字节、最大 entry 数和可选目录深度上限，超限时删除整个 staging candidate。增加“许多合法小文件但总量超限”和伪造 size 元数据测试。
 
-**状态：** 仍开放。不在一期范围。
+**状态（2026-08-14）：** 本地整改完成。`ExtractZip` 增加总量 256 MiB、4096 entries、深度 16，声明与实际双累计；失败 `RemoveAll(destDir)`。
 
 ### AQ-03（中）：panel release 元数据的默认 HTTP client 没有超时
 
@@ -123,7 +123,7 @@
 
 **建议：** `release.Client` 缺省使用带明确 timeout 的私有 `http.Client`，或要求调用方显式注入；同时保持 request context 传播。增加一个阻塞 handler 的 deadline 回归测试。
 
-**状态：** 仍开放。不在一期范围。
+**状态（2026-08-14）：** 本地整改完成。`release.Client` 在 HTTPClient 为 nil 时使用 2 分钟私有 client，不再使用 `http.DefaultClient`。
 
 ### AQ-04（中）：CI 覆盖率命令可重复触发 CLI 测试失败
 

--- a/docs/superpowers/plans/2026-08-13-code-quality-phase-2.md
+++ b/docs/superpowers/plans/2026-08-13-code-quality-phase-2.md
@@ -1,0 +1,142 @@
+# Mihari 二期代码质量提升实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (or implement in-session with the same TDD + review gates).
+
+**Goal:** 关闭 AQ-02、AQ-03，并加入非阻断的 govulncheck 观察 job。
+
+**Architecture:** `ExtractZip` 委托不可变默认 limits 的 `extractZipWithLimits`；声明与实际双累计；`release.Client` nil client 使用 2 分钟私有 HTTP client。
+
+**Tech Stack:** Go 1.26.5、archive/zip、httptest、GitHub Actions、govulncheck via `go run`.
+
+**Spec:** `docs/superpowers/specs/2026-08-13-code-quality-phase-2-design.md`
+
+## Global Constraints
+
+- 非 `main` 分支与独立 worktree；不改 `/v1`、CLI/JSON、settings schema、`go.mod`。
+- 不启用 gosec/bodyclose/noctx/errorlint。
+- 不新增依赖。
+- Red–Green–Refactor；每个行为 Red 必须是断言失败。
+- 测试只用 `t.TempDir` / `httptest`；无公网。
+- 本目标授权 commit、push、PR、merge。
+- 每个 Task 独立 signed commit。
+
+---
+
+## Task 1：AQ-02 archive 总量/条目/深度
+
+**Files:**
+- Modify: `internal/panel/archive/zip.go`
+- Modify: `internal/panel/archive/zip_test.go`
+
+**Interfaces:**
+- 公共 `ExtractZip(archivePath, destDir string) error` 不变。
+- 私有 `extractLimits`、`defaultExtractLimits`（值，非可变 var hook）、`extractZipWithLimits`。
+- `extractFile` 返回 `(int64, error)`，written 来自 copy。
+
+### Step 1：写失败测试
+
+新增：
+
+- `TestExtractZipRejectsTooManyEntries`：`extractZipWithLimits` + `maxEntries: 2`，zip 含 3 个小文件（含 index.html）；断言 `errors.As` `CodeDataFailure`、消息 `panel archive has too many entries`、`os.IsNotExist(dest)`。
+- `TestExtractZipRejectsPathTooDeep`：17 层 `a/.../index.html`；公共 `ExtractZip`；消息 `panel archive path is too deep`；`IsNotExist`。
+- `TestExtractZipRejectsDeclaredTotalTooLarge`：helper 伪造 **至少 2 个文件** 各自 `UncompressedSize64 <= MaxExtractedFileSize` 但之和 > `maxTotal`（用 `CreateRaw` 或 CD patch）；断言 `"panel archive is too large"`、`IsNotExist`。
+- `TestExtractZipRejectsActualTotalTooLarge`：伪造偏小/0 的 header、实际 payload 超过测试 `maxTotal`；走 `extractZipWithLimits`；失败不得仅因声明之和（声明之和必须 < maxTotal）。
+
+```
+go test -count=1 -run '^TestExtractZipRejects' ./internal/panel/archive
+```
+
+Expected: 新用例断言失败（超时/过大/过深尚未实现），不是缺符号。可先加空 `extractZipWithLimits` 包装现有逻辑使测试编译。
+
+### Step 2：实现最小 Green
+
+按设计 §4.3 实现。深度用 `\`→`/`、`Clean`、`ToSlash`。失败 `RemoveAll(destDir)`。`len(reader.File) > maxEntries` 在 MkdirAll 前拒绝。
+
+```
+gofmt -w internal/panel/archive/zip.go internal/panel/archive/zip_test.go
+go test -count=1 ./internal/panel/archive
+```
+
+Expected: PASS，既有 traversal/symlink/index 不退化。
+
+### Step 3：提交
+
+```
+git add internal/panel/archive/zip.go internal/panel/archive/zip_test.go
+git commit -s -m "fix: 限制 panel 归档展开总量"
+```
+
+---
+
+## Task 2：AQ-03 默认 timeout
+
+**Files:**
+- Modify: `internal/panel/release/github.go`
+- Modify: `internal/panel/release/github_test.go`
+
+### Step 1：Red
+
+- `TestNilClientIsNotDefaultClient`：`Client{}.httpClient() != http.DefaultClient` 且 Timeout == 2m。
+- `TestClientLatestReleaseUsesNilClientPath`：`HTTPClient: nil` + httptest APIBase 成功取 release。
+- `TestClientLatestReleaseHonorsContextDeadline`：handler `<-r.Context().Done()`；150ms ctx；`CodeNetworkFailure`。
+
+```
+go test -count=1 -run '^Test(NilClient|ClientLatestRelease)' ./internal/panel/release
+```
+
+Expected: `TestNilClientIsNotDefaultClient` FAIL（当前返回 DefaultClient）。
+
+### Step 2：Green
+
+实现 `defaultHTTPClient` / `httpClient` 按设计。
+
+```
+gofmt -w internal/panel/release/github.go internal/panel/release/github_test.go
+go test -count=1 ./internal/panel/release
+```
+
+### Step 3：提交
+
+```
+git commit -s -m "fix: 为 panel release client 设置默认超时"
+```
+
+---
+
+## Task 3：govulncheck 观察 job + 文档
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+- Modify: `docs/code-quality-audit-2026-08-13.md`
+- Modify: `docs/superpowers/plans/2026-08-13-code-quality-roadmap.md`
+- Add already-written: `docs/superpowers/specs/2026-08-13-code-quality-phase-2-design.md`
+- Add: this plan
+
+### Step 1
+
+在 `ci.yml` 增加 job `govulncheck`：ubuntu、setup-go、job 级 `continue-on-error: true`、不加入 `test.needs`、打印版本、`go run golang.org/x/vuln/cmd/govulncheck@latest ./...`、summary 写 `RESULT=...`。
+
+审计/roadmap：AQ-02/AQ-03 标本地整改；Phase 2 状态 `实施中` 直到 CI 绿；linter 四行表（gosec/bodyclose/noctx/errorlint）均为不启用。
+
+### Step 2：结构检查
+
+确认 YAML 中 `govulncheck` 不在 `test.needs`；`continue-on-error` 在 job 级。
+
+### Step 3：提交
+
+```
+git commit -s -m "ci: 增加 govulncheck 观察任务"
+```
+
+（文档可同 commit 或随后 `docs: 记录二期质量整改`。）
+
+---
+
+## Task 4：验收、PR、merge
+
+```
+gofmt -l .
+go test -count=1 ./internal/panel/archive ./internal/panel/release ./internal/panel
+```
+
+Push `docs/code-quality-phase-2`，开 PR，等待 required checks，全绿后 `gh pr merge --merge`。

--- a/docs/superpowers/plans/2026-08-13-code-quality-roadmap.md
+++ b/docs/superpowers/plans/2026-08-13-code-quality-roadmap.md
@@ -55,7 +55,7 @@ Phase 1 是其他阶段的硬前置：测试与 coverage 信号不可信时，�
 | Phase | 主题 | 状态 | 详细计划 | 核心发现 |
 |---|---|---|---|---|
 | 1 | 发布风险与质量门禁 | 已验收 | [2026-08-13-code-quality-phase-1.md](2026-08-13-code-quality-phase-1.md) | AQ-01、AQ-04、AQ-05 |
-| 2 | 外部输入与网络安全 | 待一期验收后规划 | 一期完成后创建 `2026-08-13-code-quality-phase-2.md` | AQ-02、AQ-03 |
+| 2 | 外部输入与网络安全 | 实施中 | [2026-08-13-code-quality-phase-2.md](2026-08-13-code-quality-phase-2.md) | AQ-02、AQ-03 |
 | 3 | 运行时、平台与可观测性 | 待二期验收后规划 | 二期完成后创建 `2026-08-13-code-quality-phase-3.md` | 平台覆盖、后台错误回收 |
 | 4 | 可维护性与数据驱动治理 | 等待稳定基线与历史数据 | 三期完成且数据条件满足后创建 `2026-08-13-code-quality-phase-4.md` | 大文件、固定等待、性能与 coverage |
 
@@ -142,6 +142,15 @@ AQ-02、AQ-03 仍开放。一期状态列为 `已验收`，仅在本 closure com
 - 在不访问公网的测试中覆盖压缩炸弹、条目洪泛、伪造 size、阻塞 handler、deadline 和 staging 清理。
 - 引入 `govulncheck ./...` 的 CI 观察任务；先记录工具版本、数据库可用性和当前结果，再决定是否 required。
 - 以观察模式评估 `gosec`、`bodyclose`、`noctx`、`errorlint`；只把与 Mihari 边界相关且低误报的规则写入 `.golangci.yml`。
+
+### Linter 观察（2026-08-14，不启用）
+
+| 规则 | 命中 | 决策 |
+|---|---:|---|
+| bodyclose | 6 | 不启用；多为测试/已 defer Close |
+| noctx | 60 | 不启用；测试 httptest.NewRequest 噪声 |
+| errorlint | 8 | 不启用 |
+| gosec | n/a | 未纳入 golangci v2 本次 dry-run；不启用 |
 
 ### 非目标
 

--- a/docs/superpowers/specs/2026-08-13-code-quality-phase-2-design.md
+++ b/docs/superpowers/specs/2026-08-13-code-quality-phase-2-design.md
@@ -1,0 +1,214 @@
+# Mihari 二期代码质量提升设计
+
+Date: 2026-08-14  
+Status: Draft  
+Branch: `docs/code-quality-phase-2`  
+Baseline: `a603423` (Phase 1 merged as #73)  
+Roadmap: `docs/superpowers/plans/2026-08-13-code-quality-roadmap.md` §5  
+Audit: `docs/code-quality-audit-2026-08-13.md` AQ-02, AQ-03
+
+## 1. 背景与目标
+
+Phase 1 关闭了特权自更新摘要缺口并恢复了默认测试/coverage 信号。Phase 2 收紧不可信外部输入：panel ZIP 展开总量、条目数与目录深度，以及 panel release 元数据请求的默认 HTTP deadline。同时加入可观察、非阻断的 `govulncheck` CI job，并记录 linter 观察结果，但不批量启用高噪声规则。
+
+## 2. 范围与非目标
+
+### 2.1 范围
+
+1. AQ-02：`archive.ExtractZip` 在既有单文件/压缩包大小、路径穿越和 symlink 保护之外，增加总展开字节、最大 entry 数和目录深度上限；声明大小与实际写入量都要检查；超限时清理 destDir。
+2. AQ-03：`release.Client` 在未注入 HTTP client 时使用带 2 分钟 Timeout 的私有 client，并继续用 `NewRequestWithContext` 传播调用方 deadline。
+3. 确定性测试覆盖：多文件总量超限、伪造 UncompressedSize64、条目洪泛、过深路径、阻塞 metadata handler、默认 timeout。
+4. CI 增加非 required 的 `govulncheck` 观察 job。
+5. 记录 `bodyclose`/`noctx`/`errorlint` 观察命中；本阶段不把它们写入 required `.golangci.yml`（观察已显示 noctx 约 60 条、errorlint 8、bodyclose 6，批量启用会强迫无关重构）。
+
+### 2.2 非目标
+
+- 不更换 panel ZIP 格式或新增第三方归档库。
+- 不统一全仓 HTTP client。
+- 不因 linter 观察结果批量改测试或 Web gateway。
+- 默认单元测试不访问公网或真实 panel 上游。
+- 不改公开 CLI/JSON/`/v1`/settings schema/持久化/`go.mod`。
+
+## 3. 不可破坏约束
+
+- daemon 仍是持久化状态与 mihomo 生命周期的唯一写入者。
+- panel 安装仍走既有 staging → ExtractZip → promote；失败不留下可服务的 candidate。
+- 既有路径穿越、绝对路径、Windows drive、symlink、`index.html` 要求和单文件 64 MiB 限制不得退化。
+- 错误文本不得包含 URL 或凭据。
+- 发布构建保持 `CGO_ENABLED=0`。
+
+## 4. AQ-02：panel archive 总量与结构上限
+
+### 4.1 当前行为
+
+`internal/panel/archive/zip.go` 限制**单文件** 64 MiB，并拒绝不安全路径和 symlink。常量 `MaxZipSize = 128 MiB` 存在于 archive 包，但 `ExtractZip` 并不检查压缩包文件大小；128 MiB 上限实际由 `panel.Service.download` 的 `defaultMaxAssetBytes` 在下载阶段执行。遍历 entry 时不累计总展开字节、不限制 entry 数、不限制深度。`ExtractZip` 仅在缺少 `index.html` 时 `RemoveAll(destDir)`。`internal/panel/install.go` 在 ExtractZip 失败后也会 `RemoveAll(stagingDir)`。
+
+本阶段不在 `ExtractZip` 再加一遍压缩包文件 `Stat` 上限；下载路径已有 128 MiB，本地 `InstallFromZip` 的调用方须把 `destDir` 当作独占 extract root。
+
+### 4.2 常量
+
+保留：
+
+- `MaxZipSize = 128 << 20`
+- `MaxExtractedFileSize = 64 << 20`
+
+新增：
+
+- `MaxTotalExtractedBytes = 256 << 20`
+- `MaxArchiveEntries = 4096`（每个 zip header，含目录）
+- `MaxArchiveDepth = 16`（与 `SafeName`/`resolveTarget` 相同：`\`→`/`，`Clean`，`ToSlash`，跳过空与 `.` 后的组件数）
+
+### 4.3 检查顺序
+
+`zip.OpenReader` 之后、`MkdirAll` 之前：若 `len(reader.File) > limits.maxEntries` → `"panel archive has too many entries"`（中央目录已全部解析，此检查避免再创建 destDir）。
+
+对每个 `reader.File`，在打开内容之前：
+
+1. 既有 `SafeName` / symlink / `resolveTarget`。
+2. 计算 depth（斜杠归一化路径）；若 `depth > limits.maxDepth` → `dataFailure("panel archive path is too deep")`。
+3. 目录：`MkdirAll` 后继续（目录不计入实际写入字节）。
+4. 文件：若 `UncompressedSize64 > limits.maxFile` 保持既有 `"panel archive file is too large"`。
+5. `declaredTotal += UncompressedSize64`；若 `declaredTotal > limits.maxTotal` → `dataFailure("panel archive is too large")`。
+6. `extractFile` 改为返回 `(int64, error)`：用 `LimitReader(limits.maxFile+1)` 复制，返回 **copy 的 written**，不得用 header 冒充 written。
+7. `actualTotal += written`；若 `actualTotal > limits.maxTotal` → `dataFailure("panel archive is too large")`。
+
+伪造 metadata（声明很小或 0、实际很大）由 per-file LimitReader 与 `actualTotal` 捕获，不能只靠 `UncompressedSize64`。
+
+### 4.4 失败清理
+
+`destDir` 是调用方拥有的独占 extract root。`ExtractZip` 在成功 `MkdirAll(destDir)` 之后的任何错误路径调用 `os.RemoveAll(destDir)`，然后返回原错误。失败测试断言 `os.IsNotExist(destDir)`。调用方已有的 staging `RemoveAll` 保持不变。
+
+公开签名不变：`func ExtractZip(archivePath, destDir string) error`。
+
+私有入口（禁止包级可变 hook）：
+
+```go
+type extractLimits struct {
+	maxFile, maxTotal uint64
+	maxEntries, maxDepth int
+}
+
+var defaultExtractLimits = extractLimits{
+	maxFile: MaxExtractedFileSize, maxTotal: MaxTotalExtractedBytes,
+	maxEntries: MaxArchiveEntries, maxDepth: MaxArchiveDepth,
+}
+
+func ExtractZip(path, dest string) error {
+	return extractZipWithLimits(path, dest, defaultExtractLimits)
+}
+```
+
+`defaultExtractLimits` 是不可变值；测试不得改包级变量。需要更小总量的测试直接调用 `extractZipWithLimits`。条目洪泛优先用真实 `MaxArchiveEntries+1` 个极小 header；若过慢才对该用例使用更小 `maxEntries` 的 limits 值（仍走同一函数，不是全局 var）。
+
+### 4.5 测试
+
+合法成功路径与既有拒绝用例通过公共 `ExtractZip` + `t.TempDir`。`archive/zip.Writer.Create/CreateHeader` 会在 Close 时用实际字节覆盖 `UncompressedSize64`，因此不能用普通 Writer 伪造声明大小。需要伪造 header 的测试用同包 helper：`zip.Writer.CreateRaw` 或在 Writer.Close 后改写 central-directory 的 uncompressed-size 字段。
+
+- 既有 nested index / traversal / absolute / missing index / symlink 仍通过公共 `ExtractZip`。
+- `TestExtractZipRejectsTooManyEntries`：优先 `ExtractZip` + `MaxArchiveEntries+1` 个极小 entry；失败则 `os.IsNotExist(dest)`。
+- `TestExtractZipRejectsDeclaredTotalTooLarge`：伪造偏大 `UncompressedSize64`、实际 payload 很小；应在大量写入前以 `"panel archive is too large"` 失败。
+- `TestExtractZipRejectsActualTotalTooLarge`：伪造偏小或 0 的 `UncompressedSize64`、实际 stored payload 超过测试 `maxTotal`；必须调用 `extractZipWithLimits`（不是改包级 var）；断言失败来自 `actualTotal` 或 per-file LimitReader，而不是声明之和。
+- `TestExtractZipRejectsPathTooDeep`：17 层 `a/a/.../index.html`。
+- 每个新失败用例断言 `os.IsNotExist(destDir)`。
+- 合法 `dist/index.html` + 若干资产仍成功。
+
+## 5. AQ-03：release client 默认超时
+
+### 5.1 当前行为
+
+`Client.httpClient()` 在 `HTTPClient == nil` 时返回 `http.DefaultClient`。生产 `zashboard.New(nil, "")` / `metacubexd.New(nil, "")` 走这条路径。`getJSON` 已用 `NewRequestWithContext`，但无 client timeout 时，未设 deadline 的 context 会一直等。
+
+### 5.2 设计
+
+```go
+const defaultReleaseTimeout = 2 * time.Minute
+
+func defaultHTTPClient() *http.Client {
+	return &http.Client{Timeout: defaultReleaseTimeout}
+}
+
+func (c Client) httpClient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return defaultHTTPClient()
+}
+```
+
+注入的 `httptest` client 不受影响。更短的 context deadline 仍优先。
+
+签名不变。错误仍映射为 `CodeNetworkFailure` / `CodeDataFailure`，消息不含 URL。
+
+### 5.3 测试
+
+- `TestNilClientIsNotDefaultClient`：`Client{}.httpClient() != http.DefaultClient` 且 `Timeout == 2*time.Minute`。禁止只测 helper 而让 `httpClient()` 仍返回 DefaultClient。禁止修改 `http.DefaultClient.Timeout`。
+- `TestClientLatestReleaseUsesNilClientPath`：`Client{HTTPClient: nil, APIBase: server.URL}` + 短 context 调用 `LatestRelease`，证明 nil-client 生产路径被执行。
+- `TestClientLatestReleaseHonorsContextDeadline`：handler **阻塞在 `<-r.Context().Done()`**（禁止 `select{}`，以免 `Server.Close` 死锁）；短 deadline 返回 `CodeNetworkFailure`。
+- 既有 `LatestRelease` / `BranchTip` 成功测试保持注入 `server.Client()`。
+
+## 6. govulncheck 观察 job
+
+在 `.github/workflows/ci.yml` 增加 job `govulncheck`：
+
+- `runs-on: ubuntu-latest`
+- checkout + setup-go（go-version-file）
+- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`（不修改 `go.mod`）
+- **job 级** `continue-on-error: true`；不加入 `test` fan-in 的 `needs`
+- 先打印 `govulncheck -version`（或等价版本输出）
+- 根据退出码向 `$GITHUB_STEP_SUMMARY` 写一行 `RESULT=clean|vulns|unavailable|tool_error` 并附 stdout
+
+观察模式：发现漏洞、数据库不可用或工具失败都不得把 required `test`/`lint` 打红。
+
+## 7. Linter 观察（不启用）
+
+本机对当前树启用 `bodyclose`/`noctx`/`errorlint` 的 dry-run 约 74 issues（noctx 60、errorlint 8、bodyclose 6），多数在测试里的 `http.NewRequest` / `httptest.NewRequest`。`gosec` 不在本仓 golangci v2 默认插件集中作一次干净 dry-run；记录为“未启用 / 不进入门禁”。审计与 roadmap 更新包含四行评估表（规则、命中、真阳性判断、豁免、是否门禁），结论均为不启用。不改 `.golangci.yml` required 集合。
+
+## 8. Key Decisions
+
+| 决策 | 理由 |
+|---|---|
+| 总量 256 MiB / 4096 entries / 深度 16 | 覆盖真实 panel 资产，同时挡住 zip bomb；单文件与压缩包上限保持不变 |
+| 声明与实际双累计 | 审计明确要求伪造 size 不能逃逸 |
+| ExtractZip 失败即 RemoveAll destDir | 避免部分展开残留；与 install staging 清理一致 |
+| 私有 `extractZipWithLimits` + 不可变 default 值 | 避免包级可变 hook；公共 `ExtractZip` 只传默认 limits |
+| 默认 2 分钟私有 client | 与 panel 下载、self-update 一致，不用 DefaultClient |
+| govulncheck 观察且不进 fan-in | 供应链可见，但不把 DB/网络抖动变成 PR 阻断 |
+| 不启用 noctx/bodyclose/errorlint | dry-run 噪声高，违反 roadmap“不因工具告警批量重构” |
+
+## 9. Alternatives
+
+1. **只信 UncompressedSize64**：实现更简单，但伪造 header 可绕过。拒绝。
+2. **要求调用方必须注入 HTTP client**：把安全边界推给装配层，当前 `New(nil,"")` 会漏。拒绝。
+3. **把 govulncheck 设为 required**：在无 pin 数据库、无豁免流程时会误伤。本阶段观察即可。
+
+## 10. Security
+
+威胁：恶意或被替换的 panel ZIP、悬挂的 GitHub metadata 连接。缓解：总量/条目/深度、实际写入校验、失败清理、client timeout + context。不声称能抵抗被攻破的发布账户同时替换 ZIP 与上游。
+
+## 11. Testing matrix
+
+| 行为 | 入口 | 断言 |
+|---|---|---|
+| 总量声明超限 | `ExtractZip` 或 limits + 伪造偏大 header | `CodeDataFailure`，`IsNotExist(dest)` |
+| 总量实际超限 | `extractZipWithLimits` + 伪造偏小 header | 失败来自 actual/LimitReader |
+| 条目过多 | `ExtractZip` | `"too many entries"`，`IsNotExist(dest)` |
+| 路径过深 | `ExtractZip` | `"path is too deep"` |
+| 路径穿越/symlink | 既有测试 | 不退化 |
+| nil client 不是 DefaultClient | `Client{}.httpClient()` | `!= DefaultClient` 且 Timeout=2m |
+| nil client 走生产路径 | `LatestRelease` HTTPClient=nil | 成功或按短 ctx 网络失败 |
+| metadata 阻塞 | handler 等 `ctx.Done` | `CodeNetworkFailure` |
+| govulncheck | workflow YAML | job 级 continue-on-error，不在 test.needs，有 RESULT 行 |
+
+## 12. Rollout
+
+一个 PR：`docs/code-quality-phase-2` → `main`。本目标授权 commit、push、PR 和 merge。回滚即 revert 该 PR。
+
+### PR Plan
+
+1. **PR：fix: 收紧 panel 归档展开与 release 超时**
+   - Files: `internal/panel/archive/*`, `internal/panel/release/*`, `.github/workflows/ci.yml`, 审计/roadmap/本设计与实施计划
+   - 无依赖 PR
+
+## 13. Open Questions
+
+无。常量、错误文案、观察型 CI 与 linter 策略已由 roadmap 与本目标决定。

--- a/internal/panel/archive/zip.go
+++ b/internal/panel/archive/zip.go
@@ -17,7 +17,27 @@ const (
 	MaxZipSize = 128 << 20
 	// MaxExtractedFileSize bounds a single extracted file.
 	MaxExtractedFileSize = 64 << 20
+	// MaxTotalExtractedBytes bounds the sum of extracted file bytes.
+	MaxTotalExtractedBytes = 256 << 20
+	// MaxArchiveEntries bounds the number of zip headers, including directories.
+	MaxArchiveEntries = 4096
+	// MaxArchiveDepth bounds slash-separated components in an entry path.
+	MaxArchiveDepth = 16
 )
+
+type extractLimits struct {
+	maxFile    uint64
+	maxTotal   uint64
+	maxEntries int
+	maxDepth   int
+}
+
+var defaultExtractLimits = extractLimits{
+	maxFile:    MaxExtractedFileSize,
+	maxTotal:   MaxTotalExtractedBytes,
+	maxEntries: MaxArchiveEntries,
+	maxDepth:   MaxArchiveDepth,
+}
 
 // SafeName reports whether a zip entry name is relative and free of path traversal.
 func SafeName(name string) bool {
@@ -45,55 +65,94 @@ func SafeName(name string) bool {
 // ExtractZip extracts archivePath into destDir, rejecting unsafe paths, symlinks,
 // and archives that do not contain index.html anywhere under destDir.
 func ExtractZip(archivePath, destDir string) error {
+	return extractZipWithLimits(archivePath, destDir, defaultExtractLimits)
+}
+
+func extractZipWithLimits(archivePath, destDir string, limits extractLimits) error {
 	reader, err := zip.OpenReader(archivePath)
 	if err != nil {
 		return dataFailure("invalid panel archive")
 	}
 	defer reader.Close()
 
+	if limits.maxEntries > 0 && len(reader.File) > limits.maxEntries {
+		return dataFailure("panel archive has too many entries")
+	}
 	if err := os.MkdirAll(destDir, 0o700); err != nil {
 		return fmt.Errorf("create panel extract directory: %w", err)
 	}
 
 	var foundIndex bool
+	var declaredTotal, actualTotal uint64
+	fail := func(err error) error {
+		_ = os.RemoveAll(destDir)
+		return err
+	}
 	for _, file := range reader.File {
 		if !SafeName(file.Name) {
-			return dataFailure("unsafe path in panel archive")
+			return fail(dataFailure("unsafe path in panel archive"))
 		}
 		mode := file.Mode()
 		if mode&os.ModeSymlink != 0 {
-			return dataFailure("symlink in panel archive")
+			return fail(dataFailure("symlink in panel archive"))
 		}
 		// Some archives mark links via ModeType without ModeSymlink bit on all platforms.
 		if mode&os.ModeType == os.ModeSymlink {
-			return dataFailure("symlink in panel archive")
+			return fail(dataFailure("symlink in panel archive"))
+		}
+		if archivePathDepth(file.Name) > limits.maxDepth {
+			return fail(dataFailure("panel archive path is too deep"))
 		}
 
 		target, err := resolveTarget(destDir, file.Name)
 		if err != nil {
-			return err
+			return fail(err)
 		}
 		if file.FileInfo().IsDir() {
 			if err := os.MkdirAll(target, 0o700); err != nil {
-				return fmt.Errorf("create panel directory: %w", err)
+				return fail(fmt.Errorf("create panel directory: %w", err))
 			}
 			continue
 		}
 		if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
-			return fmt.Errorf("create panel parent directory: %w", err)
+			return fail(fmt.Errorf("create panel parent directory: %w", err))
 		}
-		if err := extractFile(file, target); err != nil {
-			return err
+		if file.UncompressedSize64 > limits.maxFile {
+			return fail(dataFailure("panel archive file is too large"))
 		}
+		if declaredTotal+file.UncompressedSize64 < declaredTotal || declaredTotal+file.UncompressedSize64 > limits.maxTotal {
+			return fail(dataFailure("panel archive is too large"))
+		}
+		declaredTotal += file.UncompressedSize64
+		written, err := extractFile(file, target, limits.maxFile)
+		if err != nil {
+			return fail(err)
+		}
+		if actualTotal+uint64(written) < actualTotal || actualTotal+uint64(written) > limits.maxTotal {
+			return fail(dataFailure("panel archive is too large"))
+		}
+		actualTotal += uint64(written)
 		if strings.EqualFold(filepath.Base(file.Name), "index.html") {
 			foundIndex = true
 		}
 	}
 	if !foundIndex {
-		_ = os.RemoveAll(destDir)
-		return dataFailure("panel archive is missing index.html")
+		return fail(dataFailure("panel archive is missing index.html"))
 	}
 	return nil
+}
+
+func archivePathDepth(name string) int {
+	forward := strings.ReplaceAll(name, "\\", "/")
+	cleaned := filepath.ToSlash(filepath.Clean(filepath.FromSlash(forward)))
+	depth := 0
+	for _, part := range strings.Split(cleaned, "/") {
+		if part == "" || part == "." {
+			continue
+		}
+		depth++
+	}
+	return depth
 }
 
 func resolveTarget(destDir, name string) (string, error) {
@@ -111,35 +170,32 @@ func resolveTarget(destDir, name string) (string, error) {
 	return target, nil
 }
 
-func extractFile(file *zip.File, target string) error {
-	if file.UncompressedSize64 > MaxExtractedFileSize {
-		return dataFailure("panel archive file is too large")
-	}
+func extractFile(file *zip.File, target string, maxFile uint64) (int64, error) {
 	source, err := file.Open()
 	if err != nil {
-		return dataFailure("open panel archive entry")
+		return 0, dataFailure("open panel archive entry")
 	}
 	defer source.Close()
 
 	destination, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
-		return fmt.Errorf("create panel file: %w", err)
+		return 0, fmt.Errorf("create panel file: %w", err)
 	}
-	written, copyErr := io.Copy(destination, io.LimitReader(source, MaxExtractedFileSize+1))
+	written, copyErr := io.Copy(destination, io.LimitReader(source, int64(maxFile)+1))
 	closeErr := destination.Close()
 	if copyErr != nil {
 		os.Remove(target)
-		return dataFailure("extract panel archive entry")
+		return written, dataFailure("extract panel archive entry")
 	}
-	if written > MaxExtractedFileSize {
+	if uint64(written) > maxFile {
 		os.Remove(target)
-		return dataFailure("panel archive file is too large")
+		return written, dataFailure("panel archive file is too large")
 	}
 	if closeErr != nil {
 		os.Remove(target)
-		return closeErr
+		return written, closeErr
 	}
-	return nil
+	return written, nil
 }
 
 func dataFailure(message string) error {

--- a/internal/panel/archive/zip_test.go
+++ b/internal/panel/archive/zip_test.go
@@ -3,10 +3,14 @@ package archive
 import (
 	"archive/zip"
 	"bytes"
+	"errors"
+	"hash/crc32"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/mihari-proxy/mihari/internal/control/protocol"
 )
 
 func TestExtractZipAcceptsNestedRootWithIndexHTML(t *testing.T) {
@@ -98,6 +102,115 @@ func TestExtractZipRejectsSymlinkEntries(t *testing.T) {
 	if err := ExtractZip(archivePath, dest); err == nil {
 		t.Fatal("expected symlink rejection")
 	}
+}
+
+func TestExtractZipRejectsTooManyEntries(t *testing.T) {
+	files := map[string]string{
+		"index.html": "<html>ok</html>",
+		"a.txt":      "a",
+		"b.txt":      "b",
+	}
+	archivePath := writeZip(t, files)
+	dest := filepath.Join(t.TempDir(), "out")
+	err := extractZipWithLimits(archivePath, dest, extractLimits{
+		maxFile: MaxExtractedFileSize, maxTotal: MaxTotalExtractedBytes, maxEntries: 2, maxDepth: MaxArchiveDepth,
+	})
+	assertExtractRejected(t, dest, err, "panel archive has too many entries")
+}
+
+func TestExtractZipRejectsPathTooDeep(t *testing.T) {
+	name := strings.Repeat("a/", MaxArchiveDepth) + "index.html"
+	archivePath := writeZip(t, map[string]string{name: "<html>ok</html>"})
+	dest := filepath.Join(t.TempDir(), "out")
+	err := ExtractZip(archivePath, dest)
+	assertExtractRejected(t, dest, err, "panel archive path is too deep")
+}
+
+func TestExtractZipRejectsDeclaredTotalTooLarge(t *testing.T) {
+	index := []byte("<html>ok</html>")
+	limits := extractLimits{maxFile: 200, maxTotal: 150, maxEntries: 16, maxDepth: MaxArchiveDepth}
+	archivePath := writeRawZip(t, []rawZipFile{
+		{Name: "index.html", Payload: index, Uncompressed: uint64(len(index))},
+		{Name: "big.txt", Payload: []byte("tiny"), Uncompressed: 200},
+	})
+	dest := filepath.Join(t.TempDir(), "out")
+	err := extractZipWithLimits(archivePath, dest, limits)
+	assertExtractRejected(t, dest, err, "panel archive is too large")
+}
+
+func TestExtractZipRejectsActualTotalTooLarge(t *testing.T) {
+	payload := bytes.Repeat([]byte("x"), 40)
+	limits := extractLimits{maxFile: 100, maxTotal: 50, maxEntries: 16, maxDepth: MaxArchiveDepth}
+	archivePath := writeZip(t, map[string]string{
+		"index.html": string(payload),
+		"more.txt":   string(payload),
+	})
+	dest := filepath.Join(t.TempDir(), "out")
+	err := extractZipWithLimits(archivePath, dest, limits)
+	assertExtractRejected(t, dest, err, "panel archive is too large")
+}
+
+func TestExtractFileReturnsCopiedBytes(t *testing.T) {
+	payload := []byte("copied-bytes")
+	archivePath := writeZip(t, map[string]string{"index.html": string(payload)})
+	reader, err := zip.OpenReader(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+	target := filepath.Join(t.TempDir(), "out.html")
+	written, err := extractFile(reader.File[0], target, MaxExtractedFileSize)
+	if err != nil || written != int64(len(payload)) {
+		t.Fatalf("written=%d err=%v", written, err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil || string(got) != string(payload) {
+		t.Fatalf("got=%q err=%v", got, err)
+	}
+}
+
+func assertExtractRejected(t *testing.T, dest string, err error, wantMsg string) {
+	t.Helper()
+	var api protocol.APIError
+	if !errors.As(err, &api) || api.Code != protocol.CodeDataFailure || api.Message != wantMsg {
+		t.Fatalf("err=%v want %q", err, wantMsg)
+	}
+	if _, statErr := os.Stat(dest); !os.IsNotExist(statErr) {
+		t.Fatalf("dest still exists: %v", statErr)
+	}
+}
+
+type rawZipFile struct {
+	Name         string
+	Payload      []byte
+	Uncompressed uint64
+}
+
+func writeRawZip(t *testing.T, files []rawZipFile) string {
+	t.Helper()
+	var buf bytes.Buffer
+	writer := zip.NewWriter(&buf)
+	for _, file := range files {
+		header := &zip.FileHeader{Name: file.Name, Method: zip.Store}
+		header.UncompressedSize64 = file.Uncompressed
+		header.CompressedSize64 = uint64(len(file.Payload))
+		header.CRC32 = crc32.ChecksumIEEE(file.Payload)
+		entry, err := writer.CreateRaw(header)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := entry.Write(file.Payload); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "raw.zip")
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }
 
 func TestSafeArchiveName(t *testing.T) {

--- a/internal/panel/release/github.go
+++ b/internal/panel/release/github.go
@@ -7,11 +7,15 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/mihari-proxy/mihari/internal/control/protocol"
 )
 
-const maxResponseSize = 2 << 20
+const (
+	maxResponseSize       = 2 << 20
+	defaultReleaseTimeout = 2 * time.Minute
+)
 
 // Asset is a GitHub release asset.
 type Asset struct {
@@ -40,11 +44,15 @@ type Client struct {
 	APIBase    string
 }
 
+func defaultHTTPClient() *http.Client {
+	return &http.Client{Timeout: defaultReleaseTimeout}
+}
+
 func (c Client) httpClient() *http.Client {
 	if c.HTTPClient != nil {
 		return c.HTTPClient
 	}
-	return http.DefaultClient
+	return defaultHTTPClient()
 }
 
 func (c Client) apiBase() string {

--- a/internal/panel/release/github_test.go
+++ b/internal/panel/release/github_test.go
@@ -3,9 +3,13 @@ package release
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
+
+	"github.com/mihari-proxy/mihari/internal/control/protocol"
 )
 
 func TestClientLatestRelease(t *testing.T) {
@@ -29,6 +33,45 @@ func TestClientBranchTip(t *testing.T) {
 	sha, err := (Client{HTTPClient: server.Client(), APIBase: server.URL}).BranchTip(context.Background(), "o", "r", "gh-pages")
 	if err != nil || sha != "abc123" {
 		t.Fatalf("sha=%q err=%v", sha, err)
+	}
+}
+
+func TestNilClientIsNotDefaultClient(t *testing.T) {
+	client := Client{}.httpClient()
+	if client == http.DefaultClient {
+		t.Fatal("nil HTTPClient must not use http.DefaultClient")
+	}
+	if client.Timeout != 2*time.Minute {
+		t.Fatalf("timeout=%s want 2m", client.Timeout)
+	}
+}
+
+func TestClientLatestReleaseUsesNilClientPath(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(Release{TagName: "v2", Assets: []Asset{{Name: "a.zip", URL: "u", Size: 1}}})
+	}))
+	defer server.Close()
+	rel, err := (Client{APIBase: server.URL}).LatestRelease(context.Background(), "o", "r")
+	if err != nil || rel.TagName != "v2" {
+		t.Fatalf("rel=%#v err=%v", rel, err)
+	}
+}
+
+func TestClientLatestReleaseHonorsContextDeadline(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, err := (Client{HTTPClient: server.Client(), APIBase: server.URL}).LatestRelease(ctx, "o", "r")
+	if time.Since(start) > time.Second {
+		t.Fatal("call hung")
+	}
+	var api protocol.APIError
+	if !errors.As(err, &api) || api.Code != protocol.CodeNetworkFailure {
+		t.Fatalf("err=%v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
Phase 2 of the code-quality roadmap:

- **AQ-02**: panel ZIP extract now caps total bytes, entry count, and path depth; declared and actual sizes are both checked; failures remove destDir.
- **AQ-03**: `release.Client` uses a private 2-minute HTTP client when none is injected.
- Observe-only `govulncheck` job (not in the `test` fan-in). No noisy linters enabled.

Public CLI/JSON/`/v1`/settings/`go.mod` unchanged.

## Test plan
- [x] `go test -count=1 ./internal/panel/archive ./internal/panel/release ./internal/panel`
- [ ] CI required jobs