### PR TITLE
chore(release): 记录 v0.7.3 变更日志

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@
 
 ### Fixed
 
+## [v0.7.3] - 2026-08-17
+
+### Added
+
+- 托管端口被占用时，错误 details 在可获得时带上占用进程 PID 与基名（#87）。
+- runtime 装配失败但控制通道仍可 listen 时，驻留仅状态降级控制面：`GET /v1/status` 返回 `health=degraded` 与可省略的 `last_error`（#87）。
+
+### Fixed
+
+- Windows 服务在控制通道未能 listen 时不再向 SCM 报 running（#87）。
+- TUI 重连页脚展示净化后的连接失败原因；服务状态晚到时补全控制面不可达提示（#87）。
+- `mihari status` 在降级时打印 `Error:` 行（#87）。
+
 ## [v0.7.2] - 2026-08-14
 
 ### Fixed


### PR DESCRIPTION
## 变更内容

记录 v0.7.3 变更日志（#87）。自 v0.7.1 起：v0.7.2 变更日志已合入但未打标签；本次发修订号 **v0.7.3**，覆盖服务启动失败可观测与假 running 修复。

合并后打 annotated tag `v0.7.3` 触发 Release 工作流。

## 类型

- [ ] feat: 新功能
- [ ] fix: Bug 修复
- [ ] refactor: 重构
- [x] docs: 文档
- [ ] test: 测试
- [x] chore: 构建/工具

## 检查清单

- [ ] `go test -race ./...` 通过（文档-only，依赖 CI）
- [x] `go vet ./...` 通过（无 Go 变更）
- [x] `gofmt -l cmd internal` 无输出（无 Go 变更）
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] 若修改了 `internal/control/protocol` 的契约、CLI 输出/退出码或跨平台行为，已在 PR 描述中说明影响

## 相关 Issues

#87