### PR TITLE
test(runtime): 修复 TestUpdatePanelDownloadsOutsideMutationLock 的 select 竞态

### DIFF
--- a/internal/runtime/panel_test.go
+++ b/internal/runtime/panel_test.go
@@ -339,6 +339,11 @@ func TestUpdatePanelDownloadsOutsideMutationLock(t *testing.T) {
 	updateEntered := make(chan struct{})
 	releaseUpdate := make(chan struct{})
 	activateEntered := make(chan struct{})
+	// The activate hook parks until the test observed activateEntered, so
+	// activateDone cannot become ready while the select below is choosing a
+	// case. Without the handshake, both channels could be ready at once and
+	// the select might report the nil result as a failure.
+	activateProceed := make(chan struct{})
 	panels := &fakePanels{
 		update: func(ctx context.Context, _ string) error {
 			close(updateEntered)
@@ -349,9 +354,14 @@ func TestUpdatePanelDownloadsOutsideMutationLock(t *testing.T) {
 				return ctx.Err()
 			}
 		},
-		activate: func(context.Context, string) error {
+		activate: func(ctx context.Context, _ string) error {
 			close(activateEntered)
-			return nil
+			select {
+			case <-activateProceed:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
 		},
 	}
 	manager := newTestManager(Options{Panels: panels})
@@ -373,6 +383,7 @@ func TestUpdatePanelDownloadsOutsideMutationLock(t *testing.T) {
 	}()
 	select {
 	case <-activateEntered:
+		close(activateProceed)
 	case err := <-activateDone:
 		close(releaseUpdate)
 		t.Fatalf("activate could not enter while update download was blocked: %v", err)


### PR DESCRIPTION
## 问题

Windows CI 偶发失败（PR #64 引入的测试）：

```text
panel_test.go:378: activate could not enter while update download was blocked: <nil>
```

## 根因

`activate` fake 为 `close(activateEntered); return nil`，两步之间无同步点。主测试 goroutine 稍一调度延迟，`select` 执行时 `activateEntered` 与 `activateDone` 双双 ready，Go 的 `select` 在多个 ready case 间伪随机选择，可能选中 `activateDone` 分支收到 `nil`，误报为「activate 未能进入」。

## 修复

在 `activate` fake 与主 `select` 之间加握手：

- fake 发出 `activateEntered` 信号后挂起在 `activateProceed`（同时监听 `ctx.Done()`，超时路径不泄漏 goroutine）
- 主 `select` 选中 `<-activateEntered` 后才 `close(activateProceed)` 放行 activate 返回

由此保证 select 决策期间 `activateDone` 必然未 ready，彻底消除双 ready 竞态；「activate 可在 update 下载阶段进入 mutation lock」的互斥语义验证保持不变（3s 超时 Fatal 分支保留）。

## 验证

- [x] Windows 本机 `go test -count=100 -run '^TestUpdatePanelDownloadsOutsideMutationLock$' ./internal/runtime`：100/100 通过
- [x] `go test -race ./internal/runtime`：干净
- [x] 全量 `go test ./...`：46 包全过
- [x] gofmt / golangci-lint：干净

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)