### PR TITLE
fix(tui): proxies 页切换节点失败时显示错误提示

### DIFF
--- a/docs/superpowers/plans/2026-08-14-proxies-select-error-feedback.md
+++ b/docs/superpowers/plans/2026-08-14-proxies-select-error-feedback.md
@@ -1,0 +1,306 @@
+# Proxies 页节点切换失败反馈 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** proxies 页切换节点失败时显示可见的红色错误提示，并让 `selectionResultMsg` 实现 shell 的 action-outcome 契约（#80）。
+
+**Architecture:** 纯 TUI 单页改动。`Model` 增加 `lastError`（rules 页同款模式）；`selectionResultMsg` 失败时设 `ui.ProxySelectFailed`、成功时清空；`buildContent` 首行以 `theme.Danger` 渲染错误；`selectFocused` 发起新选择前清旧错误。后端零改动。
+
+**Tech Stack:** Go + bubbletea v2 + lipgloss v2，标准 `go test`。
+
+**设计文档:** `docs/superpowers/specs/2026-08-14-proxies-select-error-feedback-design.md`
+
+**工作目录（worktree）:** `C:\Users\Kinema\Documents\modular_dev\mihari\.claude\worktrees\fix-proxies-select-silent-failure`
+
+**注意（memory 教训）:** worktree 内 gopls/codegraph 指向 main 旧版，不可信；验证只认 `go build` / `go test`。push 前必须过 gofmt + golangci-lint（CI 有独立检查）。
+
+---
+
+### Task 1: `selectionResultMsg` 实现 action-outcome 契约
+
+**Files:**
+- Modify: `internal/tui/pages/proxies/model.go:61-65`（`selectionResultMsg` 定义处）
+- Test: `internal/tui/pages/proxies/model_test.go`
+
+**Step 1: 写失败测试**
+
+在 `internal/tui/pages/proxies/model_test.go` 末尾（`stripProxyANSI` 之前或文件尾均可）追加：
+
+```go
+func TestSelectionResultMsg_ImplementsActionOutcomeContract(t *testing.T) {
+	boom := errors.New("boom")
+	if got := (selectionResultMsg{err: boom}).Err(); got != boom {
+		t.Fatalf("Err()=%v want boom", got)
+	}
+	if got := (selectionResultMsg{}).Err(); got != nil {
+		t.Fatalf("zero-value Err()=%v want nil", got)
+	}
+}
+```
+
+**Step 2: 跑测试确认失败**
+
+```bash
+cd "C:\Users\Kinema\Documents\modular_dev\mihari\.claude\worktrees\fix-proxies-select-silent-failure" && go test ./internal/tui/pages/proxies/ -run TestSelectionResultMsg_ImplementsActionOutcomeContract -v
+```
+
+预期：编译失败，`selectionResultMsg{...}.Err undefined (type proxies.selectionResultMsg has no field or method Err)`。
+
+**Step 3: 最小实现**
+
+`internal/tui/pages/proxies/model.go`，在 `selectionResultMsg` 定义后追加（照抄其他页的注释风格）：
+
+```go
+// Err implements the shell's action-outcome contract so proxy selections are
+// classified Succeeded/Failed in the Recent operations ledger.
+func (m selectionResultMsg) Err() error { return m.err }
+
+var _ interface{ Err() error } = selectionResultMsg{}
+```
+
+**Step 4: 跑测试确认通过**
+
+同 Step 2 命令。预期：PASS。
+
+**Step 5: Commit**
+
+```bash
+git add internal/tui/pages/proxies/model.go internal/tui/pages/proxies/model_test.go
+git commit -m "test(tui): proxies selectionResultMsg 实现 action-outcome 契约 (#80)"
+```
+
+---
+
+### Task 2: 失败时显示错误提示（Now 不变、pending 清除）
+
+**Files:**
+- Modify: `internal/tui/ui/strings.go:100`（`TimeoutLabel` 行后加常量）
+- Modify: `internal/tui/pages/proxies/model.go`（`Model` 字段、`selectionResultMsg` 分支、`buildContent`）
+- Test: `internal/tui/pages/proxies/model_test.go`（新测试 + `fakeClient` 加 `selectErr`）
+
+**Step 1: 扩展 fakeClient 并写失败测试**
+
+`internal/tui/pages/proxies/model_test.go` 的 `fakeClient` 结构体加 `selectErr error` 字段，`SelectProxy` 改为：
+
+```go
+type fakeClient struct {
+	selectedGroup string
+	selectedNode  string
+	operationID   string
+	selectErr     error
+	delay         uint16
+	delayErr      error
+	delayCalls    map[string]int
+}
+
+func (c *fakeClient) SelectProxy(_ context.Context, group string, request protocol.ProxySelectionRequest) (protocol.MutationResult, error) {
+	c.selectedGroup, c.selectedNode, c.operationID = group, request.Name, request.OperationID
+	if c.selectErr != nil {
+		return protocol.MutationResult{}, c.selectErr
+	}
+	return protocol.MutationResult{Schema: "mihari/v1", OperationID: request.OperationID}, nil
+}
+```
+
+追加测试：
+
+```go
+func TestModel_SelectProxyFailureShowsError(t *testing.T) {
+	client := &fakeClient{selectErr: errors.New("upstream down")}
+	model := New(client, func() string { return "op-1" })
+	model.SetSize(80, 24)
+	model.SetGroups(protocol.ProxyGroups{Groups: []protocol.ProxyGroup{{
+		Name: "GLOBAL", Now: "old", Nodes: []protocol.ProxyNode{{Name: "node-a", Type: "VLESS"}},
+	}}})
+	updateProxyKey(t, model, tea.KeyPressMsg{Code: tea.KeyEnter}) // 展开组
+	updateProxyKey(t, model, tea.KeyPressMsg{Code: tea.KeyDown})  // 焦点到节点
+	applyProxyCmd(t, model, updateProxyKey(t, model, tea.KeyPressMsg{Code: tea.KeyEnter}))
+
+	if model.groups[0].Now != "old" {
+		t.Fatalf("failed selection must not update Now, got %q", model.groups[0].Now)
+	}
+	if _, pending := model.pending[FocusID{Group: "GLOBAL", Node: "node-a"}]; pending {
+		t.Fatal("pending marker should clear after failure")
+	}
+	view := model.View()
+	if !strings.Contains(view, model.theme.Danger.Render(ui.ProxySelectFailed)) {
+		t.Fatalf("view missing failure feedback %q:\n%s", ui.ProxySelectFailed, view)
+	}
+}
+```
+
+**Step 2: 跑测试确认失败**
+
+```bash
+go test ./internal/tui/pages/proxies/ -run TestModel_SelectProxyFailureShowsError -v
+```
+
+预期：编译失败，`undefined: ui.ProxySelectFailed`。
+
+**Step 3: 最小实现（三处）**
+
+1. `internal/tui/ui/strings.go`，`TimeoutLabel = "Timeout"` 行后加（gofmt 会重排对齐）：
+
+```go
+	ProxySelectFailed        = "Proxy selection failed"
+```
+
+2. `internal/tui/pages/proxies/model.go` `Model` 结构体 `pending` 字段后加：
+
+```go
+	lastError      string
+```
+
+3. `Update` 的 `selectionResultMsg` 分支改为：
+
+```go
+	case selectionResultMsg:
+		delete(m.pending, FocusID{Group: typed.group, Node: typed.node})
+		if typed.err != nil {
+			m.lastError = ui.ProxySelectFailed
+			return m, nil
+		}
+		if index := m.groupIndex(typed.group); index >= 0 {
+			m.groups[index].Now = typed.node
+		}
+		return m, nil
+```
+
+4. `buildContent` 开头（`focusStart, focusEnd = -1, -1` 之后）插入：
+
+```go
+	if m.lastError != "" {
+		lines = append(lines, m.theme.Danger.Render(m.lastError))
+	}
+```
+
+**Step 4: 跑测试确认通过**
+
+同 Step 2 命令，另跑整包：`go test ./internal/tui/pages/proxies/ -v`。预期：全部 PASS。
+
+**Step 5: Commit**
+
+```bash
+git add internal/tui/ui/strings.go internal/tui/pages/proxies/model.go internal/tui/pages/proxies/model_test.go
+git commit -m "fix(tui): proxies 页切换节点失败时显示红色错误提示 (#80)"
+```
+
+---
+
+### Task 3: 成功结果与新选择发起时清除错误
+
+**Files:**
+- Modify: `internal/tui/pages/proxies/model.go`（成功分支清 `lastError`；`selectFocused` 开头清）
+- Test: `internal/tui/pages/proxies/model_test.go`
+
+**Step 1: 写失败测试**
+
+```go
+func TestModel_SelectProxySuccessClearsError(t *testing.T) {
+	client := &fakeClient{selectErr: errors.New("upstream down")}
+	model := New(client, func() string { return "op-1" })
+	model.SetSize(80, 24)
+	model.SetGroups(protocol.ProxyGroups{Groups: []protocol.ProxyGroup{{
+		Name: "GLOBAL", Now: "old", Nodes: []protocol.ProxyNode{{Name: "node-a", Type: "VLESS"}},
+	}}})
+	updateProxyKey(t, model, tea.KeyPressMsg{Code: tea.KeyEnter})
+	updateProxyKey(t, model, tea.KeyPressMsg{Code: tea.KeyDown})
+	applyProxyCmd(t, model, updateProxyKey(t, model, tea.KeyPressMsg{Code: tea.KeyEnter}))
+	if !strings.Contains(model.View(), ui.ProxySelectFailed) {
+		t.Fatal("failure feedback missing")
+	}
+
+	client.selectErr = nil
+	applyProxyCmd(t, model, updateProxyKey(t, model, tea.KeyPressMsg{Code: tea.KeyEnter}))
+	if strings.Contains(model.View(), ui.ProxySelectFailed) {
+		t.Fatal("stale failure feedback after success")
+	}
+	if model.groups[0].Now != "node-a" {
+		t.Fatalf("Now=%q want node-a", model.groups[0].Now)
+	}
+}
+
+func TestModel_NewSelectionClearsStaleError(t *testing.T) {
+	client := &fakeClient{selectErr: errors.New("upstream down")}
+	model := New(client, func() string { return "op-1" })
+	model.SetSize(80, 24)
+	model.SetGroups(protocol.ProxyGroups{Groups: []protocol.ProxyGroup{{
+		Name: "GLOBAL", Now: "old", Nodes: []protocol.ProxyNode{{Name: "node-a", Type: "VLESS"}},
+	}}})
+	updateProxyKey(t, model, tea.KeyPressMsg{Code: tea.KeyEnter})
+	updateProxyKey(t, model, tea.KeyPressMsg{Code: tea.KeyDown})
+	applyProxyCmd(t, model, updateProxyKey(t, model, tea.KeyPressMsg{Code: tea.KeyEnter}))
+	if !strings.Contains(model.View(), ui.ProxySelectFailed) {
+		t.Fatal("failure feedback missing")
+	}
+
+	command := updateProxyKey(t, model, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if command == nil {
+		t.Fatal("expected selection command")
+	}
+	if strings.Contains(model.View(), ui.ProxySelectFailed) {
+		t.Fatal("stale error must clear when a new selection starts")
+	}
+}
+```
+
+**Step 2: 跑测试确认失败**
+
+```bash
+go test ./internal/tui/pages/proxies/ -run 'TestModel_SelectProxySuccessClearsError|TestModel_NewSelectionClearsStaleError' -v
+```
+
+预期：两个测试均 FAIL——Task 2 的实现成功路径未清 `lastError`，`selectFocused` 也不清。
+
+**Step 3: 最小实现**
+
+1. `selectionResultMsg` 成功路径（`if typed.err != nil` 块之后、`groupIndex` 之前）加：
+
+```go
+		m.lastError = ""
+```
+
+2. `selectFocused()` 在 `m.pending[id] = true` 之前加：
+
+```go
+	m.lastError = ""
+```
+
+**Step 4: 跑测试确认通过**
+
+同 Step 2 命令 + 整包回归 `go test ./internal/tui/pages/proxies/`。预期：全部 PASS。
+
+**Step 5: Commit**
+
+```bash
+git add internal/tui/pages/proxies/model.go internal/tui/pages/proxies/model_test.go
+git commit -m "fix(tui): proxies 页成功切换或发起新选择时清除错误提示 (#80)"
+```
+
+---
+
+### Task 4: 全量预检（不产生 commit，除非有遗漏修正）
+
+**Step 1: 格式化检查**（CI 有 `test -z "$(gofmt -l .)"` 硬检查）
+
+```bash
+gofmt -l .
+```
+
+预期：无输出。若有输出 → `gofmt -w <files>` 后 amend/追加 commit。
+
+**Step 2: lint**（CI 独立 job，staticcheck；本地 v2.12.2 同 CI 版本）
+
+```bash
+golangci-lint run
+```
+
+预期：`0 issues.`
+
+**Step 3: 全量测试**
+
+```bash
+go test ./...
+```
+
+预期：全部 ok。随后 push、开 PR（关联 #80，`Fixes #80`）、盯 CI 全绿；merge 由用户执行（仓库 squash-only）。

--- a/docs/superpowers/specs/2026-08-14-proxies-select-error-feedback-design.md
+++ b/docs/superpowers/specs/2026-08-14-proxies-select-error-feedback-design.md
@@ -1,0 +1,65 @@
+# Proxies 页节点切换失败反馈设计
+
+日期：2026-08-14
+状态：已定稿，随 PR #80 修复实施
+目标 issue：[#80](https://github.com/mihari-proxy/mihari/issues/80)
+目标分支：`fix/proxies-select-silent-failure`
+
+## 1. 背景
+
+proxies 页切换节点是实时链路：`selectFocused()`（`internal/tui/pages/proxies/model.go:376`）→ control client `PUT /v1/proxy-groups/{name}` → control server `selectProxy` handler（`internal/control/server/runtime.go:184`）→ `Manager.SelectProxy`（`internal/runtime/manager.go:556`，doOperation 去重 + maintenance 锁 + revision 检查）→ mihomo `PUT /proxies/{group}`。
+
+后端每一层都有规范化的 `APIError` → HTTP 状态码映射（502/403/409/422，非 `APIError` 兜底 500），但 TUI 前端对失败完全静默——`selectionResultMsg` 处理（`model.go:133-140`）在 `err != nil` 时只清 pending 标记（"…" 变回空格），无任何错误文案。用户感知是"按了 enter 没反应"。
+
+这同时与项目自身模式不一致：其他所有页面的 mutation 结果消息（system / subscriptions / webgui / setup / rules / connections）都实现了 shell 的 action-outcome 契约（`Err() error`，`internal/tui/model.go:103`），`selectionResultMsg` 是唯一例外。
+
+## 2. 目标
+
+- 切换失败时页面给出可见的错误提示（Danger 色，页面内容首行）。
+- `selectionResultMsg` 实现 `Err() error` 契约，对齐其他页面的模式。
+- 成功路径行为不变：更新 `Now`，无错误的乐观更新（失败时 UI 与真实状态一致）。
+- 失败提示在下次操作开始时清除（成功结果、或再次发起选择）。
+
+## 3. 非目标
+
+- 不修 `delayResultMsg` 把一切错误伪装成 Timeout 的问题（#80 只登记选择路径；延迟测速错误区分另行处理）。
+- 不把选择动作迁移到 `ActionIntentMsg`/`executeAction` 全流程（ledger 可见性靠页面内提示解决；契约先行对齐，迁移属于更大重构）。
+- 不透出 APIError 动态 detail（与 rules 页静态文案模式一致，避免把上游错误原文直接渲染进 TUI）。
+- 不改 control server / runtime / mihomo client 任何后端代码。
+
+## 4. 方案
+
+全部改动收敛在 TUI proxies 页 + 一个文案常量：
+
+1. **`selectionResultMsg` 契约**：增加 value receiver 的 `Err() error` 与 `var _ interface{ Err() error } = selectionResultMsg{}` 断言，命名与注释风格照抄其他页（如 `mutationResultMsg`）。
+2. **错误状态**：`Model` 增加 `lastError string` 字段（rules 页同款模式）。
+3. **Update 分支**：`selectionResultMsg` 失败时 `m.lastError = ui.ProxySelectFailed`；成功时清空并更新 `Now`（现有逻辑）。
+4. **清除时机**：`selectFocused()` 在发起新选择前清 `m.lastError`——旧失败提示不跨越下一次尝试。
+5. **View 渲染**：`buildContent()` 开头插入一行 `m.theme.Danger.Render(m.lastError)`。操作失败属于 Negative 语义（`StatusTone` 注释：failed/error → Danger），比 rules 页数据缺失用的 Muted 更醒目。位置安全性：`buildContent` 内 focus 行号映射基于 `sectionBase := len(lines)` 动态计算，首行插入自动保持 `View()` 裁剪与 `ensureFocusVisible()` 一致，无需调整偏移。
+6. **文案常量**：`internal/tui/ui/strings.go` 增加 `ProxySelectFailed = "Proxy selection failed"`（proxies 组，`TimeoutLabel` 旁）。
+
+## 5. 用户界面
+
+失败时页面首行出现红色提示（其余布局不变）：
+
+```text
+Proxy selection failed
+╭─ GLOBAL · SELECTOR · 1 ─────────────────╮
+│ ▾  Now: old                              │
+│ ...                                      │
+╰──────────────────────────────────────────╯
+```
+
+## 6. 测试计划
+
+`internal/tui/pages/proxies/model_test.go`（复用现有 `fakeClient` / `updateProxyKey` / `applyProxyCmd`）：
+
+- 契约：`selectionResultMsg{}.Err()` 返回携带的 err；零值为 nil。
+- 失败：fake client 返回错误 → view 含 Danger 渲染的 `ui.ProxySelectFailed`；`groups[0].Now` 不变；pending 标记清除。
+- 成功清除：失败后再成功 → 提示消失、`Now` 更新。
+- 新发起清除：失败后再次 enter（结果未回）→ 提示立即消失。
+
+## 7. 风险
+
+- 改动仅触碰单页 UI 状态，无后端 / 协议变更；`buildContent` 首行插入对滚动与 focus 映射无影响（§4.5）。
+- CI 预检（memory 已记录）：gofmt 对齐新常量、golangci-lint 0 issues、`go test ./...` 全绿后才可 push。

--- a/internal/tui/pages/proxies/model.go
+++ b/internal/tui/pages/proxies/model.go
@@ -48,6 +48,7 @@ type Model struct {
 	focus          FocusID
 	delays         map[string]DelayState
 	pending        map[FocusID]bool
+	lastError      string
 	contentFocused bool
 	width          int
 	height         int
@@ -138,10 +139,12 @@ func (m *Model) Update(message tea.Msg) (ui.Page, tea.Cmd) {
 	switch typed := message.(type) {
 	case selectionResultMsg:
 		delete(m.pending, FocusID{Group: typed.group, Node: typed.node})
-		if typed.err == nil {
-			if index := m.groupIndex(typed.group); index >= 0 {
-				m.groups[index].Now = typed.node
-			}
+		if typed.err != nil {
+			m.lastError = ui.ProxySelectFailed
+			return m, nil
+		}
+		if index := m.groupIndex(typed.group); index >= 0 {
+			m.groups[index].Now = typed.node
 		}
 		return m, nil
 	case delayResultMsg:
@@ -226,6 +229,9 @@ func (m *Model) View() string {
 // a bordered section; expanded node cards sit inside the parent section body.
 func (m *Model) buildContent() (lines []string, focusStart, focusEnd int) {
 	focusStart, focusEnd = -1, -1
+	if m.lastError != "" {
+		lines = append(lines, m.theme.Danger.Render(m.lastError))
+	}
 	inner := ui.FullSectionInner(m.width)
 	textW := ui.SectionTextWidth(inner)
 	for _, group := range m.groups {

--- a/internal/tui/pages/proxies/model.go
+++ b/internal/tui/pages/proxies/model.go
@@ -64,6 +64,12 @@ type selectionResultMsg struct {
 	err   error
 }
 
+// Err implements the shell's action-outcome contract so proxy selections are
+// classified Succeeded/Failed in the Recent operations ledger.
+func (m selectionResultMsg) Err() error { return m.err }
+
+var _ interface{ Err() error } = selectionResultMsg{}
+
 type delayResultMsg struct {
 	node  string
 	delay uint16

--- a/internal/tui/pages/proxies/model.go
+++ b/internal/tui/pages/proxies/model.go
@@ -143,6 +143,7 @@ func (m *Model) Update(message tea.Msg) (ui.Page, tea.Cmd) {
 			m.lastError = ui.ProxySelectFailed
 			return m, nil
 		}
+		m.lastError = ""
 		if index := m.groupIndex(typed.group); index >= 0 {
 			m.groups[index].Now = typed.node
 		}
@@ -389,6 +390,7 @@ func (m *Model) selectFocused() tea.Cmd {
 	if m.client == nil || m.focus.Node == "" {
 		return nil
 	}
+	m.lastError = ""
 	id := m.focus
 	m.pending[id] = true
 	operationID := m.newOperationID()

--- a/internal/tui/pages/proxies/model_test.go
+++ b/internal/tui/pages/proxies/model_test.go
@@ -253,6 +253,7 @@ type fakeClient struct {
 	selectedGroup string
 	selectedNode  string
 	operationID   string
+	selectErr     error
 	delay         uint16
 	delayErr      error
 	delayCalls    map[string]int
@@ -260,6 +261,9 @@ type fakeClient struct {
 
 func (c *fakeClient) SelectProxy(_ context.Context, group string, request protocol.ProxySelectionRequest) (protocol.MutationResult, error) {
 	c.selectedGroup, c.selectedNode, c.operationID = group, request.Name, request.OperationID
+	if c.selectErr != nil {
+		return protocol.MutationResult{}, c.selectErr
+	}
 	return protocol.MutationResult{Schema: "mihari/v1", OperationID: request.OperationID}, nil
 }
 
@@ -281,6 +285,29 @@ func TestSelectionResultMsg_ImplementsActionOutcomeContract(t *testing.T) {
 	}
 	if got := (selectionResultMsg{}).Err(); got != nil {
 		t.Fatalf("zero-value Err()=%v want nil", got)
+	}
+}
+
+func TestModel_SelectProxyFailureShowsError(t *testing.T) {
+	client := &fakeClient{selectErr: errors.New("upstream down")}
+	model := New(client, func() string { return "op-1" })
+	model.SetSize(80, 24)
+	model.SetGroups(protocol.ProxyGroups{Groups: []protocol.ProxyGroup{{
+		Name: "GLOBAL", Now: "old", Nodes: []protocol.ProxyNode{{Name: "node-a", Type: "VLESS"}},
+	}}})
+	updateProxyKey(t, model, tea.KeyPressMsg{Code: tea.KeyEnter}) // 展开组
+	updateProxyKey(t, model, tea.KeyPressMsg{Code: tea.KeyDown})  // 焦点到节点
+	applyProxyCmd(t, model, updateProxyKey(t, model, tea.KeyPressMsg{Code: tea.KeyEnter}))
+
+	if model.groups[0].Now != "old" {
+		t.Fatalf("failed selection must not update Now, got %q", model.groups[0].Now)
+	}
+	if _, pending := model.pending[FocusID{Group: "GLOBAL", Node: "node-a"}]; pending {
+		t.Fatal("pending marker should clear after failure")
+	}
+	view := model.View()
+	if !strings.Contains(view, model.theme.Danger.Render(ui.ProxySelectFailed)) {
+		t.Fatalf("view missing failure feedback %q:\n%s", ui.ProxySelectFailed, view)
 	}
 }
 

--- a/internal/tui/pages/proxies/model_test.go
+++ b/internal/tui/pages/proxies/model_test.go
@@ -311,6 +311,53 @@ func TestModel_SelectProxyFailureShowsError(t *testing.T) {
 	}
 }
 
+func TestModel_SelectProxySuccessClearsError(t *testing.T) {
+	client := &fakeClient{selectErr: errors.New("upstream down")}
+	model := New(client, func() string { return "op-1" })
+	model.SetSize(80, 24)
+	model.SetGroups(protocol.ProxyGroups{Groups: []protocol.ProxyGroup{{
+		Name: "GLOBAL", Now: "old", Nodes: []protocol.ProxyNode{{Name: "node-a", Type: "VLESS"}},
+	}}})
+	updateProxyKey(t, model, tea.KeyPressMsg{Code: tea.KeyEnter})
+	updateProxyKey(t, model, tea.KeyPressMsg{Code: tea.KeyDown})
+	applyProxyCmd(t, model, updateProxyKey(t, model, tea.KeyPressMsg{Code: tea.KeyEnter}))
+	if !strings.Contains(model.View(), ui.ProxySelectFailed) {
+		t.Fatal("failure feedback missing")
+	}
+
+	client.selectErr = nil
+	applyProxyCmd(t, model, updateProxyKey(t, model, tea.KeyPressMsg{Code: tea.KeyEnter}))
+	if strings.Contains(model.View(), ui.ProxySelectFailed) {
+		t.Fatal("stale failure feedback after success")
+	}
+	if model.groups[0].Now != "node-a" {
+		t.Fatalf("Now=%q want node-a", model.groups[0].Now)
+	}
+}
+
+func TestModel_NewSelectionClearsStaleError(t *testing.T) {
+	client := &fakeClient{selectErr: errors.New("upstream down")}
+	model := New(client, func() string { return "op-1" })
+	model.SetSize(80, 24)
+	model.SetGroups(protocol.ProxyGroups{Groups: []protocol.ProxyGroup{{
+		Name: "GLOBAL", Now: "old", Nodes: []protocol.ProxyNode{{Name: "node-a", Type: "VLESS"}},
+	}}})
+	updateProxyKey(t, model, tea.KeyPressMsg{Code: tea.KeyEnter})
+	updateProxyKey(t, model, tea.KeyPressMsg{Code: tea.KeyDown})
+	applyProxyCmd(t, model, updateProxyKey(t, model, tea.KeyPressMsg{Code: tea.KeyEnter}))
+	if !strings.Contains(model.View(), ui.ProxySelectFailed) {
+		t.Fatal("failure feedback missing")
+	}
+
+	command := updateProxyKey(t, model, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if command == nil {
+		t.Fatal("expected selection command")
+	}
+	if strings.Contains(model.View(), ui.ProxySelectFailed) {
+		t.Fatal("stale error must clear when a new selection starts")
+	}
+}
+
 func TestView_GroupWrappedInBorderedSection(t *testing.T) {
 	model := New(nil, nil)
 	model.SetSize(80, 24)

--- a/internal/tui/pages/proxies/model_test.go
+++ b/internal/tui/pages/proxies/model_test.go
@@ -274,6 +274,16 @@ func (c *fakeClient) DelayProxy(_ context.Context, name string, _ protocol.Delay
 	return protocol.DelayResult{Schema: "mihari/v1", Delays: map[string]uint16{name: c.delay}}, nil
 }
 
+func TestSelectionResultMsg_ImplementsActionOutcomeContract(t *testing.T) {
+	boom := errors.New("boom")
+	if got := (selectionResultMsg{err: boom}).Err(); got != boom {
+		t.Fatalf("Err()=%v want boom", got)
+	}
+	if got := (selectionResultMsg{}).Err(); got != nil {
+		t.Fatalf("zero-value Err()=%v want nil", got)
+	}
+}
+
 func TestView_GroupWrappedInBorderedSection(t *testing.T) {
 	model := New(nil, nil)
 	model.SetSize(80, 24)

--- a/internal/tui/ui/strings.go
+++ b/internal/tui/ui/strings.go
@@ -98,6 +98,7 @@ const (
 	MissingValue             = "—"
 	TestingLabel             = "Testing…"
 	TimeoutLabel             = "Timeout"
+	ProxySelectFailed        = "Proxy selection failed"
 	ConnectionsActiveLabel   = "Active"
 	ConnectionsClosedLabel   = "Closed"
 	SourceIPLabel            = "Source IP"


### PR DESCRIPTION
Fixes #80

## 问题

proxies 页切换节点是实时链路(TUI → control server → runtime manager → mihomo API),后端每层都有规范的 `APIError` → HTTP 状态码映射,但 TUI 前端在 `selectionResultMsg` 的 `err != nil` 时只清 pending 标记,**无任何错误提示**——用户感知是"按了 enter 没反应"。

这同时是全仓库唯一未实现 shell action-outcome 契约(`Err() error`)的 mutation 结果消息。

## 修复(纯 TUI 改动,后端零变更)

- `selectionResultMsg` 实现 `Err() error` 契约,对齐其他页面模式
- `Model` 增加 `lastError`(rules 页同款模式):失败时设 `ui.ProxySelectFailed`
- `buildContent` 首行以 `theme.Danger` 渲染错误提示;focus 行号映射基于 `len(lines)` 动态计算,首行插入不影响滚动与 focus
- 清除时机:成功结果、或再次发起选择(`selectFocused`)

## 测试

- 契约:`Err()` 携带 err / 零值 nil
- 失败:view 含 Danger 渲染的错误提示;`Now` 不变(无错误乐观更新);pending 清除
- 成功清除:失败后再成功,提示消失、`Now` 更新
- 新发起清除:失败后再次 enter,提示立即消失

本地预检:`go test ./...` 46 包全 ok;proxies 包覆盖率 85.1%(改动函数 `Err`/`buildContent` 100%);`gofmt -l .` 无输出;`golangci-lint run` 0 issues。

设计与实施文档:`docs/superpowers/specs/2026-08-14-proxies-select-error-feedback-design.md` + `docs/superpowers/plans/2026-08-14-proxies-select-error-feedback.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)