### PR TITLE
fix(tui): Overview 页 Enter 保持 rail 焦点

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -725,7 +725,13 @@ func (model Model) updateRail(key string) (tea.Model, tea.Cmd) {
 	case "down":
 		model.railIndex = min(len(model.rail)-1, model.railIndex+1)
 	case "enter":
-		// Enter opens the selected page; arrow keys never cross rail ↔ content.
+		// Enter opens the selected page only when it has in-page keyboard
+		// targets. Overview and unavailable stubs do not implement
+		// ContentFocusable; parking focus there hides the rail footer and
+		// swallows arrow keys.
+		if _, ok := model.pages[model.active].(ui.ContentFocusable); !ok {
+			return model, nil
+		}
 		model.focus = ui.Focus{Area: ui.FocusContent, Page: model.active}
 		model.pages[model.active].FocusFirst()
 		if page, ok := model.pages[model.active].(interface{ Load() tea.Cmd }); ok {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -300,6 +300,10 @@ func TestStatusBarRightStatusDualServiceAndDaemon(t *testing.T) {
 
 func TestRail_EnterOpensContentButArrowsDoNot(t *testing.T) {
 	model := NewModel()
+	model = updateModelKey(t, model, tea.KeyPressMsg{Code: tea.KeyDown})
+	if model.active != ui.PageProxies {
+		t.Fatalf("active=%s", model.active)
+	}
 	model = updateModelKey(t, model, tea.KeyPressMsg{Code: tea.KeyTab})
 	if model.focus.Area != ui.FocusRail {
 		t.Fatalf("tab focus=%v", model.focus)
@@ -311,6 +315,24 @@ func TestRail_EnterOpensContentButArrowsDoNot(t *testing.T) {
 	model = updateModelKey(t, model, tea.KeyPressMsg{Code: tea.KeyEnter})
 	if model.focus.Area != ui.FocusContent {
 		t.Fatalf("enter focus=%v", model.focus)
+	}
+}
+
+func TestRail_EnterOnOverviewKeepsRailFocus(t *testing.T) {
+	model := NewModel()
+	if model.active != ui.PageOverview || model.focus.Area != ui.FocusRail {
+		t.Fatalf("start active=%s focus=%v", model.active, model.focus)
+	}
+	model = updateModelKey(t, model, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if model.focus.Area != ui.FocusRail || model.active != ui.PageOverview {
+		t.Fatalf("overview enter moved focus: active=%s focus=%v", model.active, model.focus)
+	}
+	if view := model.View().Content; !strings.Contains(view, ui.FooterRail) {
+		t.Fatalf("overview enter switched footer away from rail:\n%s", view)
+	}
+	model = updateModelKey(t, model, tea.KeyPressMsg{Code: tea.KeyDown})
+	if model.railIndex != 1 || model.active != ui.PageProxies || model.focus.Area != ui.FocusRail {
+		t.Fatalf("arrow after overview enter: railIndex=%d active=%s focus=%v", model.railIndex, model.active, model.focus)
 	}
 }
 
@@ -337,9 +359,10 @@ func TestRail_HJKLNeverNavigates(t *testing.T) {
 
 func TestContent_EscReturnsToRailButArrowsDoNot(t *testing.T) {
 	model := NewModel()
+	model = updateModelKey(t, model, tea.KeyPressMsg{Code: tea.KeyDown})
 	model = updateModelKey(t, model, tea.KeyPressMsg{Code: tea.KeyEnter})
-	if model.focus.Area != ui.FocusContent {
-		t.Fatalf("focus=%v", model.focus)
+	if model.active != ui.PageProxies || model.focus.Area != ui.FocusContent {
+		t.Fatalf("focus=%v active=%s", model.focus, model.active)
 	}
 	updated, command := model.Update(tea.KeyPressMsg{Code: 'h', Text: "h"})
 	model = updated.(Model)
@@ -564,9 +587,10 @@ func TestModelRoutesMihariCheckSpinnerToSystemAfterLeavingPage(t *testing.T) {
 func TestRail_DigitShortcutWorksFromContentFocus(t *testing.T) {
 	model := NewModel()
 	model.inputMode = ui.InputNavigation
+	model = updateModelKey(t, model, tea.KeyPressMsg{Code: tea.KeyDown})
 	model = updateModelKey(t, model, tea.KeyPressMsg{Code: tea.KeyEnter})
-	if model.focus.Area != ui.FocusContent {
-		t.Fatalf("enter focus=%v", model.focus.Area)
+	if model.active != ui.PageProxies || model.focus.Area != ui.FocusContent {
+		t.Fatalf("enter focus=%v active=%s", model.focus.Area, model.active)
 	}
 	model = updateModelKey(t, model, tea.KeyPressMsg{Code: '4', Text: "4"})
 	if model.active != ui.PageRules || model.railIndex != 3 {

--- a/internal/tui/ui/render.go
+++ b/internal/tui/ui/render.go
@@ -34,7 +34,9 @@ func railTabLabel(index int, page PageID) string {
 	return strconv.Itoa(index+1) + " " + PageLabel(page)
 }
 
-// ContentFocusable pages can suppress in-page selection chrome while the rail owns focus.
+// ContentFocusable pages have in-page keyboard targets. The rail uses this
+// to decide whether Enter may move focus into the page; pages use
+// SetContentFocused to suppress selection chrome while the rail owns focus.
 type ContentFocusable interface {
 	SetContentFocused(bool)
 }


### PR DESCRIPTION
Fixes #82

## 问题

rail 焦点停在 Overview 时按 Enter，`updateRail` 无条件把焦点切到 `FocusContent`。Overview 没有可聚焦控件（`FocusFirst` 为空，未实现 `ContentFocusable`），导致：

- 焦点停在空的 content 区
- footer 从 rail 提示切到 Overview 的 "Esc back"
- 方向键不再移动 rail

## 修复

- Enter 仅在活动页面实现 `ContentFocusable` 时进入 content
- Overview 与 unavailable stub 保持 rail 焦点（no-op）
- Proxies 等有内容焦点的页面行为不变

## 测试

- 新增 `TestRail_EnterOnOverviewKeepsRailFocus`：Enter 后仍在 rail、footer 仍是 rail 提示、方向键仍可切到 Proxies
- 既有 rail Enter / Esc / 数字快捷键测试改为先落到 Proxies，再验证 content 焦点

本地预检：`gofmt -l cmd internal` 无输出；`CGO_ENABLED=0 go build ./cmd/mihari` 通过；`go vet ./...` 通过；`go test ./...` 46 包全 ok；`golangci-lint run`（v2.12.2）0 issues。