### PR TITLE
chore(release): 记录 v0.7.4 变更日志

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@
 
 ### Fixed
 
+## [v0.7.4] - 2026-08-17
+
+### Fixed
+
+- Windows 将 Sparkle/mihomo 的 `Meta Tunnel` 网卡识别为其他 TUN，Enable 在非 force 时走 `tun_conflict` 门控（#91, #92）。
+- TUN 冲突分类按本实例内核 PID 与 live `tun.device` 扣除自身，不再按列表第一项盲删（#92）。
+- Enable 后核对 mihomo live `tun.enable`；未真正开启则回滚 Desired，并填充已有的 `last_error`（#92）。
+- regenerate/reload 成功后仍返回 PATCH 失败，避免 Desired On / Live Off（#92）。
+
 ## [v0.7.3] - 2026-08-17
 
 ### Added


### PR DESCRIPTION
## 变更内容

记录 v0.7.4 变更日志（#91, #92）。覆盖 Windows 识别 Sparkle/Meta Tunnel、按 PID/设备名扣除自身、Enable 后核对 live 并回滚 Desired。

合并后打 annotated tag `v0.7.4` 触发 Release 工作流。

## 类型

- [x] docs: 文档
- [x] chore: 构建/工具

## 检查清单

- [ ] `go test -race ./...` 通过（文档-only，依赖 main 上 #92 的 CI）
- [x] `go vet ./...` 通过（无 Go 变更）
- [x] `gofmt -l cmd internal` 无输出（无 Go 变更）
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] 若修改了 `internal/control/protocol` 的契约、CLI 输出/退出码或跨平台行为，已在 PR 描述中说明影响

## 相关 Issues

#91