### PR TITLE
fix(tun): 识别 Sparkle/Meta Tunnel 并在 Enable 后核对 live

### DIFF
--- a/docs/superpowers/plans/2026-08-17-tun-conflict-detect-and-live.md
+++ b/docs/superpowers/plans/2026-08-17-tun-conflict-detect-and-live.md
@@ -1,0 +1,813 @@
+# TUN 冲突探测与 Live 校验 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Windows 认出 Sparkle/mihomo 的 `Meta Tunnel` 网卡；按 PID/网卡名扣除自身；Enable 必须看到 live 为 true，否则回滚并填 `last_error`。
+
+**Architecture:** `tundetect` 继续只观察。Windows 用纯字符串分类器认 Wintun/mihomo 家族网卡。`Classify` 改为接收 `Self{TunActive,TunName,CorePID}`。`runtime.mutateTun` 在 apply 后读 `liveTunEnable`，不一致则回滚 Desired；PATCH 错误不再被 regenerate 成功吞掉。
+
+**Tech Stack:** Go 1.26，`golang.org/x/sys/windows`（已有），标准 `go test`。`CGO_ENABLED=0`。
+
+**设计文档:** `docs/superpowers/specs/2026-08-17-tun-conflict-detect-and-live-design.md`
+
+**Issue:** https://github.com/mihari-proxy/mihari/issues/91
+
+**工作目录（worktree）:** 必须在 `.worktrees/fix-tun-conflict-detect-and-live`（分支 `fix/tun-conflict-detect-and-live`）。禁止修改主工作区 `main`。
+
+## Global Constraints
+
+- 禁止在 `main` 上直接改代码或提交。
+- `/v1` 只允许加法：`TunStatus.last_error` 已存在；不新增错误码；`CodeTunConflict` 的 message 不变。
+- 不杀外部进程，不换 `device`/`inet4-address` 做双 TUN 共存，不扫描 `Sparkle.exe`。
+- 错误文案不得包含 token、controller secret、订阅 URL、完整路径。
+- Windows 分类纯函数必须能在非 Windows 上 `go test`。
+- 平台 syscall 必须留在 `_windows.go` / `_linux.go` / `_darwin.go`。
+- 测试不得访问公网、真实用户目录或已安装的 mihomo/Sparkle。
+- 每个行为先写失败测试，再写最小实现。
+- 修改过的 Go 文件必须 `gofmt`。
+- Conventional Commits：类型英文、摘要中文。一个 task 一个 commit。提交加 `-s`（DCO）。
+
+---
+
+### Task 1: Windows 网卡名字分类器
+
+**Files:**
+- Create: `internal/tundetect/windows_names.go`
+- Create: `internal/tundetect/windows_names_test.go`
+- Modify: `internal/tundetect/tundetect_windows.go`（`isWintun` 改委托，展示名格式）
+
+**Interfaces:**
+- Consumes: 无
+- Produces: `isWindowsTunAdapter(desc, friendly string) bool`；`formatAdapterName(desc, friendly string) string`
+
+- [ ] **Step 1: 写失败测试**
+
+`internal/tundetect/windows_names_test.go`：
+
+```go
+package tundetect
+
+import "testing"
+
+func TestIsWindowsTunAdapter(t *testing.T) {
+	tests := []struct {
+		name     string
+		desc     string
+		friendly string
+		want     bool
+	}{
+		{"legacy wintun desc", "Wintun Userspace Tunnel", "Ethernet 2", true},
+		{"sparkle meta tunnel", "Meta Tunnel", "mihomo", true},
+		{"friendly mihomo only", "Some Vendor NIC", "mihomo", true},
+		{"friendly Meta exact", "Virtual", "Meta", true},
+		{"wireguard tunnel", "WireGuard Tunnel", "OfficeNet", true},
+		{"wlan", "Intel(R) Wi-Fi 6 AX201 160MHz", "WLAN", false},
+		{"tap windows", "TAP-Windows Adapter V9", "以太网 8", false},
+		{"sangfor", "Sangfor SSL VPN CS Support System VNIC", "以太网 7", false},
+		{"netease tap", "Netease UU TAP-Win32 Adapter V9.21", "以太网 6", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isWindowsTunAdapter(tt.desc, tt.friendly); got != tt.want {
+				t.Fatalf("got=%v want=%v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatAdapterName(t *testing.T) {
+	if got := formatAdapterName("Meta Tunnel", "mihomo"); got != "mihomo (Meta Tunnel)" {
+		t.Fatalf("got=%q", got)
+	}
+	if got := formatAdapterName("Wintun Userspace Tunnel", "Wintun Userspace Tunnel"); got != "Wintun Userspace Tunnel" {
+		t.Fatalf("got=%q", got)
+	}
+	if got := formatAdapterName("Wintun Userspace Tunnel", ""); got != "Wintun Userspace Tunnel" {
+		t.Fatalf("got=%q", got)
+	}
+}
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+```powershell
+Set-Location D:\modular_dev\mihari\.worktrees\fix-tun-conflict-detect-and-live
+go test ./internal/tundetect -run "TestIsWindowsTunAdapter|TestFormatAdapterName" -count=1
+```
+
+预期：编译失败，`isWindowsTunAdapter` / `formatAdapterName` 未定义。
+
+- [ ] **Step 3: 最小实现**
+
+`internal/tundetect/windows_names.go`（无构建标签）：
+
+```go
+package tundetect
+
+import "strings"
+
+func isWindowsTunAdapter(desc, friendly string) bool {
+	haystack := strings.ToLower(desc + " " + friendly)
+	for _, needle := range []string{"wintun", "meta tunnel", "wireguard"} {
+		if strings.Contains(haystack, needle) {
+			return true
+		}
+	}
+	name := strings.ToLower(strings.TrimSpace(friendly))
+	if name == "" {
+		name = strings.ToLower(strings.TrimSpace(desc))
+	}
+	return name == "mihomo" || name == "meta"
+}
+
+func formatAdapterName(desc, friendly string) string {
+	friendly = strings.TrimSpace(friendly)
+	desc = strings.TrimSpace(desc)
+	switch {
+	case friendly == "":
+		return desc
+	case desc == "" || strings.EqualFold(friendly, desc):
+		return friendly
+	default:
+		return friendly + " (" + desc + ")"
+	}
+}
+```
+
+`tundetect_windows.go`：`isWintun` 改为 `return isWindowsTunAdapter(desc, friendly)`；枚举里用 `formatAdapterName`。
+
+- [ ] **Step 4: 跑测试确认通过**
+
+同 Step 2。预期：PASS。再跑 `go test ./internal/tundetect -count=1`。
+
+- [ ] **Step 5: Commit**
+
+```powershell
+Set-Location D:\modular_dev\mihari\.worktrees\fix-tun-conflict-detect-and-live
+git add internal/tundetect/windows_names.go internal/tundetect/windows_names_test.go internal/tundetect/tundetect_windows.go
+git commit -s -m "fix(tundetect): 识别 Meta Tunnel 与 mihomo 网卡名"
+```
+
+---
+
+### Task 2: Detection.Process 与 Classify(Self)
+
+**Files:**
+- Modify: `internal/tundetect/tundetect.go`
+- Modify: `internal/tundetect/classify.go`
+- Modify: `internal/tundetect/classify_test.go`
+- Modify: `internal/tundetect/tundetect_windows.go`（进程改为 `Process`）
+- Modify: `internal/tundetect/tundetect_linux.go`
+- Modify: `internal/tundetect/tundetect_darwin.go`
+- Modify: `internal/runtime/tun_test.go`（Detection 字面量）
+- Modify: `internal/integration/sysproxy_tun_test.go`（若构造了 MihomoProcesses）
+
+**Interfaces:**
+- Consumes: Task 1 的 `formatAdapterName`（网卡匹配时比较 alias）
+- Produces:
+
+```go
+type Process struct {
+    Name string
+    PID  int
+}
+
+type Self struct {
+    TunActive bool
+    TunName   string
+    CorePID   int
+}
+
+func Classify(d Detection, self Self) *protocol.TunConflict
+func formatProcess(p Process) string // "name (pid)"
+func adapterNameMatch(listed, tunName string) bool
+```
+
+- [ ] **Step 1: 写失败测试**
+
+重写 `classify_test.go` 的表，旧的 `Classify(d, bool)` 与 `[]string` 进程必须编不过。新增用例：
+
+```go
+func TestClassify_SubtractsByPIDNotPosition(t *testing.T) {
+	got := Classify(Detection{
+		MihomoProcesses: []Process{
+			{Name: "mihomo-alpha.exe", PID: 11220},
+			{Name: "mihomo.exe", PID: 13400},
+		},
+	}, Self{CorePID: 13400})
+	if got == nil || len(got.OtherMihomoProcesses) != 1 || got.OtherMihomoProcesses[0] != "mihomo-alpha.exe (11220)" {
+		t.Fatalf("got=%#v", got)
+	}
+}
+
+func TestClassify_DoesNotDropAdapterWhenSelfInactive(t *testing.T) {
+	got := Classify(Detection{
+		TunInterfaces: []string{"mihomo (Meta Tunnel)"},
+	}, Self{TunActive: false, CorePID: 13400})
+	if got == nil || len(got.OtherTunInterfaces) != 1 || got.OtherTunInterfaces[0] != "mihomo (Meta Tunnel)" {
+		t.Fatalf("got=%#v", got)
+	}
+}
+
+func TestClassify_SubtractsAdapterByName(t *testing.T) {
+	got := Classify(Detection{
+		TunInterfaces: []string{"Meta", "mihomo (Meta Tunnel)"},
+	}, Self{TunActive: true, TunName: "Meta"})
+	if got == nil || len(got.OtherTunInterfaces) != 1 || got.OtherTunInterfaces[0] != "mihomo (Meta Tunnel)" {
+		t.Fatalf("got=%#v", got)
+	}
+}
+
+func TestClassify_UnknownLiveNameDropsOne(t *testing.T) {
+	got := Classify(Detection{
+		TunInterfaces: []string{"Meta"},
+	}, Self{TunActive: true, TunName: ""})
+	if got != nil {
+		t.Fatalf("got=%#v", got)
+	}
+}
+
+func TestClassify_UnknownPIDKeepsAllProcesses(t *testing.T) {
+	got := Classify(Detection{
+		MihomoProcesses: []Process{{Name: "mihomo.exe", PID: 13400}},
+	}, Self{})
+	if got == nil || len(got.OtherMihomoProcesses) != 1 {
+		t.Fatalf("got=%#v", got)
+	}
+}
+```
+
+把原表驱动改成 `self Self` + `[]Process`。原先「single mihomo is self, subtracts to nil」改为 `Self{CorePID: 1}` 且进程 PID=1。
+
+- [ ] **Step 2: 跑测试确认失败**
+
+```powershell
+Set-Location D:\modular_dev\mihari\.worktrees\fix-tun-conflict-detect-and-live
+go test ./internal/tundetect -count=1
+```
+
+预期：编译失败（`Classify` 仍是 `bool`，`MihomoProcesses` 仍是 `[]string`）。
+
+- [ ] **Step 3: 最小实现**
+
+`tundetect.go` 增加 `Process`、`Self`，`Detection.MihomoProcesses []Process`。
+
+`classify.go`：
+
+- 网卡：`TunActive && TunName!=""` 则按 `adapterNameMatch` 删一项；`TunActive && TunName==""` 则删 `[0]`；否则不删。
+- 进程：`CorePID!=0` 则删 PID 相等的一项；否则不删。
+- 输出进程用 `formatProcess`。
+
+`adapterNameMatch(listed, tunName)`：忽略大小写；`listed==tunName`，或 `listed` 为 `tunName (...)`，或 `listed` 以 ` (tunName)` 结尾。
+
+三端 enumerate 函数改返回 `[]Process`。Windows：`PID: int(entry.ProcessID)`。Linux：`strconv.Atoi(e.Name())`。Darwin：解析 `ps` 的 pid 列。
+
+更新 `runtime/tun_test.go`：
+
+```go
+Detection: tundetect.Detection{MihomoProcesses: []tundetect.Process{{Name: "mihomo", PID: 123}, {Name: "mihomo", PID: 456}}},
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+```powershell
+go test ./internal/tundetect ./internal/runtime ./internal/integration -count=1
+```
+
+预期：PASS。
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add internal/tundetect internal/runtime/tun_test.go internal/integration
+git commit -s -m "fix(tundetect): 按 PID 与网卡名扣除自身"
+```
+
+---
+
+### Task 3: runtime 把 Self 接到 Classify
+
+**Files:**
+- Modify: `internal/runtime/tun.go`（`detectTunConflict` / `selfTunLiveActive`）
+- Modify: `internal/runtime/tun_test.go`（`TestEnableTunSubtractsSelfWhenLiveActive` 补 device + PID）
+
+**Interfaces:**
+- Consumes: `tundetect.Self`、`tundetect.Classify`
+- Produces: `selfFromLive(ctx) tundetect.Self`；`liveTunDevice(configs) string`
+
+- [ ] **Step 1: 写失败测试**
+
+在 `TestEnableTunSubtractsSelfWhenLiveActive` 旁追加：
+
+```go
+func TestEnableTunKeepsForeignAdapterWhenLiveDeviceDiffers(t *testing.T) {
+	controller := &fakeController{configs: map[string]any{
+		"tun": map[string]any{"enable": true, "device": "Meta", "stack": "gVisor"},
+	}}
+	manager := newTunManagerWithDetect(t, controller, defaultTunSettings(map[string]any{
+		"enable": true, "stack": "gVisor",
+	}), &tundetect.FakeBackend{
+		Detection: tundetect.Detection{TunInterfaces: []string{"Meta", "mihomo (Meta Tunnel)"}},
+	})
+	_, err := manager.EnableTun(context.Background(), Operation{ID: "tun-foreign", Source: "test"}, false)
+	var apiError protocol.APIError
+	if !errors.As(err, &apiError) || apiError.Code != protocol.CodeTunConflict {
+		t.Fatalf("err=%v", err)
+	}
+	names, _ := apiError.Details["other_tun_interfaces"].([]string)
+	if len(names) != 1 || names[0] != "mihomo (Meta Tunnel)" {
+		t.Fatalf("details=%#v", apiError.Details)
+	}
+	if controller.patchCalls != 0 {
+		t.Fatalf("patchCalls=%d", controller.patchCalls)
+	}
+}
+```
+
+该测试在 Task 2 之后、本 task 实现前应失败：`detectTunConflict` 仍用 `Classify(d, bool)`，live 时会盲删第一张 `Meta`，剩下 Sparkle 网卡——等等，那其实已经会门控。
+
+更精确：若实现仍用 bool 盲删，检测顺序 `["mihomo (Meta Tunnel)", "Meta"]` 时会删错（删 Sparkle，留下自己），Enable **不会**门控。用这个顺序写测试：
+
+```go
+Detection: tundetect.Detection{TunInterfaces: []string{"mihomo (Meta Tunnel)", "Meta"}},
+```
+
+盲删会删 Sparkle，Enable 错误成功。按名扣除会留下 Sparkle，Enable 应 `CodeTunConflict`。
+
+- [ ] **Step 2: 跑测试确认失败**
+
+```powershell
+go test ./internal/runtime -run TestEnableTunKeepsForeignAdapterWhenLiveDeviceDiffers -count=1
+```
+
+预期：FAIL，`err=nil`（盲删删错网卡）。
+
+- [ ] **Step 3: 最小实现**
+
+```go
+func (m *Manager) detectTunConflict(ctx context.Context) *protocol.TunConflict {
+	if m.tunDetect == nil {
+		return nil
+	}
+	detection, err := m.tunDetect.Detect(ctx)
+	if err != nil {
+		return nil
+	}
+	return tundetect.Classify(detection, m.selfFromLive(ctx))
+}
+
+func (m *Manager) selfFromLive(ctx context.Context) tundetect.Self {
+	self := tundetect.Self{CorePID: m.store.Load().Core.PID}
+	if m.controller == nil || ctx.Err() != nil {
+		return self
+	}
+	configs, err := m.controller.Configs(ctx)
+	if err != nil {
+		return self
+	}
+	if live, ok := liveTunEnable(configs); ok && live {
+		self.TunActive = true
+		self.TunName = liveTunDevice(configs)
+	}
+	return self
+}
+
+func liveTunDevice(configs map[string]any) string {
+	raw, _ := configs["tun"].(map[string]any)
+	device, _ := raw["device"].(string)
+	return strings.TrimSpace(device)
+}
+```
+
+删除只返回 bool 的 `selfTunLiveActive`，或改成对 `selfFromLive(ctx).TunActive` 的包装（无其它调用则可删）。
+
+`newTunManagerWithDetect` 如需 PID，在 Options 里给 Store 预置 `Core: {PID: 13400}` 不是本用例必需。
+
+- [ ] **Step 4: 跑测试确认通过**
+
+```powershell
+go test ./internal/runtime -count=1
+```
+
+预期：PASS。
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add internal/runtime/tun.go internal/runtime/tun_test.go
+git commit -s -m "fix(runtime): Classify 使用 live device 与 core PID"
+```
+
+---
+
+### Task 4: PATCH 失败不可被 regenerate 吞掉
+
+**Files:**
+- Modify: `internal/runtime/tun.go`（`applyTun`）
+- Modify: `internal/runtime/tun_test.go`
+- Modify: `internal/runtime/manager_test.go`（`fakeController.Reload`）
+
+**Interfaces:**
+- Consumes: 现有 `applyTun`、`configReloader`
+- Produces: `applyTun` 在 `patchErr != nil` 时必须返回 `patchErr`
+
+- [ ] **Step 1: 写失败测试**
+
+给 `fakeController` 增加：
+
+```go
+reloads   int
+reloadErr error
+
+func (c *fakeController) Reload(context.Context, string, bool) error {
+	c.reloads++
+	return c.reloadErr
+}
+```
+
+新测试（用 `subscription.Open` + 空 catalog，走 bootstrap regenerate）：
+
+```go
+func TestApplyTunReturnsPatchErrorEvenIfReloadSucceeded(t *testing.T) {
+	root := t.TempDir()
+	controller := &fakeController{
+		configs: map[string]any{},
+		patchConfigs: func(context.Context, map[string]any) error {
+			return protocol.APIError{Code: protocol.CodeUpstreamFailure, Message: "patch tun rejected"}
+		},
+	}
+	subs, err := subscription.Open(subscription.ServiceOptions{
+		CatalogPath: filepath.Join(root, "catalog.yaml"),
+		CacheDir:    filepath.Join(root, "cache"),
+		ProxyAddr:   "127.0.0.1:9190",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	settings := defaultTunSettings(nil)
+	settingsPath := filepath.Join(root, "settings.yaml")
+	if err := config.Save(settingsPath, settings); err != nil {
+		t.Fatal(err)
+	}
+	manager := newTestManager(Options{
+		Controller:    controller,
+		SettingsPath:  settingsPath,
+		Settings:      settings,
+		Subscriptions: subs,
+		RuntimeConfig: filepath.Join(root, "runtime", "config.yaml"),
+		StagingDir:    filepath.Join(root, "staging"),
+	})
+	_, err = manager.EnableTun(context.Background(), Operation{ID: "tun-patch-fail", Source: "test"}, false)
+	if err == nil {
+		t.Fatal("expected patch error")
+	}
+	loaded, loadErr := config.Load(settingsPath)
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if tunDesiredEnable(loaded.Tun) {
+		t.Fatalf("desired must roll back, tun=%#v", loaded.Tun)
+	}
+}
+```
+
+当前 `applyTun` 在 reload 成功后返回 nil，本测试会失败在 `err==nil` 或 Desired 仍为 true。
+
+- [ ] **Step 2: 跑测试确认失败**
+
+```powershell
+go test ./internal/runtime -run TestApplyTunReturnsPatchErrorEvenIfReloadSucceeded -count=1
+```
+
+预期：FAIL，`err==nil` 或 Desired 未回滚。
+
+- [ ] **Step 3: 最小实现**
+
+`applyTun` 末尾改为：
+
+```go
+if patchErr != nil {
+	return patchErr
+}
+if regenerated || patched {
+	return nil
+}
+if regenerateErr != nil {
+	return regenerateErr
+}
+return protocol.APIError{Code: protocol.CodeInvalidState, Message: "mihomo controller is unavailable"}
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+```powershell
+go test ./internal/runtime -count=1
+```
+
+预期：PASS。
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add internal/runtime/tun.go internal/runtime/tun_test.go internal/runtime/manager_test.go
+git commit -s -m "fix(tun): regenerate 成功后仍返回 PATCH 错误"
+```
+
+---
+
+### Task 5: Enable 后核对 live 并回滚
+
+**Files:**
+- Modify: `internal/runtime/tun.go`
+- Modify: `internal/runtime/tun_test.go`
+
+**Interfaces:**
+- Consumes: `liveTunEnable`、`applyTun`、现有 settings 回滚
+- Produces: Enable 在 live 非 true 时返回 `CodeUpstreamFailure` / `"TUN did not become live after apply"`，Desired 回滚
+
+- [ ] **Step 1: 写失败测试**
+
+```go
+func TestEnableTunRollsBackWhenLiveStaysOff(t *testing.T) {
+	controller := &fakeController{
+		configs: map[string]any{"tun": map[string]any{"enable": false, "stack": "gVisor"}},
+		patchConfigs: func(context.Context, map[string]any) error {
+			return nil
+		},
+	}
+	manager := newTunManager(t, controller, defaultTunSettings(nil))
+	_, err := manager.EnableTun(context.Background(), Operation{ID: "tun-live-off", Source: "test"}, false)
+	var apiError protocol.APIError
+	if !errors.As(err, &apiError) || apiError.Code != protocol.CodeUpstreamFailure {
+		t.Fatalf("err=%v", err)
+	}
+	if apiError.Message != "TUN did not become live after apply" {
+		t.Fatalf("message=%q", apiError.Message)
+	}
+	assertPersistedTun(t, manager.settingsPath, false, "") // 见 Step 3：previous 为 nil 时 settings.Tun 应回到空/非 desired
+}
+
+func TestEnableTunForceStillRequiresLive(t *testing.T) {
+	controller := &fakeController{
+		configs: map[string]any{"tun": map[string]any{"enable": false}},
+		patchConfigs: func(context.Context, map[string]any) error { return nil },
+	}
+	manager := newTunManagerWithDetect(t, controller, defaultTunSettings(nil), &tundetect.FakeBackend{
+		Detection: tundetect.Detection{TunInterfaces: []string{"mihomo (Meta Tunnel)"}},
+	})
+	_, err := manager.EnableTun(context.Background(), Operation{ID: "tun-force-live", Source: "test"}, true)
+	var apiError protocol.APIError
+	if !errors.As(err, &apiError) || apiError.Code != protocol.CodeUpstreamFailure {
+		t.Fatalf("force must not skip live check, err=%v", err)
+	}
+}
+
+func TestEnableTunFailsWhenConfigsUnreadableAfterApply(t *testing.T) {
+	controller := &fakeController{
+		configs:    map[string]any{},
+		configsErr: protocol.APIError{Code: protocol.CodeUpstreamFailure, Message: "mihomo controller is unavailable"},
+	}
+	// patchConfigs 默认会写 configs，但随后 Configs 返回 err
+	manager := newTunManager(t, controller, defaultTunSettings(nil))
+	_, err := manager.EnableTun(context.Background(), Operation{ID: "tun-unread", Source: "test"}, false)
+	if err == nil {
+		t.Fatal("unread live must not count as success")
+	}
+}
+```
+
+`assertPersistedTun` 在 Tun 被回滚成 nil 时会 `Fatal("expected persisted tun block")`。本用例 previous 为 nil，回滚后允许 `loaded.Tun==nil` 或 `!tunDesiredEnable`。测试里不要调用 `assertPersistedTun`；改成：
+
+```go
+loaded, err := config.Load(manager.settingsPath)
+if err != nil {
+	t.Fatal(err)
+}
+if tunDesiredEnable(loaded.Tun) {
+	t.Fatalf("desired rolled back? tun=%#v", loaded.Tun)
+}
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+```powershell
+go test ./internal/runtime -run "TestEnableTunRollsBackWhenLiveStaysOff|TestEnableTunForceStillRequiresLive|TestEnableTunFailsWhenConfigsUnreadableAfterApply" -count=1
+```
+
+预期：FAIL，`err==nil`（apply 被当成成功）。
+
+- [ ] **Step 3: 最小实现**
+
+在 `mutateTun` 里 `applyTun` 成功之后、`coordinator.Do` 之前：
+
+```go
+if enable {
+	live, ok := false, false
+	if m.controller != nil && ctx.Err() == nil {
+		if configs, cfgErr := m.controller.Configs(ctx); cfgErr == nil {
+			live, ok = liveTunEnable(configs)
+		}
+	}
+	if !(ok && live) {
+		m.settingsMu.Lock()
+		m.settings.Tun = previousTun
+		_ = m.persistSettings()
+		m.settingsMu.Unlock()
+		if applyBackErr := m.applyTun(ctx, previousTun); applyBackErr != nil {
+			_ = applyBackErr // best-effort restore; 第一次失败仍返回
+		}
+		return protocol.TunStatus{}, protocol.APIError{
+			Code:    protocol.CodeUpstreamFailure,
+			Message: "TUN did not become live after apply",
+		}
+	}
+}
+```
+
+`applyTun(nil)`：`buildManagedTun` 不在这条回滚路径；直接把 `previousTun`（可能为 nil）交给 `applyTun`。`applyTun` 对 nil 的 PATCH 应为 `{"tun": nil}` 或跳过？当前 `PatchConfigs({"tun": nil})` 可能不合法。
+
+回滚二次 apply 规则（必须写死）：
+
+- `previousTun == nil` 或 `len==0`：PATCH `{"tun": {"enable": false, "stack": defaultTunStack}}` 会改变「未托管」语义。改为：只 persist 回空 Tun，**不要** PATCH 一个伪造的 managed 块。二次 apply 仅当 `len(previousTun)>0`。
+- `previousTun` 非空：`applyTun(ctx, previousTun)`。
+
+`applyTun` 里 `nextTun==nil` 时跳过 PATCH。
+
+- [ ] **Step 4: 跑测试确认通过**
+
+```powershell
+go test ./internal/runtime -count=1
+```
+
+预期：PASS。现有 `TestEnableTunPersistsAndPatches` 仍过（fake 会把 patch 写进 configs）。
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add internal/runtime/tun.go internal/runtime/tun_test.go
+git commit -s -m "fix(tun): Enable 后核对 live 失败则回滚"
+```
+
+---
+
+### Task 6: 填充 TunStatus.last_error
+
+**Files:**
+- Modify: `internal/runtime/tun.go`
+- Modify: `internal/runtime/tun_test.go`
+- Modify: `internal/runtime/manager.go`（若 `tunLastError` 放在 Manager 结构体上）
+
+**Interfaces:**
+- Consumes: Task 5 的失败路径
+- Produces: `Manager.tunLastError string`；`buildTunStatus` 非空 `LastError`
+
+- [ ] **Step 1: 写失败测试**
+
+```go
+func TestTunStatusLastErrorWhenDesiredOnLiveOff(t *testing.T) {
+	live := false
+	controller := &fakeController{configs: map[string]any{
+		"tun": map[string]any{"enable": live, "stack": "gVisor"},
+	}}
+	manager := newTunManager(t, controller, defaultTunSettings(map[string]any{
+		"enable": true, "stack": "gVisor",
+	}))
+	status, err := manager.TunStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.LastError != "live TUN is off" {
+		t.Fatalf("LastError=%q", status.LastError)
+	}
+}
+
+func TestEnableTunFailurePersistsLastErrorOnStatus(t *testing.T) {
+	controller := &fakeController{
+		configs:      map[string]any{"tun": map[string]any{"enable": false}},
+		patchConfigs: func(context.Context, map[string]any) error { return nil },
+	}
+	manager := newTunManager(t, controller, defaultTunSettings(nil))
+	_, _ = manager.EnableTun(context.Background(), Operation{ID: "tun-err", Source: "test"}, false)
+	status, err := manager.TunStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.LastError != "TUN did not become live after apply" {
+		t.Fatalf("LastError=%q", status.LastError)
+	}
+	if status.DesiredEnable {
+		t.Fatal("desired should stay off after failed enable")
+	}
+}
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+```powershell
+go test ./internal/runtime -run "TestTunStatusLastErrorWhenDesiredOnLiveOff|TestEnableTunFailurePersistsLastErrorOnStatus" -count=1
+```
+
+预期：FAIL，`LastError` 为空。
+
+- [ ] **Step 3: 最小实现**
+
+`Manager` 增加 `tunLastError string`（与 `settingsMu` 一起保护，或单独字段仅在 lock 内写）。
+
+- 成功 mutate 且 live 核对通过：`tunLastError=""`。
+- live 核对失败 / apply 失败：`tunLastError=mapped.Message`。
+- `buildTunStatus`：
+
+```go
+if lastError == "" {
+	lastError = m.tunLastError
+}
+if lastError == "" && status.DesiredEnable && status.LiveEnable != nil && !*status.LiveEnable {
+	lastError = "live TUN is off"
+}
+status.LastError = lastError
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+```powershell
+go test ./internal/runtime ./internal/cli ./internal/tui/pages/system ./internal/control/protocol -count=1
+gofmt -l internal/tundetect internal/runtime
+```
+
+预期：测试 PASS；`gofmt -l` 无输出。
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add internal/runtime
+git commit -s -m "fix(tun): Desired/Live 漂移时填充 last_error"
+```
+
+---
+
+### Task 7: 交叉验证
+
+**Files:** 本任务不改生产代码，除非 `gofmt` / 编译缺口。
+
+**Interfaces:**
+- Consumes: Task 1–6
+- Produces: 验证记录（命令已实际跑过）
+
+- [ ] **Step 1: 包测试**
+
+```powershell
+Set-Location D:\modular_dev\mihari\.worktrees\fix-tun-conflict-detect-and-live
+go test ./internal/tundetect ./internal/runtime ./internal/cli ./internal/tui/pages/system ./internal/control/protocol ./internal/integration -count=1
+```
+
+预期：PASS。
+
+- [ ] **Step 2: vet 与格式**
+
+```powershell
+go vet ./internal/tundetect ./internal/runtime
+gofmt -l internal/tundetect internal/runtime
+```
+
+预期：vet 无输出；gofmt 无输出。
+
+- [ ] **Step 3: 无 CGO 编译当前平台**
+
+```powershell
+$env:CGO_ENABLED = '0'
+go build -o bin/mihari-check.exe ./cmd/mihari
+```
+
+预期：成功。不要提交 `bin/`。
+
+- [ ] **Step 4: 不在本 task 提交**，除非 Step 1–3 发现必须修的格式问题。有修则：
+
+```powershell
+git add internal
+git commit -s -m "style(tun): 格式化冲突探测改动"
+```
+
+---
+
+## Spec coverage
+
+| 规格条款 | Task |
+|---|---|
+| `Meta Tunnel` / 别名 `mihomo` 为信号 A | 1 |
+| 展示名 `friendly (desc)` | 1 |
+| 按 PID 扣自身进程 | 2 |
+| live 未起来不删别人网卡 | 2 |
+| 按 device 名扣自身网卡 | 2、3 |
+| 盲删顺序导致漏门控 | 3 |
+| PATCH 失败不可吞 | 4 |
+| Enable 后 live 核对 + 回滚 | 5 |
+| Force 不跳过 live 核对 | 5 |
+| controller 读不到不算成功 | 5 |
+| `last_error` | 6 |
+| 不改 `/v1` 键、不杀进程、不双 TUN | 全局约束 |
+
+## Type consistency
+
+- `tundetect.Process` / `tundetect.Self` / `Classify(Detection, Self)` 在 Task 2 定义，Task 3 使用。
+- 协议仍是 `[]string` `other_mihomo_processes`，格式 `name (pid)`。
+- live 失败文案固定为 `TUN did not become live after apply`；漂移兜底为 `live TUN is off`。

--- a/docs/superpowers/specs/2026-08-17-tun-conflict-detect-and-live-design.md
+++ b/docs/superpowers/specs/2026-08-17-tun-conflict-detect-and-live-design.md
@@ -1,0 +1,263 @@
+# TUN 冲突探测与 Live 校验设计
+
+日期：2026-08-17
+状态：待审核
+Issue：https://github.com/mihari-proxy/mihari/issues/91
+目标分支：`fix/tun-conflict-detect-and-live`
+工作目录：`.worktrees/fix-tun-conflict-detect-and-live`
+
+## 1. 背景
+
+Windows 上 Sparkle（以及同类 mihomo GUI）开启 TUN 后，Mihari System 页出现两组错误观感：
+
+1. **认不出别人的 TUN。** TUI 只显示 `N other mihomo`，没有 `Conflict · N TUN`。Enable 不走 `CodeTunConflict`。
+2. **Enable 像成功，内核其实没开起来。** 界面为 `Desired On · Live Off · Active · gVisor`。磁盘 `mihari.yaml` 与 `runtime/config.yaml` 都是 `tun.enable: true`，但本实例 `GET /configs` 的 `tun.enable` 是 `false`。
+
+2026-08-17 在 v0.7.3 服务模式（elevated）上的只读现场：
+
+| 对象 | 值 |
+|---|---|
+| Sparkle 网卡别名 | `mihomo` |
+| `GetAdaptersAddresses` 描述 / ifDesc | `Meta Tunnel` |
+| 驱动 | `wintun.sys`（描述 `Wintun Userspace Tunnel`） |
+| 地址 | `198.18.0.1/30` |
+| 默认路由 | `0.0.0.0/0 → 198.18.0.2`（metric 0） |
+| Sparkle 内核 | `mihomo-alpha.exe`（用户会话） |
+| Mihari 内核 | `mihomo.exe`（Services，听 `127.0.0.1:9090` / `9190`） |
+| Mihari 现场 tun | `enable:false`，`device:""`，`stack:gVisor`，`auto-route:true`，`inet4-address:[198.18.0.1/30]` |
+
+`/30` 是点对点假 IP 前缀，不是 TCP 端口：`198.18.0.1` 为本端，`198.18.0.2` 为对端网关。`198.18.0.0/15` 是 Clash/mihomo 常用 Fake-IP 段。两家默认抢同一段地址和同一条默认路由，第二个必然失败。
+
+代码上的三处断裂：
+
+1. `internal/tundetect/tundetect_windows.go` 的 `isWintun` 只认 Description / FriendlyName 含 `wintun`。现代 mihomo/Sparkle 把隧道类型写成 `Meta Tunnel`、别名写成 `mihomo`，两个字段都不含 `wintun`。驱动描述在 `GetAdaptersAddresses` 里根本看不到。
+2. `Classify` 对网卡和进程都按切片第一项盲删「自身」。Toolhelp 顺序不稳定：现场曾把 Sparkle 的 `mihomo-alpha.exe` 当 self 删掉，把本实例 `mihomo.exe` 标成 other。
+3. `applyTun` 只要 regenerate/reload 或 PATCH 任一 HTTP 成功就返回 nil，不读 live。服务模式下 mihomo stdout/stderr 被丢弃；`buildTunStatus` 的 `lastError` 实参恒为 `""`。用户看不到失败。
+
+既有门控契约仍然成立，只是信号 A 喂不进去：Enable 仅在 `OtherTunInterfaces` 非空且非 force 时拒绝；Disable 永不门控；检测失败不得阻塞 Enable。
+
+## 2. 目标
+
+- Windows 把 Sparkle/mihomo 这种 `Meta Tunnel` + 别名 `mihomo` 的 Wintun 网卡识别为信号 A。
+- `Classify` 按本实例内核 PID、以及（当 live 且知道设备名时）网卡名扣除自身，不再按列表位置盲删。
+- Enable 在 persist 成功后必须确认 live `tun.enable` 与请求一致；不一致则回滚 Desired，并返回可映射的错误。
+- `GET /v1/tun` 在 apply 失败或 Desired/Live 漂移时填写已有的 `last_error`（加法，不改 schema）。
+- TUI/CLI 继续用现有分情形文案：信号 A 出现后显示 `Conflict · N TUN` 并走 force 确认。
+- 保持 `CGO_ENABLED=0`，不改 `/v1` 既有字段语义，不杀外部进程，不把两个 `auto-route` TUN 做成共存。
+
+## 3. 非目标
+
+- 不给 Mihari 换独立 `device` / `inet4-address` 来和 Sparkle 同时 `auto-route`。同一主机只允许一个 TUN 所有者。
+- 不把 `Sparkle.exe` / `clash.exe` 等 GUI 进程名扩进信号 B。信号 B 仍只匹配映像名含 `mihomo` 的内核；GUI 有无 TUN 以网卡为准。
+- 不安装或随包分发 `wintun.dll`。本次失败是地址/路由冲突，不是缺驱动。
+- 不改 Linux `tun_flags`、macOS `utun` 的枚举规则。Unix 只跟进 Classify 的身份扣除。
+- 不新增协议版本，不改 `CodeTunConflict` 的 message，不加 TCP 控制面。
+- 不自动关闭别人的 TUN，不在 force 之后改路由表去拆别人的默认路由。
+- 不把 mihomo / 系统错误原文、controller secret、订阅 URL 写入 `last_error`、日志或 TUI。
+
+## 4. 方案比较
+
+### 4.1 采用：收紧分类器 + 按身份扣除 + Enable 后核对 live
+
+三处最小修补对准三处断裂，不改「谁拥有 TUN」的产品规则：
+
+- 探测仍只观察，不写入。
+- 门控仍只看信号 A。
+- 本实例 live 未起来时，别人的网卡全部算 other（当前现场 Desired On / Live Off，正该拦住下一次 Enable）。
+- Enable 成功的定义从「HTTP 没报错」改成「live 与请求一致」。
+
+能复用现有 `CodeTunConflict`、force 确认、`TunStatus.LastError`、TUI `tunConflictLabel`。
+
+### 4.2 不采用：只靠换 `device` / `198.18.0.5/30` 做成双 TUN
+
+能避开 IP 冲突，避不开 `0.0.0.0/0`。两个 `auto-route: true` 仍会抢默认路由或成环。用户已确认这种情况只保留一个所有者。
+
+### 4.3 不采用：把所有 `IfType=53` 虚拟网卡都当 TUN
+
+会把 Hyper-V、部分企业 VPN、无关虚拟 NIC 算进信号 A，误拦 Enable。分类必须落在 Wintun/mihomo 家族的名字与隧道类型上。
+
+### 4.4 不采用：检测失败也改成硬失败
+
+与现有设计决策相反：检测 best-effort，失败视为无证据，不得让不透明的枚举错误挡住合法 Enable。本次保持。
+
+## 5. 详细设计
+
+### 5.1 Windows 信号 A：`isWindowsTunAdapter`
+
+`enumerateWintunAdapters` 继续走 `GetAdaptersAddresses`。展示名优先 FriendlyName，空则用 Description；若两者都非空且不忽略大小写相等，格式为 `friendly (desc)`，例如 `mihomo (Meta Tunnel)`。
+
+新增可单测的纯函数（无 syscall）：
+
+```go
+func isWindowsTunAdapter(desc, friendly string) bool
+```
+
+判定（大小写不敏感）：
+
+1. `desc` 或 `friendly` 包含 `wintun`、`meta tunnel`、`wireguard` 之一；或
+2. trim 后的 `friendly` 或 `desc` 等于 `mihomo` 或 `meta`。
+
+不匹配：普通以太网、WLAN、蓝牙、`TAP-Windows`、深信服 VNIC、网易 UU TAP。这些名字不含上述针，也不等于 `mihomo`/`meta`。
+
+`isWintun` 删除或改成对 `isWindowsTunAdapter` 的别名，避免两套规则。
+
+不在本阶段用 SetupAPI 读 `SWD\Wintun` 硬件 ID。名字规则覆盖已证实的 Sparkle/mihomo 现场，且可在无网卡的单元测试里钉死。
+
+Linux / Darwin 枚举函数保持不变。
+
+### 5.2 Detection 与 Classify 按身份扣除
+
+`Detection` 的进程列表改为带 PID 的结构，避免再解析 `"name (pid)"`：
+
+```go
+type Process struct {
+    Name string
+    PID  int
+}
+
+type Detection struct {
+    TunInterfaces   []string
+    MihomoProcesses []Process
+}
+
+type Self struct {
+    TunActive bool
+    TunName   string // live 且 /configs.tun.device 非空时使用；否则空
+    CorePID   int    // supervisor 观察到的本实例 mihomo PID；未知则为 0
+}
+
+func Classify(d Detection, self Self) *protocol.TunConflict
+```
+
+扣除规则：
+
+| 集合 | 条件 | 行为 |
+|---|---|---|
+| 网卡 | `self.TunActive && self.TunName != ""` | 删除**名字相等**的一项（展示名或 `friendly` 前缀，见下） |
+| 网卡 | `self.TunActive && self.TunName == ""` | 与现在一样删除恰好一项（名字未知时只能保守少算自身） |
+| 网卡 | `!self.TunActive` | 不删。本实例没占网卡，列表里每张都是别人的 |
+| 进程 | `self.CorePID != 0` | 删除 PID 相等的一项 |
+| 进程 | `self.CorePID == 0` | 不删。信号 B 不门控，多报一个自身可以接受 |
+
+网卡名比较：先对展示字符串做相等（忽略大小写）；若展示串是 `alias (desc)` 而 `TunName` 只是 alias 或只是 desc，也算命中。`TunName` 来自本实例 `GET /configs` 的 `tun.device`；空字符串表示未知，走「删一项」回退。
+
+协议层 `TunConflict.OtherMihomoProcesses` 仍是 `[]string`，格式保持 `mihomo-alpha.exe (11220)`。不改 JSON 键。
+
+`Manager.detectTunConflict` 组装 `Self`：
+
+- `TunActive` = 现有 `selfTunLiveActive`
+- `TunName` = live configs 的 `tun.device`（若有且为 string）
+- `CorePID` = `m.store.Load().Core.PID`（core 未上报则为 0）
+
+FakeBackend / 集成测试同步改 `Detection.MihomoProcesses` 类型。
+
+### 5.3 Enable 后核对 live
+
+`mutateTun` 在 `applyTun` 返回 nil 之后：
+
+1. 再读 `liveTunEnable`。
+2. 若请求 `enable==true` 且 `!(ok && live)`：把 settings 回滚到 `previousTun` 并 persist（沿用现有失败回滚）；best-effort 再 `applyTun(previousTun)` 把运行配置拉回（忽略这次二次 apply 的 live 核对，避免递归）；返回
+
+   ```text
+   code    = upstream_failure
+   message = "TUN did not become live after apply"
+   ```
+
+3. 若请求 `enable==false`，不因 live 仍为 true 而失败。Disable 的不对称保持：拆自己的 desired 不得被别人的网卡或内核迟滞挡住。
+4. `applyTun` 若同时做了 regenerate 与 PATCH，**PATCH 失败必须返回错误**，不得再被 `regenerated==true` 吞掉。Reload 已把文件打进内核后 PATCH 又失败，以 PATCH 为准并走同一套 settings 回滚。
+
+不新增错误码。`CodeUpstreamFailure` 已有 CLI/TUI 映射。`mapTunApplyError` 继续把权限类失败映射为 `CodePermissionDenied`。
+
+Force 只绕过信号 A 门控，**不**绕过 live 核对。Force 之后内核仍然开不起来（地址已被别人占用）时，用户应看到 apply 失败，而不是 Desired On / Live Off。
+
+### 5.4 `last_error` 填充
+
+`TunStatus.LastError` 字段已存在且 `omitempty`，只是生产路径从未赋值。
+
+`Manager` 增加进程内 `tunLastError string`（不落盘，不进 `/v1` 以外的持久化）：
+
+- apply / live 核对失败：写入净化后的 `APIError.Message`。
+- Enable/Disable 成功且 live 与请求一致：清空。
+- `buildTunStatus` 优先用这次调用传入的错误；空则用 `tunLastError`。
+- 若 Desired On 且 live 明确为 false，且 `tunLastError` 仍空（例如进程重启后内存没了），填稳定文案 `live TUN is off`。不得把 configs 原文塞进去。
+
+CLI `mihari tun status` 已打印 `LastError:`。TUI TUN 详情 `tunDetailText` 已有 `Last error` 行。本次只保证 daemon 填值，不改文案键。
+
+### 5.5 产品语义（与用户已确认的处理方式一致）
+
+- 同一时刻只应有一个 TUN + `auto-route` 所有者。
+- 别人先占了 `198.18.0.1/30` 和默认路由时：非 force 的 Enable 应在门控处失败（信号 A）；若检测仍漏网，live 核对必须失败并回滚 Desired。
+- 用户若继续用 Sparkle：在 Mihari 里 Disable TUN。
+- 用户若改用 Mihari：先关 Sparkle TUN，再 Enable。
+- 两个内核可以并存（不同 mixed-port），但不能两个都开 TUN。
+
+### 5.6 安全与平台
+
+- 展示名、进程基名、PID 可以进 conflict details；完整路径、命令行、订阅 URL、secret 不行。
+- 枚举继续 best-effort：`Detect` 出错则 `Conflict==nil`，Enable 不因此失败。
+- Windows 实现留在 `tundetect_windows.go`；分类纯函数可放同文件或 `classify_windows.go`，由 `_test.go` 无构建标签测试（纯字符串，不需要 windows 构建）。为让 `go test` 在非 Windows 上也能跑分类器，把 `isWindowsTunAdapter` 放进无构建标签的 `adapter_windows_names.go`（仅字符串，无 syscall）或直接放 `classify.go` 旁的 `windows_names.go`。
+- 发布构建保持 `CGO_ENABLED=0`。
+
+## 6. 测试要点
+
+必须用 `t.TempDir()` / fake controller / FakeBackend，禁止公网、真实用户目录、真实 Sparkle/mihomo。
+
+| 行为 | 包 | 断言 |
+|---|---|---|
+| `Meta Tunnel` + 别名 `mihomo` 为 TUN | `tundetect` | `isWindowsTunAdapter` true |
+| `Wintun Userspace Tunnel` 仍为 TUN | `tundetect` | true |
+| WLAN / TAP-Windows / 深信服 VNIC 不是 TUN | `tundetect` | false |
+| 展示名 `mihomo (Meta Tunnel)` | `tundetect` | 格式函数单测 |
+| 按 PID 扣除自身，保留另一个 pid | `tundetect` | `OtherMihomoProcesses` 只含 other |
+| live 未起来时不删任何网卡 | `tundetect` | Sparkle 网卡留在 OtherTun |
+| live + 已知 device 时只删匹配名 | `tundetect` | 自身 `Meta` 去掉，`mihomo (Meta Tunnel)` 留下 |
+| 信号 A 出现则 Enable 门控 | `runtime` | `CodeTunConflict`，无 PATCH |
+| 信号 B 单独不门控 | `runtime` | 现有测试改成结构化 Process |
+| Enable 后 live 仍 false 则回滚 | `runtime` | Desired 回 false，返回 `upstream_failure`，settings 无 enable true |
+| PATCH 失败即使 reload 成功也失败 | `runtime` | 回滚，不把 Desired 留下 |
+| 检测错误不门控 | `runtime` | 保持现有 |
+| status 在 Desired On / Live Off 带 last_error | `runtime` | `LastError` 非空 |
+| 协议 JSON 仍无新键 | `protocol` | 现有 round-trip 保持；`last_error` 有值时出现 |
+
+不在默认 `go test ./...` 里打真实网卡或真实服务。
+
+## 7. Key Decisions
+
+1. **同一主机一个 TUN 所有者。** 不靠换 `/30` 做成双栈共存；`auto-route` 默认路由只能有一条。
+2. **信号 A 按 mihomo/Wintun 家族名字认网卡，不按「所有虚拟 NIC」。** 覆盖 `Meta Tunnel` / 别名 `mihomo`，排除 TAP 与企业 VPN。
+3. **自身扣除按 PID 与网卡名，不按切片位置。** 修掉「把本实例标成 other」的现场。
+4. **Enable 成功 = live 已变为 true。** HTTP 成功但 live 仍 false 必须回滚 Desired。Force 只绕过冲突门控。
+5. **PATCH 失败不可被 regenerate 成功掩盖。** 现场 Desired/Live 分裂的直接原因之一。
+6. **`last_error` 只填净化短句，沿用已有字段。** 不新开协议版本，不落盘。
+7. **不把 GUI 进程名扩进信号 B。** 避免 Sparkle 仅开窗口、未开 TUN 时误报；TUN 以网卡为准。
+
+## 8. 风险与回滚
+
+- 名字规则可能漏掉尚未见到的隧道类型（例如只叫 `Clash` 的网卡）。漏检时 live 核对仍是第二道闸。新增针要加表驱动测试。
+- 别名恰好叫 `meta` 的无关网卡会被当成 TUN。概率低；若出现再收紧到 `IfType==53` 且组合判断。
+- live 核对依赖 controller。controller 不可用时 `liveTunEnable` 读不到，Enable 应按「未证实 live」失败并回滚，而不是当成成功。
+- 回滚二次 `applyTun(previous)` 是 best-effort：失败只记 `last_error`，不得掩盖第一次的 `TUN did not become live`。
+
+回滚本功能：还原 `tundetect` 分类与 `runtime/tun.go` 的 apply 语义即可，无持久化格式变更。
+
+## 9. PR Plan
+
+### PR 1 — 探测与 Classify 身份扣除
+
+- 标题：`fix(tundetect): 识别 Meta Tunnel 并按 PID 扣除自身`
+- 文件：`internal/tundetect/*`，以及 FakeBackend 调用方的类型适配（`internal/runtime/tun_test.go`、`internal/integration/sysproxy_tun_test.go`）
+- 依赖：无
+- 内容：Windows 名字分类、展示名格式、`Detection.Process`、`Classify(Self)`。门控与 apply 语义先不动，只让信号 A 在测试里能喂到现有 gate。
+
+### PR 2 — Enable live 核对与 last_error
+
+- 标题：`fix(tun): Enable 后核对 live 并回填 last_error`
+- 文件：`internal/runtime/tun.go`、`internal/runtime/tun_test.go`、必要时 `internal/cli/tun_test.go`、`internal/tui/pages/system` 仅当详情行缺 LastError 断言
+- 依赖：PR 1（`Self` / 结构化 Detection）
+- 内容：PATCH 失败不可吞；live 不一致回滚；status 填 `last_error`。
+
+可以在同一分支连续提交，按两个 commit 对应上述 PR 边界，便于审查。合并回 `main` 走一条 PR 也可以，但 commit 必须拆开。
+
+## 10. Open Questions
+
+无。产品选择（单所有者、不换地址共存、force 不跳过 live 核对）已在调查对话中确认。实现期若发现必须用 `IfType` 才能排除误报，作为 PR 1 内的测试驱动收紧，不升协议版本。

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -146,6 +146,7 @@ type Manager struct {
 	serviceStatus     func() (string, error)
 	onBackgroundError func(component string, err error)
 	settingsMu        sync.Mutex
+	tunLastError      string
 	maintenance       chan struct{}
 	installed         chan struct{}
 	closing           atomic.Bool

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -1071,6 +1071,13 @@ type fakeController struct {
 	patchConfigs           func(context.Context, map[string]any) error
 	lastPatch              map[string]any
 	patchCalls             int
+	reloads                int
+	reloadErr              error
+}
+
+func (c *fakeController) Reload(context.Context, string, bool) error {
+	c.reloads++
+	return c.reloadErr
 }
 
 type controllerCall struct {

--- a/internal/runtime/tun.go
+++ b/internal/runtime/tun.go
@@ -295,19 +295,31 @@ func (m *Manager) detectTunConflict(ctx context.Context) *protocol.TunConflict {
 	if err != nil {
 		return nil
 	}
-	return tundetect.Classify(detection, tundetect.Self{TunActive: m.selfTunLiveActive(ctx)})
+	return tundetect.Classify(detection, m.selfFromLive(ctx))
 }
 
-// selfTunLiveActive reports whether mihomo's live tun.enable is true, so Classify
-// subtracts this daemon's own TUN adapter from the detected set.
-func (m *Manager) selfTunLiveActive(ctx context.Context) bool {
-	if m.controller == nil {
-		return false
+// selfFromLive builds the Classify identity from the running core PID and live
+// tun.enable / tun.device. Detection failures stay best-effort: a missing
+// controller or unreadable configs leave TunActive false so no adapter is
+// subtracted.
+func (m *Manager) selfFromLive(ctx context.Context) tundetect.Self {
+	self := tundetect.Self{CorePID: m.store.Load().Core.PID}
+	if m.controller == nil || ctx.Err() != nil {
+		return self
 	}
 	configs, err := m.controller.Configs(ctx)
 	if err != nil {
-		return false
+		return self
 	}
-	live, ok := liveTunEnable(configs)
-	return ok && live
+	if live, ok := liveTunEnable(configs); ok && live {
+		self.TunActive = true
+		self.TunName = liveTunDevice(configs)
+	}
+	return self
+}
+
+func liveTunDevice(configs map[string]any) string {
+	raw, _ := configs["tun"].(map[string]any)
+	device, _ := raw["device"].(string)
+	return strings.TrimSpace(device)
 }

--- a/internal/runtime/tun.go
+++ b/internal/runtime/tun.go
@@ -295,7 +295,7 @@ func (m *Manager) detectTunConflict(ctx context.Context) *protocol.TunConflict {
 	if err != nil {
 		return nil
 	}
-	return tundetect.Classify(detection, m.selfTunLiveActive(ctx))
+	return tundetect.Classify(detection, tundetect.Self{TunActive: m.selfTunLiveActive(ctx)})
 }
 
 // selfTunLiveActive reports whether mihomo's live tun.enable is true, so Classify

--- a/internal/runtime/tun.go
+++ b/internal/runtime/tun.go
@@ -104,6 +104,30 @@ func (m *Manager) mutateTun(ctx context.Context, op Operation, enable bool, forc
 		return protocol.TunStatus{}, mapped
 	}
 
+	if enable {
+		live, ok := false, false
+		if m.controller != nil && ctx.Err() == nil {
+			if configs, cfgErr := m.controller.Configs(ctx); cfgErr == nil {
+				live, ok = liveTunEnable(configs)
+			}
+		}
+		if !(ok && live) {
+			m.settingsMu.Lock()
+			m.settings.Tun = previousTun
+			_ = m.persistSettings()
+			m.settingsMu.Unlock()
+			if len(previousTun) > 0 {
+				if applyBackErr := m.applyTun(ctx, previousTun); applyBackErr != nil {
+					_ = applyBackErr // best-effort restore; first failure is still returned
+				}
+			}
+			return protocol.TunStatus{}, protocol.APIError{
+				Code:    protocol.CodeUpstreamFailure,
+				Message: "TUN did not become live after apply",
+			}
+		}
+	}
+
 	_, err := m.coordinator.Do(ctx, state.CommandMeta{
 		ID: op.ID, Source: op.Source, IfRevision: op.IfRevision,
 	}, func(snapshot state.Snapshot) (state.Snapshot, error) {
@@ -138,7 +162,7 @@ func (m *Manager) applyTun(ctx context.Context, nextTun map[string]any) error {
 	}
 
 	patched := false
-	if m.controller != nil {
+	if m.controller != nil && nextTun != nil {
 		if err := m.controller.PatchConfigs(ctx, map[string]any{"tun": nextTun}); err != nil {
 			patchErr = err
 		} else {

--- a/internal/runtime/tun.go
+++ b/internal/runtime/tun.go
@@ -146,11 +146,11 @@ func (m *Manager) applyTun(ctx context.Context, nextTun map[string]any) error {
 		}
 	}
 
-	if regenerated || patched {
-		return nil
-	}
 	if patchErr != nil {
 		return patchErr
+	}
+	if regenerated || patched {
+		return nil
 	}
 	if regenerateErr != nil {
 		return regenerateErr

--- a/internal/runtime/tun.go
+++ b/internal/runtime/tun.go
@@ -96,11 +96,12 @@ func (m *Manager) mutateTun(ctx context.Context, op Operation, enable bool, forc
 	}
 
 	if applyErr := m.applyTun(ctx, nextTun); applyErr != nil {
+		mapped := mapTunApplyError(applyErr)
 		m.settingsMu.Lock()
 		m.settings.Tun = previousTun
 		_ = m.persistSettings()
+		m.tunLastError = tunErrorMessage(mapped)
 		m.settingsMu.Unlock()
-		mapped := mapTunApplyError(applyErr)
 		return protocol.TunStatus{}, mapped
 	}
 
@@ -115,6 +116,7 @@ func (m *Manager) mutateTun(ctx context.Context, op Operation, enable bool, forc
 			m.settingsMu.Lock()
 			m.settings.Tun = previousTun
 			_ = m.persistSettings()
+			m.tunLastError = "TUN did not become live after apply"
 			m.settingsMu.Unlock()
 			if len(previousTun) > 0 {
 				if applyBackErr := m.applyTun(ctx, previousTun); applyBackErr != nil {
@@ -127,6 +129,10 @@ func (m *Manager) mutateTun(ctx context.Context, op Operation, enable bool, forc
 			}
 		}
 	}
+
+	m.settingsMu.Lock()
+	m.tunLastError = ""
+	m.settingsMu.Unlock()
 
 	_, err := m.coordinator.Do(ctx, state.CommandMeta{
 		ID: op.ID, Source: op.Source, IfRevision: op.IfRevision,
@@ -188,6 +194,9 @@ func (m *Manager) applyTun(ctx context.Context, nextTun map[string]any) error {
 func (m *Manager) buildTunStatus(ctx context.Context, lastError string) protocol.TunStatus {
 	m.settingsMu.Lock()
 	tun := cloneTunMap(m.settings.Tun)
+	if lastError == "" {
+		lastError = m.tunLastError
+	}
 	m.settingsMu.Unlock()
 
 	status := protocol.TunStatus{
@@ -196,26 +205,23 @@ func (m *Manager) buildTunStatus(ctx context.Context, lastError string) protocol
 		DesiredEnable: tunDesiredEnable(tun),
 		Managed:       len(tun) > 0,
 		Stack:         tunStack(tun),
-		LastError:     lastError,
 	}
 	// Conflict evidence is always surfaced (even when only corroborating signal B is
 	// present) so status/CLI/TUI can display it; the enable gate keys off
 	// OtherTunInterfaces alone.
 	status.Conflict = m.detectTunConflict(ctx)
 
-	if m.controller == nil {
-		return status
+	if m.controller != nil && ctx.Err() == nil {
+		if configs, err := m.controller.Configs(ctx); err == nil {
+			if live, ok := liveTunEnable(configs); ok {
+				status.LiveEnable = &live
+			}
+		}
 	}
-	if err := ctx.Err(); err != nil {
-		return status
+	if lastError == "" && status.DesiredEnable && status.LiveEnable != nil && !*status.LiveEnable {
+		lastError = "live TUN is off"
 	}
-	configs, err := m.controller.Configs(ctx)
-	if err != nil {
-		return status
-	}
-	if live, ok := liveTunEnable(configs); ok {
-		status.LiveEnable = &live
-	}
+	status.LastError = lastError
 	return status
 }
 
@@ -271,6 +277,14 @@ func liveTunEnable(configs map[string]any) (bool, bool) {
 		return false, false
 	}
 	return enable, true
+}
+
+func tunErrorMessage(err error) string {
+	var api protocol.APIError
+	if errors.As(err, &api) {
+		return api.Message
+	}
+	return ""
 }
 
 func mapTunApplyError(err error) error {

--- a/internal/runtime/tun_test.go
+++ b/internal/runtime/tun_test.go
@@ -315,7 +315,7 @@ func TestEnableTunForceOverridesConflict(t *testing.T) {
 func TestEnableTunIgnoresOtherMihomoWithoutTun(t *testing.T) {
 	controller := &fakeController{configs: map[string]any{}}
 	manager := newTunManagerWithDetect(t, controller, defaultTunSettings(nil), &tundetect.FakeBackend{
-		Detection: tundetect.Detection{MihomoProcesses: []string{"mihomo (123)", "mihomo (456)"}},
+		Detection: tundetect.Detection{MihomoProcesses: []tundetect.Process{{Name: "mihomo", PID: 123}, {Name: "mihomo", PID: 456}}},
 	})
 
 	status, err := manager.EnableTun(context.Background(), Operation{ID: "tun-mihomo", Source: "test"}, false)

--- a/internal/runtime/tun_test.go
+++ b/internal/runtime/tun_test.go
@@ -287,6 +287,42 @@ func TestEnableTunFailsWhenConfigsUnreadableAfterApply(t *testing.T) {
 	}
 }
 
+func TestTunStatusLastErrorWhenDesiredOnLiveOff(t *testing.T) {
+	live := false
+	controller := &fakeController{configs: map[string]any{
+		"tun": map[string]any{"enable": live, "stack": "gVisor"},
+	}}
+	manager := newTunManager(t, controller, defaultTunSettings(map[string]any{
+		"enable": true, "stack": "gVisor",
+	}))
+	status, err := manager.TunStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.LastError != "live TUN is off" {
+		t.Fatalf("LastError=%q", status.LastError)
+	}
+}
+
+func TestEnableTunFailurePersistsLastErrorOnStatus(t *testing.T) {
+	controller := &fakeController{
+		configs:      map[string]any{"tun": map[string]any{"enable": false}},
+		patchConfigs: func(context.Context, map[string]any) error { return nil },
+	}
+	manager := newTunManager(t, controller, defaultTunSettings(nil))
+	_, _ = manager.EnableTun(context.Background(), Operation{ID: "tun-err", Source: "test"}, false)
+	status, err := manager.TunStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.LastError != "TUN did not become live after apply" {
+		t.Fatalf("LastError=%q", status.LastError)
+	}
+	if status.DesiredEnable {
+		t.Fatal("desired should stay off after failed enable")
+	}
+}
+
 func TestEnableTunMapsPermissionErrors(t *testing.T) {
 	controller := &fakeController{
 		patchConfigs: func(context.Context, map[string]any) error {

--- a/internal/runtime/tun_test.go
+++ b/internal/runtime/tun_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mihari-proxy/mihari/internal/config"
 	"github.com/mihari-proxy/mihari/internal/control/protocol"
 	"github.com/mihari-proxy/mihari/internal/state"
+	"github.com/mihari-proxy/mihari/internal/subscription"
 	"github.com/mihari-proxy/mihari/internal/tundetect"
 )
 
@@ -188,6 +189,48 @@ func TestEnableTunRollsBackSettingsWhenApplyFails(t *testing.T) {
 	}
 	if len(loaded.Tun) != 0 {
 		t.Fatalf("persisted tun after rollback=%#v", loaded.Tun)
+	}
+}
+
+func TestApplyTunReturnsPatchErrorEvenIfReloadSucceeded(t *testing.T) {
+	root := t.TempDir()
+	controller := &fakeController{
+		configs: map[string]any{},
+		patchConfigs: func(context.Context, map[string]any) error {
+			return protocol.APIError{Code: protocol.CodeUpstreamFailure, Message: "patch tun rejected"}
+		},
+	}
+	subs, err := subscription.Open(subscription.ServiceOptions{
+		CatalogPath: filepath.Join(root, "catalog.yaml"),
+		CacheDir:    filepath.Join(root, "cache"),
+		ProxyAddr:   "127.0.0.1:9190",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	settings := defaultTunSettings(nil)
+	settingsPath := filepath.Join(root, "settings.yaml")
+	if err := config.Save(settingsPath, settings); err != nil {
+		t.Fatal(err)
+	}
+	manager := newTestManager(Options{
+		Controller:    controller,
+		SettingsPath:  settingsPath,
+		Settings:      settings,
+		Subscriptions: subs,
+		RuntimeConfig: filepath.Join(root, "runtime", "config.yaml"),
+		StagingDir:    filepath.Join(root, "staging"),
+	})
+	_, err = manager.EnableTun(context.Background(), Operation{ID: "tun-patch-fail", Source: "test"}, false)
+	if err == nil {
+		t.Fatal("expected patch error")
+	}
+	loaded, loadErr := config.Load(settingsPath)
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if tunDesiredEnable(loaded.Tun) {
+		t.Fatalf("desired must roll back, tun=%#v", loaded.Tun)
 	}
 }
 

--- a/internal/runtime/tun_test.go
+++ b/internal/runtime/tun_test.go
@@ -234,6 +234,59 @@ func TestApplyTunReturnsPatchErrorEvenIfReloadSucceeded(t *testing.T) {
 	}
 }
 
+func TestEnableTunRollsBackWhenLiveStaysOff(t *testing.T) {
+	controller := &fakeController{
+		configs: map[string]any{"tun": map[string]any{"enable": false, "stack": "gVisor"}},
+		patchConfigs: func(context.Context, map[string]any) error {
+			return nil
+		},
+	}
+	manager := newTunManager(t, controller, defaultTunSettings(nil))
+	_, err := manager.EnableTun(context.Background(), Operation{ID: "tun-live-off", Source: "test"}, false)
+	var apiError protocol.APIError
+	if !errors.As(err, &apiError) || apiError.Code != protocol.CodeUpstreamFailure {
+		t.Fatalf("err=%v", err)
+	}
+	if apiError.Message != "TUN did not become live after apply" {
+		t.Fatalf("message=%q", apiError.Message)
+	}
+	loaded, err := config.Load(manager.settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tunDesiredEnable(loaded.Tun) {
+		t.Fatalf("desired rolled back? tun=%#v", loaded.Tun)
+	}
+}
+
+func TestEnableTunForceStillRequiresLive(t *testing.T) {
+	controller := &fakeController{
+		configs:      map[string]any{"tun": map[string]any{"enable": false}},
+		patchConfigs: func(context.Context, map[string]any) error { return nil },
+	}
+	manager := newTunManagerWithDetect(t, controller, defaultTunSettings(nil), &tundetect.FakeBackend{
+		Detection: tundetect.Detection{TunInterfaces: []string{"mihomo (Meta Tunnel)"}},
+	})
+	_, err := manager.EnableTun(context.Background(), Operation{ID: "tun-force-live", Source: "test"}, true)
+	var apiError protocol.APIError
+	if !errors.As(err, &apiError) || apiError.Code != protocol.CodeUpstreamFailure {
+		t.Fatalf("force must not skip live check, err=%v", err)
+	}
+}
+
+func TestEnableTunFailsWhenConfigsUnreadableAfterApply(t *testing.T) {
+	controller := &fakeController{
+		configs:    map[string]any{},
+		configsErr: protocol.APIError{Code: protocol.CodeUpstreamFailure, Message: "mihomo controller is unavailable"},
+	}
+	// patchConfigs 默认会写 configs，但随后 Configs 返回 err
+	manager := newTunManager(t, controller, defaultTunSettings(nil))
+	_, err := manager.EnableTun(context.Background(), Operation{ID: "tun-unread", Source: "test"}, false)
+	if err == nil {
+		t.Fatal("unread live must not count as success")
+	}
+}
+
 func TestEnableTunMapsPermissionErrors(t *testing.T) {
 	controller := &fakeController{
 		patchConfigs: func(context.Context, map[string]any) error {

--- a/internal/runtime/tun_test.go
+++ b/internal/runtime/tun_test.go
@@ -355,15 +355,19 @@ func TestDisableTunNotGatedByConflict(t *testing.T) {
 }
 
 // TestEnableTunSubtractsSelfWhenLiveActive 验证决策 3 的端到端：mihomo 自身已开 TUN
-// （live tun.enable=true）且检测到的唯一 TUN 网卡就是自身那一个时，Classify 扣除自身后
-// 无其他 TUN → enable 不被门控。覆盖 selfTunLiveActive 从 live configs 读取的链路。
+// （live tun.enable=true）且检测到的唯一 TUN 网卡就是自身那一个时，Classify 按 live
+// device 与 core PID 扣除自身后无其他 TUN → enable 不被门控。覆盖 selfFromLive。
 func TestEnableTunSubtractsSelfWhenLiveActive(t *testing.T) {
 	controller := &fakeController{configs: map[string]any{
-		"tun": map[string]any{"enable": true, "stack": "gVisor"},
+		"tun": map[string]any{"enable": true, "device": "Wintun0", "stack": "gVisor"},
 	}}
 	manager := newTunManagerWithDetect(t, controller, defaultTunSettings(nil), &tundetect.FakeBackend{
-		Detection: tundetect.Detection{TunInterfaces: []string{"Wintun0"}},
+		Detection: tundetect.Detection{
+			TunInterfaces:   []string{"Wintun0"},
+			MihomoProcesses: []tundetect.Process{{Name: "mihomo", PID: 13400}},
+		},
 	})
+	manager.store.Store(state.Snapshot{Health: "ok", Core: state.CoreState{PID: 13400}})
 
 	status, err := manager.EnableTun(context.Background(), Operation{ID: "tun-self", Source: "test"}, false)
 	if err != nil {
@@ -373,6 +377,32 @@ func TestEnableTunSubtractsSelfWhenLiveActive(t *testing.T) {
 		t.Fatalf("status=%#v", status)
 	}
 	if controller.patchCalls != 1 {
+		t.Fatalf("patchCalls=%d", controller.patchCalls)
+	}
+}
+
+// TestEnableTunKeepsForeignAdapterWhenLiveDeviceDiffers 验证按 live device 名扣除自身：
+// Sparkle 网卡排在前面时，盲删 [0] 会删错并放过 Enable；按名扣除 Meta 后必须留下
+// mihomo (Meta Tunnel) 并返回 CodeTunConflict。
+func TestEnableTunKeepsForeignAdapterWhenLiveDeviceDiffers(t *testing.T) {
+	controller := &fakeController{configs: map[string]any{
+		"tun": map[string]any{"enable": true, "device": "Meta", "stack": "gVisor"},
+	}}
+	manager := newTunManagerWithDetect(t, controller, defaultTunSettings(map[string]any{
+		"enable": true, "stack": "gVisor",
+	}), &tundetect.FakeBackend{
+		Detection: tundetect.Detection{TunInterfaces: []string{"mihomo (Meta Tunnel)", "Meta"}},
+	})
+	_, err := manager.EnableTun(context.Background(), Operation{ID: "tun-foreign", Source: "test"}, false)
+	var apiError protocol.APIError
+	if !errors.As(err, &apiError) || apiError.Code != protocol.CodeTunConflict {
+		t.Fatalf("err=%v", err)
+	}
+	names, _ := apiError.Details["other_tun_interfaces"].([]string)
+	if len(names) != 1 || names[0] != "mihomo (Meta Tunnel)" {
+		t.Fatalf("details=%#v", apiError.Details)
+	}
+	if controller.patchCalls != 0 {
 		t.Fatalf("patchCalls=%d", controller.patchCalls)
 	}
 }

--- a/internal/tundetect/classify.go
+++ b/internal/tundetect/classify.go
@@ -1,30 +1,26 @@
 package tundetect
 
-import "github.com/mihari-proxy/mihari/internal/control/protocol"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mihari-proxy/mihari/internal/control/protocol"
+)
 
 // Classify derives conflict evidence from a raw Detection by subtracting this
-// daemon's own TUN adapter (when selfTunActive) and own mihomo process. It
+// daemon's own TUN adapter and own mihomo process as identified by self. It
 // returns nil when no other actor remains, which the runtime treats as "no
 // conflict".
 //
-// Subtraction is positional and best-effort: detection lists are unordered, so
-// one entry is dropped rather than matched by identity. Only the count of
-// *other* actors matters for the gate; on a tie this errs toward caution (it
-// can only over-count by the very own adapter/process we own).
-//
-// TunInterfaces subtraction is gated on selfTunActive: the daemon contributes
-// its own TUN adapter only when mihomo's live tun.enable is true. MihomoProcesses
-// subtraction is unconditional: this daemon always drives at most one mihomo,
-// regardless of TUN state, so that process is always self.
-func Classify(d Detection, selfTunActive bool) *protocol.TunConflict {
-	otherTun := d.TunInterfaces
-	if selfTunActive && len(otherTun) > 0 {
-		otherTun = otherTun[1:]
-	}
-	otherMihomo := d.MihomoProcesses
-	if len(otherMihomo) > 0 {
-		otherMihomo = otherMihomo[1:]
-	}
+// Adapter subtraction is gated on self.TunActive: the daemon occupies a TUN
+// adapter only when mihomo's live tun.enable is true. When TunName is known,
+// the matching listed name is dropped; when it is empty, exactly one entry
+// is dropped (name unknown, so the count is conservative). Process
+// subtraction matches self.CorePID; a zero PID means identity is unknown
+// and nothing is dropped (signal B does not gate enable).
+func Classify(d Detection, self Self) *protocol.TunConflict {
+	otherTun := subtractSelfTun(d.TunInterfaces, self)
+	otherMihomo := formatOtherProcesses(d.MihomoProcesses, self.CorePID)
 	if len(otherTun) == 0 && len(otherMihomo) == 0 {
 		return nil
 	}
@@ -32,4 +28,59 @@ func Classify(d Detection, selfTunActive bool) *protocol.TunConflict {
 		OtherTunInterfaces:   otherTun,
 		OtherMihomoProcesses: otherMihomo,
 	}
+}
+
+func subtractSelfTun(ifaces []string, self Self) []string {
+	if !self.TunActive || len(ifaces) == 0 {
+		return ifaces
+	}
+	if self.TunName == "" {
+		return ifaces[1:]
+	}
+	for i, name := range ifaces {
+		if adapterNameMatch(name, self.TunName) {
+			out := make([]string, 0, len(ifaces)-1)
+			out = append(out, ifaces[:i]...)
+			out = append(out, ifaces[i+1:]...)
+			return out
+		}
+	}
+	return ifaces
+}
+
+func formatOtherProcesses(procs []Process, corePID int) []string {
+	var out []string
+	dropped := false
+	for _, p := range procs {
+		if !dropped && corePID != 0 && p.PID == corePID {
+			dropped = true
+			continue
+		}
+		out = append(out, formatProcess(p))
+	}
+	return out
+}
+
+func formatProcess(p Process) string {
+	return fmt.Sprintf("%s (%d)", p.Name, p.PID)
+}
+
+// adapterNameMatch reports whether a listed adapter display name refers to
+// tunName. Comparison is case-insensitive and accepts formatAdapterName
+// output: exact equality, "tunName (desc)", or "alias (tunName)".
+func adapterNameMatch(listed, tunName string) bool {
+	listed = strings.TrimSpace(listed)
+	tunName = strings.TrimSpace(tunName)
+	if tunName == "" {
+		return false
+	}
+	l := strings.ToLower(listed)
+	n := strings.ToLower(tunName)
+	if l == n {
+		return true
+	}
+	if strings.HasPrefix(l, n+" (") && strings.HasSuffix(l, ")") {
+		return true
+	}
+	return strings.HasSuffix(l, " ("+n+")")
 }

--- a/internal/tundetect/classify_test.go
+++ b/internal/tundetect/classify_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestClassify(t *testing.T) {
 	tests := []struct {
-		name          string
-		detection     Detection
-		selfTunActive bool
-		want          *protocol.TunConflict
+		name      string
+		detection Detection
+		self      Self
+		want      *protocol.TunConflict
 	}{
 		{
 			name:      "empty detection is nil",
@@ -22,17 +22,22 @@ func TestClassify(t *testing.T) {
 		{
 			name: "single mihomo is self, subtracts to nil",
 			detection: Detection{
-				MihomoProcesses: []string{"mihomo"},
+				MihomoProcesses: []Process{{Name: "mihomo", PID: 1}},
 			},
+			self: Self{CorePID: 1},
 			want: nil,
 		},
 		{
 			name: "only other mihomo process (signal B alone)",
 			detection: Detection{
-				MihomoProcesses: []string{"mihomo", "mihomo-other"},
+				MihomoProcesses: []Process{
+					{Name: "mihomo", PID: 1},
+					{Name: "mihomo-other", PID: 2},
+				},
 			},
+			self: Self{CorePID: 1},
 			want: &protocol.TunConflict{
-				OtherMihomoProcesses: []string{"mihomo-other"},
+				OtherMihomoProcesses: []string{"mihomo-other (2)"},
 			},
 		},
 		{
@@ -40,7 +45,7 @@ func TestClassify(t *testing.T) {
 			detection: Detection{
 				TunInterfaces: []string{"wintun-other"},
 			},
-			selfTunActive: false,
+			self: Self{TunActive: false},
 			want: &protocol.TunConflict{
 				OtherTunInterfaces: []string{"wintun-other"},
 			},
@@ -50,7 +55,7 @@ func TestClassify(t *testing.T) {
 			detection: Detection{
 				TunInterfaces: []string{"wintun-self", "wintun-other"},
 			},
-			selfTunActive: true,
+			self: Self{TunActive: true, TunName: "wintun-self"},
 			want: &protocol.TunConflict{
 				OtherTunInterfaces: []string{"wintun-other"},
 			},
@@ -60,28 +65,79 @@ func TestClassify(t *testing.T) {
 			detection: Detection{
 				TunInterfaces: []string{"wintun-self"},
 			},
-			selfTunActive: true,
-			want:          nil,
+			self: Self{TunActive: true, TunName: "wintun-self"},
+			want: nil,
 		},
 		{
 			name: "both signals A and B",
 			detection: Detection{
-				TunInterfaces:   []string{"wintun-self", "wintun-other"},
-				MihomoProcesses: []string{"mihomo", "mihomo-other"},
+				TunInterfaces: []string{"wintun-self", "wintun-other"},
+				MihomoProcesses: []Process{
+					{Name: "mihomo", PID: 1},
+					{Name: "mihomo-other", PID: 2},
+				},
 			},
-			selfTunActive: true,
+			self: Self{TunActive: true, TunName: "wintun-self", CorePID: 1},
 			want: &protocol.TunConflict{
 				OtherTunInterfaces:   []string{"wintun-other"},
-				OtherMihomoProcesses: []string{"mihomo-other"},
+				OtherMihomoProcesses: []string{"mihomo-other (2)"},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := Classify(tt.detection, tt.selfTunActive)
+			got := Classify(tt.detection, tt.self)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Fatalf("got=%#v want=%#v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestClassify_SubtractsByPIDNotPosition(t *testing.T) {
+	got := Classify(Detection{
+		MihomoProcesses: []Process{
+			{Name: "mihomo-alpha.exe", PID: 11220},
+			{Name: "mihomo.exe", PID: 13400},
+		},
+	}, Self{CorePID: 13400})
+	if got == nil || len(got.OtherMihomoProcesses) != 1 || got.OtherMihomoProcesses[0] != "mihomo-alpha.exe (11220)" {
+		t.Fatalf("got=%#v", got)
+	}
+}
+
+func TestClassify_DoesNotDropAdapterWhenSelfInactive(t *testing.T) {
+	got := Classify(Detection{
+		TunInterfaces: []string{"mihomo (Meta Tunnel)"},
+	}, Self{TunActive: false, CorePID: 13400})
+	if got == nil || len(got.OtherTunInterfaces) != 1 || got.OtherTunInterfaces[0] != "mihomo (Meta Tunnel)" {
+		t.Fatalf("got=%#v", got)
+	}
+}
+
+func TestClassify_SubtractsAdapterByName(t *testing.T) {
+	got := Classify(Detection{
+		TunInterfaces: []string{"Meta", "mihomo (Meta Tunnel)"},
+	}, Self{TunActive: true, TunName: "Meta"})
+	if got == nil || len(got.OtherTunInterfaces) != 1 || got.OtherTunInterfaces[0] != "mihomo (Meta Tunnel)" {
+		t.Fatalf("got=%#v", got)
+	}
+}
+
+func TestClassify_UnknownLiveNameDropsOne(t *testing.T) {
+	got := Classify(Detection{
+		TunInterfaces: []string{"Meta"},
+	}, Self{TunActive: true, TunName: ""})
+	if got != nil {
+		t.Fatalf("got=%#v", got)
+	}
+}
+
+func TestClassify_UnknownPIDKeepsAllProcesses(t *testing.T) {
+	got := Classify(Detection{
+		MihomoProcesses: []Process{{Name: "mihomo.exe", PID: 13400}},
+	}, Self{})
+	if got == nil || len(got.OtherMihomoProcesses) != 1 {
+		t.Fatalf("got=%#v", got)
 	}
 }

--- a/internal/tundetect/tundetect.go
+++ b/internal/tundetect/tundetect.go
@@ -4,9 +4,9 @@
 //
 // The package only observes. Detect reports every TUN adapter and every mihomo
 // process on the system without filtering; Classify then subtracts this daemon's
-// own adapter/process using a flag supplied by the runtime layer (which knows
-// mihomo's live TUN state). Keeping detection stateless lets it stay testable
-// and free of runtime dependencies.
+// own adapter/process using a Self identity supplied by the runtime layer
+// (live tun.enable / tun.device and the supervised core PID). Keeping
+// detection stateless lets it stay testable and free of runtime dependencies.
 //
 // Platform backends implement unexported detect:
 //   - Windows: IP adapter table (wintun) + toolhelp process snapshot
@@ -19,15 +19,32 @@ package tundetect
 
 import "context"
 
+// Process is one observed mihomo process. Classify subtracts by PID and
+// formats the remainder as "name (pid)" for the protocol layer.
+type Process struct {
+	Name string
+	PID  int
+}
+
+// Self is this daemon's identity used by Classify to subtract our own
+// adapter and process from a raw Detection.
+type Self struct {
+	// TunActive is true when this daemon's mihomo has live tun.enable.
+	TunActive bool
+	// TunName is live tun.device when known; empty means unknown.
+	TunName string
+	// CorePID is the supervised mihomo PID; zero means unknown.
+	CorePID int
+}
+
 // Detection is the raw, unfiltered system observation. Neither field has this
 // daemon's own adapter/process subtracted; that happens in Classify.
 type Detection struct {
 	// TunInterfaces lists every TUN adapter friendly name on the system
 	// (Windows wintun, Linux tun, macOS utun).
 	TunInterfaces []string
-	// MihomoProcesses lists every mihomo process identifier on the system
-	// (e.g. "mihomo.exe" or "mihomo (4321)").
-	MihomoProcesses []string
+	// MihomoProcesses lists every mihomo process on the system.
+	MihomoProcesses []Process
 }
 
 // Backend is an injectable detection driver for tests and runtime wiring.

--- a/internal/tundetect/tundetect_darwin.go
+++ b/internal/tundetect/tundetect_darwin.go
@@ -5,6 +5,7 @@ package tundetect
 import (
 	"context"
 	"os/exec"
+	"strconv"
 	"strings"
 )
 
@@ -40,21 +41,24 @@ func enumerateDarwinTun(ctx context.Context) ([]string, error) {
 
 // enumerateDarwinMihomo lists mihomo processes via "ps -eo comm=,pid=". The
 // comm column may carry a full path; the trailing field is the pid.
-func enumerateDarwinMihomo(ctx context.Context) ([]string, error) {
+func enumerateDarwinMihomo(ctx context.Context) ([]Process, error) {
 	out, err := exec.CommandContext(ctx, "ps", "-eo", "comm=,pid=").Output()
 	if err != nil {
 		return nil, err
 	}
-	var procs []string
+	var procs []Process
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 		fields := strings.Fields(line)
 		if len(fields) < 2 {
 			continue
 		}
 		comm := fields[0]
-		pid := fields[len(fields)-1]
+		pid, err := strconv.Atoi(fields[len(fields)-1])
+		if err != nil {
+			continue
+		}
 		if strings.Contains(strings.ToLower(comm), "mihomo") {
-			procs = append(procs, comm+" ("+pid+")")
+			procs = append(procs, Process{Name: comm, PID: pid})
 		}
 	}
 	return procs, nil

--- a/internal/tundetect/tundetect_linux.go
+++ b/internal/tundetect/tundetect_linux.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -44,12 +45,12 @@ func enumerateLinuxTun() ([]string, error) {
 }
 
 // enumerateLinuxMihomo lists processes whose comm reads as mihomo.
-func enumerateLinuxMihomo() ([]string, error) {
+func enumerateLinuxMihomo() ([]Process, error) {
 	entries, err := os.ReadDir("/proc")
 	if err != nil {
 		return nil, err
 	}
-	var procs []string
+	var procs []Process
 	for _, e := range entries {
 		if !e.IsDir() || !isAllDigits(e.Name()) {
 			continue
@@ -59,9 +60,14 @@ func enumerateLinuxMihomo() ([]string, error) {
 			continue
 		}
 		name := strings.TrimSpace(string(comm))
-		if strings.Contains(strings.ToLower(name), "mihomo") {
-			procs = append(procs, name+" ("+e.Name()+")")
+		if !strings.Contains(strings.ToLower(name), "mihomo") {
+			continue
 		}
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil {
+			continue
+		}
+		procs = append(procs, Process{Name: name, PID: pid})
 	}
 	return procs, nil
 }

--- a/internal/tundetect/tundetect_windows.go
+++ b/internal/tundetect/tundetect_windows.go
@@ -28,8 +28,7 @@ func detect(ctx context.Context) (Detection, error) {
 }
 
 // enumerateWintunAdapters lists network adapters whose description or friendly
-// name marks them as wintun tunnels. Real wintun adapters (as created by
-// mihomo, WireGuard, sing-box, …) report a description containing "Wintun".
+// name marks them as Windows TUN tunnels (wintun, Meta Tunnel / mihomo, WireGuard).
 func enumerateWintunAdapters() ([]string, error) {
 	var size uint32
 	if err := windows.GetAdaptersAddresses(0, 0x20 /* GAA_FLAG_INCLUDE_FRIENDLY_NAME — fill FriendlyName for friendlier display */, 0, nil, &size); err != nil && err != windows.ERROR_BUFFER_OVERFLOW {
@@ -50,21 +49,15 @@ func enumerateWintunAdapters() ([]string, error) {
 		if !isWintun(desc, friendly) {
 			continue
 		}
-		name := friendly
-		if name == "" {
-			name = desc
-		}
-		adapters = append(adapters, name)
+		adapters = append(adapters, formatAdapterName(desc, friendly))
 	}
 	return adapters, nil
 }
 
 // isWintun reports whether an adapter's description or friendly name identifies
-// it as a wintun tunnel (case-insensitive). wintun descriptions look like
-// "Wintun Userspace Tunnel (Wintun)".
+// it as a Windows TUN tunnel (wintun, Meta Tunnel / mihomo, WireGuard).
 func isWintun(desc, friendly string) bool {
-	return strings.Contains(strings.ToLower(desc), "wintun") ||
-		strings.Contains(strings.ToLower(friendly), "wintun")
+	return isWindowsTunAdapter(desc, friendly)
 }
 
 // enumerateMihomoProcesses lists running processes whose executable name

--- a/internal/tundetect/tundetect_windows.go
+++ b/internal/tundetect/tundetect_windows.go
@@ -4,7 +4,6 @@ package tundetect
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"unsafe"
 
@@ -62,7 +61,7 @@ func isWintun(desc, friendly string) bool {
 
 // enumerateMihomoProcesses lists running processes whose executable name
 // contains "mihomo" (case-insensitive).
-func enumerateMihomoProcesses() ([]string, error) {
+func enumerateMihomoProcesses() ([]Process, error) {
 	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
 	if err != nil {
 		return nil, err
@@ -73,11 +72,11 @@ func enumerateMihomoProcesses() ([]string, error) {
 	if err := windows.Process32First(snapshot, &entry); err != nil {
 		return nil, err
 	}
-	var procs []string
+	var procs []Process
 	for {
 		exe := windows.UTF16ToString(entry.ExeFile[:])
 		if strings.Contains(strings.ToLower(exe), "mihomo") {
-			procs = append(procs, fmt.Sprintf("%s (%d)", exe, entry.ProcessID))
+			procs = append(procs, Process{Name: exe, PID: int(entry.ProcessID)})
 		}
 		if err := windows.Process32Next(snapshot, &entry); err != nil {
 			if err == windows.ERROR_NO_MORE_FILES {

--- a/internal/tundetect/windows_names.go
+++ b/internal/tundetect/windows_names.go
@@ -1,0 +1,30 @@
+package tundetect
+
+import "strings"
+
+func isWindowsTunAdapter(desc, friendly string) bool {
+	haystack := strings.ToLower(desc + " " + friendly)
+	for _, needle := range []string{"wintun", "meta tunnel", "wireguard"} {
+		if strings.Contains(haystack, needle) {
+			return true
+		}
+	}
+	name := strings.ToLower(strings.TrimSpace(friendly))
+	if name == "" {
+		name = strings.ToLower(strings.TrimSpace(desc))
+	}
+	return name == "mihomo" || name == "meta"
+}
+
+func formatAdapterName(desc, friendly string) string {
+	friendly = strings.TrimSpace(friendly)
+	desc = strings.TrimSpace(desc)
+	switch {
+	case friendly == "":
+		return desc
+	case desc == "" || strings.EqualFold(friendly, desc):
+		return friendly
+	default:
+		return friendly + " (" + desc + ")"
+	}
+}

--- a/internal/tundetect/windows_names_test.go
+++ b/internal/tundetect/windows_names_test.go
@@ -1,0 +1,41 @@
+package tundetect
+
+import "testing"
+
+func TestIsWindowsTunAdapter(t *testing.T) {
+	tests := []struct {
+		name     string
+		desc     string
+		friendly string
+		want     bool
+	}{
+		{"legacy wintun desc", "Wintun Userspace Tunnel", "Ethernet 2", true},
+		{"sparkle meta tunnel", "Meta Tunnel", "mihomo", true},
+		{"friendly mihomo only", "Some Vendor NIC", "mihomo", true},
+		{"friendly Meta exact", "Virtual", "Meta", true},
+		{"wireguard tunnel", "WireGuard Tunnel", "OfficeNet", true},
+		{"wlan", "Intel(R) Wi-Fi 6 AX201 160MHz", "WLAN", false},
+		{"tap windows", "TAP-Windows Adapter V9", "以太网 8", false},
+		{"sangfor", "Sangfor SSL VPN CS Support System VNIC", "以太网 7", false},
+		{"netease tap", "Netease UU TAP-Win32 Adapter V9.21", "以太网 6", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isWindowsTunAdapter(tt.desc, tt.friendly); got != tt.want {
+				t.Fatalf("got=%v want=%v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatAdapterName(t *testing.T) {
+	if got := formatAdapterName("Meta Tunnel", "mihomo"); got != "mihomo (Meta Tunnel)" {
+		t.Fatalf("got=%q", got)
+	}
+	if got := formatAdapterName("Wintun Userspace Tunnel", "Wintun Userspace Tunnel"); got != "Wintun Userspace Tunnel" {
+		t.Fatalf("got=%q", got)
+	}
+	if got := formatAdapterName("Wintun Userspace Tunnel", ""); got != "Wintun Userspace Tunnel" {
+		t.Fatalf("got=%q", got)
+	}
+}


### PR DESCRIPTION
## 变更内容

修复 #91：Windows 上 Sparkle 等 mihomo GUI 开了 TUN 后，Mihari 认不出对方网卡（描述是 `Meta Tunnel`、别名是 `mihomo`，不含 `wintun`），Enable 还不核对内核 live，于是出现 `Desired On · Live Off`。

本次改动：

- Windows 信号 A 识别 `wintun` / `meta tunnel` / `wireguard` 以及别名恰好为 `mihomo`/`Meta` 的网卡
- `Classify` 按本实例 core PID 与 live `tun.device` 扣除自身，不再按列表第一项盲删
- `applyTun` 在 regenerate 成功后仍返回 PATCH 错误
- Enable 成功定义为 live `tun.enable == true`；否则回滚 Desired。`--force` 只绕过冲突门控
- 沿用已有 `TunStatus.last_error`：apply/live 失败或 Desired/Live 漂移时填短句

不改 `/v1` 既有字段语义，不新增错误码，不杀外部进程，不把两个 `auto-route` TUN 做成共存。

设计：`docs/superpowers/specs/2026-08-17-tun-conflict-detect-and-live-design.md`

## 类型

- [x] fix: Bug 修复
- [x] docs: 文档
- [x] test: 测试

## 检查清单

- [ ] `go test -race ./...` 通过（未跑 race；`go test ./...` 已通过）
- [x] `go vet ./...` 通过（已对 `internal/tundetect` / `internal/runtime` 跑过；Task 7 交叉验证通过）
- [x] `gofmt -l` 对改动包无输出
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] 协议契约：仅填充已有 `last_error`（`omitempty`），无新键、无新错误码、`CodeTunConflict` message 不变

## 相关 Issues

Fixes #91

## 其他

整分支 review：Ready to merge。遗留均为可选断言/命名 nit，不挡合并。

可选后续（不在本 PR）：unmanaged Enable 失败后 `runtime/config.yaml` 可能仍留着刚生成的 `tun.enable: true`（计划刻意不 PATCH 伪造的 disable 块）。