### PR TITLE
test: 放宽 Windows AIO 并行下载冷启动超时

### DIFF
--- a/scripts/install/test_parallel_download.py
+++ b/scripts/install/test_parallel_download.py
@@ -16,6 +16,15 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 PAYLOAD = bytes(range(256)) * 8192
 
 
+def downloader_timeout(os_name=os.name):
+    # First powershell.exe + Add-Type + 4 runspaces on a cold windows-latest
+    # runner exceeded the previous 30s budget (CI run 31770214283). Later
+    # tests on the same job finished in 1-9s. Unix shells start quickly.
+    if os_name == "nt":
+        return 90
+    return 30
+
+
 class RangeServer(ThreadingHTTPServer):
     daemon_threads = True
 
@@ -122,6 +131,28 @@ class ParallelDownloadTests(unittest.TestCase):
         cls.server = RangeServer()
         cls.server_thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
         cls.server_thread.start()
+        cls.warmup_windows_downloader()
+
+    @classmethod
+    def warmup_windows_downloader(cls):
+        if os.name != "nt":
+            return
+        script = SCRIPT_DIR / "install-aio-remote.ps1"
+        command = (
+            "$ErrorActionPreference='Stop'; "
+            "$env:MIHARI_INSTALL_TEST_MODE='1'; "
+            f". ([scriptblock]::Create([IO.File]::ReadAllText('{script}'))); "
+            "Add-Type -AssemblyName System.Net.Http"
+        )
+        subprocess.run(
+            ["powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", command],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            errors="replace",
+            timeout=60,
+            check=False,
+        )
 
     @classmethod
     def tearDownClass(cls):
@@ -163,8 +194,12 @@ class ParallelDownloadTests(unittest.TestCase):
             stderr=subprocess.PIPE,
             text=True,
             errors="replace",
-            timeout=30,
+            timeout=downloader_timeout(),
         )
+
+    def test_windows_downloader_timeout_covers_cold_powershell_startup(self):
+        self.assertGreaterEqual(downloader_timeout("nt"), 90)
+        self.assertEqual(30, downloader_timeout("posix"))
 
     def assert_no_parts(self, destination):
         self.assertEqual([], glob.glob(str(destination) + ".parts-*"))


### PR DESCRIPTION
## 原因

main CI [run 31770214283](https://github.com/mihari-proxy/mihari/actions/runs/31770214283) 的 ``unit (windows-latest)`` 在 ``scripts/install/test_parallel_download.py`` 的第一个用例 ``test_content_range_header_name_is_case_insensitive`` 上以 ``subprocess.TimeoutExpired``（30s）失败。

同一 job 后续用例在 9s / 1s / 1s 内通过；两分钟前同一提交的 PR CI 也是绿的。本地该用例约 1s 通过。``CONTENT-RANGE`` 解析失败会立刻回退单流并在断言（4 个分段）处失败，不会卡满 30s。

根因是冷启动的 ``powershell.exe`` + ``Add-Type`` + 4 个 runspace 在 GitHub-hosted Windows runner 上会超过 30s 测试预算。

## 改动

- Windows 下载器子进程超时从 30s 提到 90s，并钉住该预算
- ``setUpClass`` 预热 ``powershell.exe`` 与 ``System.Net.Http``，把冷启动从第一个用例里挪走
- 不改生产安装脚本

## 验证

``python scripts/install/test_parallel_download.py -v`` → 7 tests, 0 failures, 2 skipped（Windows）