### PR TITLE
fix(tui): 修复 Overview 双栏卡片截断 Core/Web GUI 数值

### DIFF
--- a/internal/tui/pages/overview/model.go
+++ b/internal/tui/pages/overview/model.go
@@ -12,8 +12,13 @@ import (
 	"github.com/mihari-proxy/mihari/internal/tui/ui"
 )
 
-// wideMinWidth is the content width at which KPI cards switch to a 2-column grid.
-const wideMinWidth = 60
+// wideMinWidth is the content width at which KPI cards switch to a 2-column
+// grid. 80 is the smallest width whose half-card text column (35) can hold a
+// typical Core status line with IEC units. Narrower panes stack so a 2-column
+// MaxWidth clip cannot eat "MiB". The Full shell (100×28, content 84) stays
+// two-column; Web GUI's longer address line wraps instead of truncating
+// (issue #84).
+const wideMinWidth = 80
 
 // overviewLabelWidth is the label column width of the General card grid;
 // continuation lines of wrapped values (e.g. Health) indent to match it.
@@ -100,14 +105,21 @@ func (m *Model) View() string {
 	// everything stacks single-column.
 	if m.width >= wideMinWidth {
 		half := m.halfCardInner()
-		// Equalize body line counts so both cards of a row end at the same
-		// bottom border (JoinHorizontal aligns tops; card height is body-driven).
-		generalBody, coreBody := ui.EqualizeLineCount(m.renderGeneralBody(half), m.renderCoreCard(half))
+		// Wrap to the half-card text width before equalizing heights so
+		// RenderBorderedSection's MaxWidth cannot clip IEC units or
+		// "N sessions" mid-token (issue #84).
+		generalBody, coreBody := ui.EqualizeLineCount(
+			wrapSectionBody(m.renderGeneralBody(half), half),
+			wrapSectionBody(m.renderCoreCard(half), half),
+		)
 		row1 := lipgloss.JoinHorizontal(lipgloss.Top,
 			m.cardAt(ui.OverviewGeneralTitle, generalBody, half),
 			m.cardAt(ui.CoreCardTitle, coreBody, half),
 		)
-		subBody, guiBody := ui.EqualizeLineCount(subscription, webGUI)
+		subBody, guiBody := ui.EqualizeLineCount(
+			wrapSectionBody(subscription, half),
+			wrapSectionBody(webGUI, half),
+		)
 		row2 := lipgloss.JoinHorizontal(lipgloss.Top,
 			m.cardAt(ui.SubscriptionCardTitle, subBody, half),
 			m.cardAt(ui.WebGUICardTitle, guiBody, half),
@@ -393,6 +405,16 @@ func (m *Model) cardAt(title, body string, inner int) string {
 	// Title sits in the top border edge: ╭─── Name ────────╮
 	// `inner` matches the previous lipgloss content Width (padding included).
 	return ui.RenderBorderedSection(m.theme, title, body, inner)
+}
+
+// wrapSectionBody reflows body to the printable width inside a section of
+// contentWidth so later MaxWidth clipping cannot cut a token in half.
+func wrapSectionBody(body string, contentWidth int) string {
+	width := ui.SectionTextWidth(contentWidth)
+	if width <= 0 || body == "" {
+		return body
+	}
+	return lipgloss.NewStyle().Width(width).Render(body)
 }
 
 func valueOr(value, fallback string) string {

--- a/internal/tui/pages/overview/model_test.go
+++ b/internal/tui/pages/overview/model_test.go
@@ -373,3 +373,92 @@ func TestOverview_NarrowLayoutStacksSingleColumn(t *testing.T) {
 		t.Fatalf("narrow layout still needs all cards: %s", view)
 	}
 }
+
+func TestOverview_MediumWidthKeepsFullCoreAndWebGUIMetrics(t *testing.T) {
+	// 74 is above the old 60-column two-column tripwire but below the
+	// half-card budget needed for Core IEC units and "N sessions" (issue #84).
+	model := New()
+	model.SetSize(74, 26)
+	mem := int64(100 << 20)
+	up := int64(136 << 20)
+	down := int64(199 << 20)
+	model.SetSnapshot(Snapshot{
+		Status: protocol.Status{Capabilities: []string{protocol.CapabilityWebGUI}},
+		Core:   protocol.CoreStatus{Status: "running", Version: "v1.19.29"},
+		Monitor: ui.MonitorSnapshot{
+			Connections:   58,
+			MemoryInUse:   mem,
+			UploadTotal:   up,
+			DownloadTotal: down,
+		},
+		WebGUI: &protocol.WebGUIStatus{
+			GatewayHealth:   "healthy",
+			GatewayAddr:     "127.0.0.1:9191",
+			ActivePanel:     "zashboard",
+			BrowserSessions: 0,
+		},
+	})
+	view := model.View()
+	for _, want := range []string{
+		ui.FormatBytes(mem),
+		"↑" + ui.FormatBytes(up),
+		"↓" + ui.FormatBytes(down),
+		"0 sessions",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("medium width truncated %q:\n%s", want, view)
+		}
+	}
+	for _, line := range strings.Split(view, "\n") {
+		if strings.Contains(line, ui.OverviewGeneralTitle) && strings.Contains(line, ui.CoreCardTitle) {
+			t.Fatalf("medium width should stack cards, not pair General/Core:\n%s", view)
+		}
+	}
+}
+
+func TestOverview_FullContentWidthKeepsWebGUISessions(t *testing.T) {
+	// 84 is the Full shell content pane (terminal 100 − rail 16). Two-column
+	// stays on, but the Web GUI address line is 40 cells and must wrap rather
+	// than MaxWidth-clip "sessions".
+	model := New()
+	model.SetSize(84, 26)
+	model.SetSnapshot(Snapshot{
+		Status: protocol.Status{Capabilities: []string{protocol.CapabilityWebGUI}},
+		Core:   protocol.CoreStatus{Status: "running", Version: "v1.19.29"},
+		Monitor: ui.MonitorSnapshot{
+			Connections:   58,
+			MemoryInUse:   100 << 20,
+			UploadTotal:   136 << 20,
+			DownloadTotal: 199 << 20,
+		},
+		WebGUI: &protocol.WebGUIStatus{
+			GatewayHealth:   "healthy",
+			GatewayAddr:     "127.0.0.1:9191",
+			ActivePanel:     "zashboard",
+			BrowserSessions: 0,
+		},
+	})
+	view := model.View()
+	for _, want := range []string{
+		ui.FormatBytes(100 << 20),
+		"↑" + ui.FormatBytes(136<<20),
+		"↓" + ui.FormatBytes(199<<20),
+		"127.0.0.1:9191",
+		"zashboard",
+		"sessions",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("full content width truncated %q:\n%s", want, view)
+		}
+	}
+	foundPair := false
+	for _, line := range strings.Split(view, "\n") {
+		if strings.Contains(line, ui.OverviewGeneralTitle) && strings.Contains(line, ui.CoreCardTitle) {
+			foundPair = true
+			break
+		}
+	}
+	if !foundPair {
+		t.Fatalf("full content width should keep the 2-column grid:\n%s", view)
+	}
+}


### PR DESCRIPTION
## 变更内容

修复 TUI Overview 双栏布局把 Core / Web GUI 数值从词中间截断的问题（`MEM 107.3 MiB` → `MEM 107.3`，`0 sessions` → `0`）。

- 将 `wideMinWidth` 从 60 提到 80：半卡正文至少 35 列，才能放下典型 Core 状态行；更窄的窗口改回单列。官方 Full 窗口（100×28，内容区 84）仍是双栏。
- 双栏正文先按 `SectionTextWidth` 换行，再交给 `RenderBorderedSection`，避免 `MaxWidth` 裁掉 `MiB` / `sessions`。
- 回归测试覆盖内容区 74（单列、单位完整）和 84（双栏、`sessions` 完整）。

## 类型

- [x] fix: Bug 修复
- [x] test: 测试

## 检查清单

- [x] `go test ./internal/tui/...` 通过
- [x] `go test -race ./internal/tui/pages/overview/` 通过
- [x] `go vet ./internal/tui/...` 通过
- [x] `gofmt -l internal/tui/pages/overview` 无输出
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] 未修改 `internal/control/protocol` 契约、CLI 输出/退出码或跨平台行为

未跑全仓 `go test -race ./...`（改动仅限 Overview 页渲染）。

## 相关 Issues

Fixes #84

## 其他

根因：`wideMinWidth=60` 过早切双栏，半卡 `textWidth` 只有约 25–32 列，`RenderBorderedSection` 用 `MaxWidth` 硬截断。截图窗口大约是内容区 72–76 列，正好踩中这个区间。
