### PR TITLE
feat(tui): System 页增加 Ports Config 与端口占用状态

### DIFF
--- a/docs/superpowers/specs/2026-08-17-system-ports-config-design.md
+++ b/docs/superpowers/specs/2026-08-17-system-ports-config-design.md
@@ -1,0 +1,243 @@
+# TUI System 页 Ports Config 与双栏布局设计
+
+日期：2026-08-17
+状态：实施中
+目标分支：`feat/system-ports-config`
+工作目录：`.worktrees/feat-system-ports-config`
+
+## 1. 背景
+
+v0.7.5 的 System 页把代理口和 Core API 挂在 Daemon 卡片里，只能看、不能改。Web 口（默认 9191）没有独立地址行。改三个托管端口只能走 Setup。
+
+现场（v0.7.5，服务 running、daemon degraded）：
+
+- Daemon 显示 `Proxy endpoint —`、`Mihomo Core API —`
+- 页脚：`managed port mixed-addr 127.0.0.1:9190 is held by mihomo.exe`
+- 用户要在 System 里直接改口，并希望宽屏时卡片不要一直单列堆叠
+
+后端已经支持：`PATCH /v1/onboarding` 可改 `mixed_addr` / `controller_addr` / `web_addr`；改完 `RestartRequired`。不需要新协议。
+
+上一版方案是在 Daemon 行内编辑。已否决：端口配置单独成区，并调整卡片优先级与双栏。
+
+## 2. 目标
+
+- 新增独立卡片 **Ports Config**，在 System 页修改三个托管端口。
+- Daemon 不再承载 Mixed / Controller 地址行。
+- 窄屏单列顺序固定；宽屏对后五个卡片做双栏。
+- 写入复用现有 onboarding 更新与 `ActionApplyEndpointChange` 确认。
+- 端口占用可探测、可一键换空闲口（对齐 Setup，解决当前 9190 被 mihomo.exe 占用的现场）。
+- 每一行展示端口状态：`Owned` / `Occupied by …` / `Available` / `Unknown`。
+
+## 3. 非目标
+
+- 不改现有 `/v1` 字段语义、错误码、settings schema。允许 `GET /v1/status` **加法**可选 `pid`（本 daemon 进程 PID），旧客户端忽略即可。
+- **禁止**用进程名判断 Owned。机器上可以同时有多个 `mihomo.exe` / `mihari.exe`（本实例内核、Sparkle、另一个 Mihari）。
+- 不加 CLI 改口命令。
+- 浏览器面板仍不能改这三个口。
+- 不把 Zashboard / MetaCubeXD 打开行搬进 Ports Config。
+- 不为 System 单独做滚动容器（矮窗口仍裁切底部，与现状相同）。
+- 不改 Overview 的 `wideMinWidth`。
+
+## 4. 卡片结构与优先级
+
+### 4.1 单列（内容宽度 < 80）
+
+自上而下：
+
+1. **Ports Config**（新，始终全宽）
+2. **Daemon**
+3. **mihomo core**
+4. **System service**
+5. **Network**
+6. **About**
+
+Ports Config 置顶：daemon degraded 时页脚已经点名 mixed-addr 占用，打开 System 立刻能改口。
+
+### 4.2 双栏（内容宽度 ≥ 80）
+
+Ports Config 仍全宽置顶。其余五张按你给的优先级从左到右、再往下排：
+
+```text
+┌─ Ports Config ───────────────────────────────────────┐
+│   Mixed           127.0.0.1:9190   ● Occupied by mihomo.exe (9736) │
+│   Controller      127.0.0.1:9090   ● Owned                  │
+│   Web             127.0.0.1:9191   ● Owned                  │
+└──────────────────────────────────────────────────────┘
+┌─ Daemon ──────────────┐ ┌─ mihomo core ─────────────┐
+│   Daemon  ● degraded  │ │   mihomo core  …          │
+│   Update Mihari       │ │   Core channel            │
+│   Run Setup           │ │   Install / Restart       │
+└───────────────────────┘ └───────────────────────────┘
+┌─ System service ──────┐ ┌─ Network ─────────────────┐
+│   Status  ● running   │ │   TUN  …                  │
+│   Reinstall service   │ │                           │
+└───────────────────────┘ └───────────────────────────┘
+┌─ About ──────────────────────────────────────────────┐
+│   Mihari   A local manager for mihomo                │
+│   GitHub   github.com/mihari-proxy/mihari            │
+└──────────────────────────────────────────────────────┘
+```
+
+- 配对：Daemon ↔ mihomo core，System service ↔ Network。
+- 奇数张 **About** 全宽，不单独占半栏。
+- 同一行两张卡片 `EqualizeLineCount`，底边对齐（与 Overview 相同）。
+- 阈值 80 是 **内容区宽度**（不含 rail）。官方 Full 100×28 内容约 84，走双栏；Compact 72 列内容约 58，保持单列。80 保证半栏放得下 `Controller` + `127.0.0.1:9090`，避免 Overview 曾经把单位裁掉的问题。
+
+### 4.3 Daemon 里留下什么
+
+从 Daemon 去掉 `Proxy endpoint` / `Mihomo Core API`。留下：
+
+- Daemon 健康 / 版本
+- 已安装面板行（Zashboard / MetaCubeXD，Enter 仍打开浏览器）
+- Update Mihari
+- Run Setup（完整向导仍在）
+
+## 5. Ports Config 交互
+
+三行，标签短、和 Setup 首页一致：
+
+| 行 | 标签 | 默认值 | 含义 |
+| --- | --- | --- | --- |
+| Mixed | `Mixed` | `127.0.0.1:9190` | 混合代理 |
+| Controller | `Controller` | `127.0.0.1:9090` | mihomo API（必须 loopback） |
+| Web | `Web` | `127.0.0.1:9191` | Web 网关（必须 loopback） |
+
+### 5.1 查看
+
+未编辑时一行三段：标签、地址、状态。状态是行值的一部分，不另起行。
+
+```text
+│   Mixed        127.0.0.1:9190   ● Occupied by mihomo.exe (9736) │
+│ > Controller   127.0.0.1:9090   ● Owned                  │
+│   Web          127.0.0.1:9191   ● Owned                  │
+```
+
+状态用现成 `StatusDot` + 着色文案，和 Daemon / Service 行同一套 tone，一眼能分出绿/红。半栏宽度不够时先裁状态、再裁地址，标签始终在。页顶仍可钉 daemon `lastError`。
+
+### 5.2 端口状态：只认 PID，不认进程名
+
+机器上可以同时有很多个 `mihomo.exe`（本实例内核、Sparkle / Meta Tunnel、别人装的 Clash）。**映像名等于 `mihomo.exe` 绝不能当成 Owned。** 同样不能因为映像名是 `mihari.exe` 就把 Web 口判给自己（可能还有第二个 Mihari）。
+
+身份只有两个数字：
+
+| 口 | 自己的持有者 | PID 来源 |
+| --- | --- | --- |
+| Mixed、Controller | 本实例监督的 mihomo 子进程 | 已有 `GET /v1/core` 的 `pid` |
+| Web | 本实例 Mihari daemon（常是服务进程，不是 TUI） | **加法** `GET /v1/status` 的可选 `pid`（`os.Getpid()`，`omitempty`） |
+
+TUI 自己的 PID 不是 daemon PID，不能用来认 Web 口。
+
+分类（TUI 本地，lookup / listen 可注入）：
+
+1. `net.Listen("tcp", addr)` 成功并立刻关掉 → **Available**。
+2. Listen 失败则 `platform.LookupTCPOccupant(addr)` 得到占用者 PID：
+   - Mixed / Controller：占用者 PID == `core.PID` 且 `core.PID > 0` → **Owned**。
+   - Web：占用者 PID == `status.PID` 且 `status.PID > 0` → **Owned**。
+   - 有占用者 PID，但对不上上面两个 → **Occupied**。行上必须带 PID，方便对照多个 `mihomo.exe`：
+     - 有名字：`Occupied by mihomo.exe (9736)`
+     - 没名字：`Occupied by PID 9736`
+     - PID 也没有（lookup 失败）→ 走 Unknown，不编造数字
+   - 查不到占用者 → **Unknown**。不标 Occupied，避免权限失败误红。
+3. `core.PID == 0`（内核没起来 / Unknown）时，任何 `mihomo.exe` 占 Mixed/Controller 都是 Occupied。这就是你现在的 degraded 现场。
+4. 禁止第三条规则：按 `mihomo` / `mihari` / `Sparkle` 字符串猜 Owned。
+
+进入 System 页、core/status/onboarding 刷新、改口成功后各 probe 一次。不每秒轮询。
+
+| 状态 | 行尾 | 颜色（必须上色） |
+| --- | --- | --- |
+| Owned | 绿点 + 绿字 `Owned` | `TonePositive` / Success |
+| Occupied | 红点 + 红字 `Occupied by mihomo.exe (9736)` | `ToneDanger` |
+| Available | 灰点 + 灰字 `Available` | Muted / Neutral |
+| Unknown | 灰点 + 灰字 `Unknown` | Muted |
+| 探测中 | 不闪红，可用 Pending chip `Checking` | Warning / Pending |
+
+颜色走现有 `StatusDot` + `ToneStyle`，不要新色板。Occupied 整段状态（点 + 字）都是 Danger，不能只改点不改字。
+
+Occupied 行上就要有 PID，不藏到详情里。Owned / Available / Unknown 行上不写 PID（Owned 的身份已经是 core/daemon PID，不必重复）。详情里仍可再列完整 `Holder PID 9736`。宽度不够时先裁进程名、保留 `(9736)`。
+
+### 5.3 编辑
+
+1. 焦点在某端口行时 Enter → 该行进入输入（`textinput`，预填当前值）。
+2. 输入时 footer：`Type address  Enter apply  Esc cancel`。
+3. Esc：丢草稿，回到查看。
+4. Enter：校验 → **仅 Occupied（他人占用）** 才自动换成空闲口；Owned / Available 不换。校验失败则 `lastError`，不弹确认。
+5. 值相对当前设置有变化 → `ActionApplyEndpointChange` 确认框（已有文案 `Replace configuration`）。
+6. 确认后 `PATCH /v1/onboarding`，只带三个地址，**不**改 `complete`。
+7. 成功：刷新 onboarding 行值；`RestartRequired` 则弹已有 `Restart required` 详情框。
+8. 失败：行 Failed chip + 顶部错误；不把底层错误原文（路径、完整订阅 URL）渲出去。
+
+`pending` 时忽略 Enter，与其它 System 行一致。`mutationsEnabled == false` 或缺少 onboarding capability 时不能进编辑。
+
+面板行、GitHub、服务动作的 Enter 语义不变。
+
+### 5.4 校验
+
+与 Setup 同一套规则（抽到双方都能用的小函数，避免复制）：
+
+- Mixed：合法 `IP:port`，端口非 0
+- Controller / Web：必须 loopback + 合法端口
+- 三个端口号互不相同
+
+占用探测比 Setup 多一层 occupant **PID** 对照；Setup 首页可以继续只用 Free/Occupied，不必这次一起改。
+
+## 6. 焦点与键盘
+
+`↑/↓` 仍按 `rows()` 源顺序走，不按双栏视觉左右走：
+
+Ports 三行 → Daemon 各行 → Core → Service → Network → About。
+
+双栏时从 Daemon 最后一行再 ↓ 会进到右侧或下一行的 Core，视觉上可能跳一下，比按格子走更简单，也不改现有行模型。
+
+编辑态：左右移光标，↑/↓ 离开编辑（等同 Esc 丢草稿），避免在输入里误切行。
+
+## 7. 实现边界
+
+只改 TUI System 表现层 + 抽出 Setup 已有的校验/换口，供两页共用：
+
+- `internal/tui/pages/system/model.go`：Ports 分区、去 Daemon 地址行、双栏 `View`
+- `internal/tui/ui/strings.go`：`PortsConfigSectionTitle`、`MixedLabel`、`PortOwned`、`PortOccupiedBy`、`PortOccupiedByOtherApp`、`PortAvailable` 等
+- 校验/换口：从 `setup` 抽到例如 `internal/tui/ui/endpoints.go`
+- 占用分类：TUI 调 `platform.LookupTCPOccupant`，只和 `core.PID` / `status.PID` 比；lookup 可注入
+- `internal/control/protocol/status.go`：`Status` 增加可选 `PID int \`json:"pid,omitempty"\``
+- daemon 填 `os.Getpid()`；旧客户端忽略该字段
+- `internal/tui/pages/system/model_test.go`、必要时 `setup` / `control` 测试
+
+System `Client` 增加 `UpdateOnboarding`（Setup 已有）。
+
+不改错误码、settings schema、JSON envelope 版本号。
+
+## 8. 测试
+
+`internal/tui/pages/system/model_test.go`，不访问公网。
+
+1. View 含 `Ports Config`、三行默认或注入地址；Daemon 不再含 `Proxy endpoint` / `Mihomo Core API`。
+2. 单列（width 70）：六张卡片自上而下，无水平拼接。
+3. 双栏（width 84）：Ports 全宽；下一行同时有 Daemon 与 mihomo core；About 全宽。
+4. Enter Mixed → 编辑态；Esc 恢复原值且不调用 UpdateOnboarding。
+5. 改 Controller 后 Enter → `ActionApplyEndpointChange`；Execute 发出的 PATCH 含三个地址、不含 `complete`。
+6. 非法地址 / 非 loopback / 端口冲突 → 不弹确认，顶部错误。
+7. 状态分类（注入 listen + lookup，不读真实网卡表）：
+   - listen 成功 → 灰 `Available`
+   - Mixed/Controller 占用者 PID == `core.PID` → 绿 `Owned`
+   - Web 占用者 PID == `status.PID` → 绿 `Owned`
+   - 占用者是另一个 `mihomo.exe`（PID ≠ core.PID）→ 红 `Occupied by mihomo.exe (9736)`
+   - 映像名是 `mihomo.exe` 或 `mihari.exe` 但 PID 对不上 → 仍是 Occupied，不是 Owned
+   - lookup 失败 → 灰 `Unknown`
+   - 渲染含 StatusDot，Occupied 为 Danger，Owned 为 Positive
+8. Occupied 行 Enter apply → 换成空闲口后再确认；Owned 行不改地址则不换口、不写盘。
+9. 写入后 `RestartRequired` → 根 shell 弹出已有 Restart required 框（可放 `internal/tui/model_test.go`）。
+10. 断开 / 无 capability：Enter 端口行不进编辑。
+11. 面板行 Enter 仍走打开浏览器。
+
+## 9. 安全与架构
+
+- Controller / Web 仍强制 loopback。
+- 浏览器拿不到 controller secret。
+- 写入仍走 daemon + onboarding，TUI 不直接改 `mihari.yaml`。
+- 保持 `CGO_ENABLED=0`。
+
+## 10. 建议验证
+
+- `go test ./internal/tui/pages/system/ ./internal/tui/pages/setup/ ./internal/tui/`
+- `gofmt -l` 改过的 Go 文件
+- 人工：窄窗单列；拉宽后 Ports 置顶全宽、Daemon|Core、Service|Network、About 全宽；改 9190 并确认后出现 Restart required

--- a/internal/control/protocol/status.go
+++ b/internal/control/protocol/status.go
@@ -29,6 +29,9 @@ type Status struct {
 	Config          *ConfigStatus `json:"config,omitempty"`
 	Capabilities    []string      `json:"capabilities,omitempty"`
 	SetupRequired   bool          `json:"setup_required,omitempty"`
+	// PID is this daemon process id. Optional additive field so local clients
+	// can tell whether a TCP occupant is this instance's web gateway.
+	PID int `json:"pid,omitempty"`
 }
 
 type ConfigStatus struct {

--- a/internal/control/server/server.go
+++ b/internal/control/server/server.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"os"
 	"sort"
 	"time"
 
@@ -71,6 +72,7 @@ func (s *Server) status(writer http.ResponseWriter, request *http.Request) {
 		Health:          snapshot.Health,
 		LastError:       snapshot.LastError,
 		StartedAt:       snapshot.StartedAt,
+		PID:             os.Getpid(),
 	}
 	if s.runtime != nil {
 		status.Capabilities = sortedUnique(s.runtime.Capabilities())

--- a/internal/control/server/server_test.go
+++ b/internal/control/server/server_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"slices"
 	"testing"
 	"time"
@@ -53,6 +54,9 @@ func TestStatusReturnsStableEnvelope(t *testing.T) {
 	}
 	if got.Schema != "mihari/v1" || got.ProtocolVersion != "v1" || got.Revision != 7 || got.Health != "ok" {
 		t.Fatalf("status=%#v", got)
+	}
+	if got.PID != os.Getpid() {
+		t.Fatalf("pid=%d want %d", got.PID, os.Getpid())
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -343,6 +343,9 @@ func (model Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			return model, tea.Batch(command, waitSessionEvent(model.events), model.loadRootServiceStatus())
 		}
 		return model, tea.Batch(command, waitSessionEvent(model.events))
+	case systempage.RestartRequiredMsg:
+		model.modal = NewDetail(ui.RestartRequiredTitle, ui.RestartRequiredBody)
+		return model, nil
 	case setuppage.CompletedMsg:
 		model.status.SetupRequired = !typed.Status.Complete
 		model.setupObserved = true

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -104,7 +104,7 @@ func TestModelRegistersCapabilityGatedWebGUIAndSystemPages(t *testing.T) {
 	}
 	model.applySessionEvent(session.Event{Kind: session.EventStatus, Status: protocol.Status{DaemonVersion: "v0.4.0", Health: "ok", Revision: 3}})
 	model.applySessionEvent(session.Event{Kind: session.EventCore, Core: protocol.CoreStatus{Status: "running", Version: "v1.19.0"}})
-	if view := system.View(); !strings.Contains(view, "v0.4.0") || !strings.Contains(view, "v1.19.0") {
+	if view := system.View(); !strings.Contains(view, "v0.4.0") || !strings.Contains(view, "running") || !strings.Contains(view, ui.PortsConfigSectionTitle) {
 		t.Fatalf("system view=%s", view)
 	}
 }
@@ -660,7 +660,7 @@ func TestModelRoutesMihariCheckResultToSystemAfterLeavingPage(t *testing.T) {
 	}
 	updated, _ := model.Update(batch[0]())
 	model = updated.(Model)
-	if view := model.pages[ui.PageSystem].View(); !strings.Contains(view, "v0.3.1 · v0.4.0 available") {
+	if view := model.pages[ui.PageSystem].View(); !strings.Contains(view, "v0.3.1") || !strings.Contains(view, "v0.4.0") {
 		t.Fatalf("System did not receive its async result:\n%s", view)
 	}
 }
@@ -784,7 +784,7 @@ func TestNetworkStatusMsgSyncsSystemPageProxyAndTun(t *testing.T) {
 	if strings.Contains(view, ui.LoadingLabel) {
 		t.Fatalf("system Network still Loading after networkStatusMsg: %s", view)
 	}
-	for _, want := range []string{ui.SystemProxyLabel, "127.0.0.1:9190", ui.OwnedLabel, ui.TUNLabel, "system"} {
+	for _, want := range []string{ui.SystemProxyLabel, ui.TUNLabel, "Desired On", "Live On"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("missing %q in system view=%s", want, view)
 		}

--- a/internal/tui/pages/system/model.go
+++ b/internal/tui/pages/system/model.go
@@ -11,7 +11,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
+	lipgloss "charm.land/lipgloss/v2"
 	"github.com/mihari-proxy/mihari/internal/control/protocol"
 	"github.com/mihari-proxy/mihari/internal/elevate"
 	"github.com/mihari-proxy/mihari/internal/platform"
@@ -20,6 +22,8 @@ import (
 	"github.com/mihari-proxy/mihari/internal/update"
 )
 
+const portsWideMinWidth = 80
+
 const (
 	rowDaemon            = "daemon"
 	rowCore              = "core"
@@ -27,8 +31,6 @@ const (
 	rowCoreUpdate        = "core-update"
 	rowCoreRestart       = "core-restart"
 	rowMihariUpdate      = "mihari-update"
-	rowProxyEndpoint     = "proxy-endpoint"
-	rowCoreAPI           = "core-api"
 	rowZashboard         = "zashboard"
 	rowMetaCubeXD        = "metacubexd"
 	rowRunSetup          = "run-setup"
@@ -46,6 +48,9 @@ const (
 	rowTUNAction         = "tun-action"
 	rowAbout             = "about"
 	rowGitHub            = "github"
+	rowMixed             = "port-mixed"
+	rowController        = "port-controller"
+	rowWeb               = "port-web"
 )
 
 // Panel IDs mirrored from internal/panel/catalog.go; local constants keep the
@@ -69,6 +74,7 @@ type Client interface {
 	DisableTun(context.Context, protocol.TunMutationRequest) (protocol.TunStatus, error)
 	WebGUI(context.Context) (protocol.WebGUIStatus, error)
 	OpenWebGUI(context.Context, string) (protocol.WebGUIOpenResult, error)
+	UpdateOnboarding(context.Context, protocol.OnboardingUpdateRequest) (protocol.OnboardingStatus, error)
 }
 
 // SelfUpdater is the local Mihari binary lifecycle surface used by the System page.
@@ -325,7 +331,26 @@ type Model struct {
 	width            int
 	height           int
 	theme            ui.Theme
+	editID           string
+	editInput        textinput.Model
+	portHolds        map[string]ui.PortHold
+	listenFree       func(string) bool
+	lookupOccupant   func(string) (platform.TCPOccupant, bool)
 }
+
+// RestartRequiredMsg tells the root shell to show the existing restart dialog.
+type RestartRequiredMsg struct{}
+
+type portHoldsMsg struct {
+	holds map[string]ui.PortHold
+}
+
+type portsApplyResultMsg struct {
+	status protocol.OnboardingStatus
+	err    error
+}
+
+func (m portsApplyResultMsg) Err() error { return m.err }
 
 // New constructs a System page without a service controller.
 func New(client Client, newOperationID func() string) *Model {
@@ -351,9 +376,18 @@ func NewWithContext(ctx context.Context, client Client, svc ServiceController, n
 		service:        svc,
 		openBrowser:    platform.OpenBrowser,
 		newOperationID: newOperationID,
-		focusID:        rowDaemon,
+		focusID:        rowMixed,
 		theme:          ui.DefaultTheme(),
+		portHolds:      map[string]ui.PortHold{},
 	}
+}
+
+// FooterHints returns edit-mode shortcuts while a port row is being typed.
+func (m *Model) FooterHints() string {
+	if m.editID != "" {
+		return ui.FooterPortsEdit
+	}
+	return ui.FooterSystem
 }
 
 // ApplyServiceStatus updates the OS service observation from the root shell poll
@@ -410,6 +444,10 @@ func (m *Model) layoutWidth() int {
 		return m.width
 	}
 	return 100
+}
+
+func (m *Model) twoColumn() bool {
+	return m.width >= portsWideMinWidth
 }
 
 func (m *Model) FocusFirst() {
@@ -591,7 +629,23 @@ func (m *Model) Update(message tea.Msg) (ui.Page, tea.Cmd) {
 			m.lastError = ""
 			m.onboarding = typed.status
 		}
+		return m, m.probePortHolds()
+	case portHoldsMsg:
+		m.portHolds = typed.holds
 		return m, nil
+	case portsApplyResultMsg:
+		m.clearRowPending()
+		if typed.err != nil {
+			m.markRowOutcome(m.focusID, false, ui.PortsApplyFailed)
+			return m, m.rowSpinCmdIfNeeded()
+		}
+		m.onboarding = typed.status
+		m.markRowOutcome(m.focusID, true, "")
+		cmds := []tea.Cmd{m.probePortHolds(), m.rowSpinCmdIfNeeded()}
+		if typed.status.RestartRequired {
+			cmds = append(cmds, func() tea.Msg { return RestartRequiredMsg{} })
+		}
+		return m, tea.Batch(cmds...)
 	case serviceStatusMsg:
 		m.serviceLoaded = true
 		m.elevated = typed.elevated
@@ -738,6 +792,9 @@ func (m *Model) Update(message tea.Msg) (ui.Page, tea.Cmd) {
 		}
 		return m, nil
 	}
+	if m.editID != "" {
+		return m.updatePortEdit(message)
+	}
 	if !ok {
 		return m, nil
 	}
@@ -812,6 +869,8 @@ func (m *Model) Update(message tea.Msg) (ui.Page, tea.Cmd) {
 			return m, m.confirmTunToggle()
 		case rowGitHub:
 			return m, m.openGitHub()
+		case rowMixed, rowController, rowWeb:
+			return m, m.beginPortEdit(m.focusID)
 		default:
 			selected := rows[index]
 			m.detail = &selected
@@ -912,17 +971,36 @@ func (m *Model) View() string {
 			m.theme.Title.Render(strings.TrimSpace(m.detail.label)+" details") + "\n\n" + m.detail.detail + "\n\n" + ui.EscCloseHint,
 		)
 	}
-	inner := ui.FullSectionInner(m.layoutWidth())
 	var parts []string
 	// Pin failure reason at the top so it is not clipped away.
 	if detail := m.visibleErrorDetail(); detail != "" {
 		parts = append(parts, m.theme.Danger.Render(detail))
 	}
+	sections := m.renderSections()
+	if m.twoColumn() && len(sections) > 1 {
+		parts = append(parts, sections[0])
+		rest := sections[1:]
+		for i := 0; i+1 < len(rest); i += 2 {
+			left, right := ui.EqualizeLineCount(rest[i], rest[i+1])
+			parts = append(parts, lipgloss.JoinHorizontal(lipgloss.Top, left, right))
+		}
+		if len(rest)%2 == 1 {
+			parts = append(parts, rest[len(rest)-1])
+		}
+	} else {
+		parts = append(parts, sections...)
+	}
+	return strings.Join(parts, "\n")
+}
+
+func (m *Model) renderSections() []string {
+	inner := ui.FullSectionInner(m.layoutWidth())
+	half := ui.HalfSectionInner(m.layoutWidth())
+	wide := m.twoColumn()
 	clock := m.rowSpinClock
 	if clock.IsZero() {
 		clock = time.Unix(0, 0)
 	}
-	// Group rows into bordered sections by item.section.
 	type sectionBuf struct {
 		title string
 		lines []string
@@ -938,15 +1016,15 @@ func (m *Model) View() string {
 		if rowFocused {
 			marker = ui.FocusMarker
 		}
-		// Lifecycle chips use absolute solid colors; apply RowFocus only to the
-		// label side so reverse video does not wash out Success/Warning/Danger fills.
 		labelPart := marker + item.label
 		value := item.value
+		if m.editID == item.id {
+			value = m.editInput.View()
+		}
 		switch {
 		case m.pending && m.pendingRow == item.id && m.pendingNote != "":
 			value = ui.RenderStatusChip(m.theme, ui.StatusChipPending, ui.SpinnerLabel(clock, m.pendingNote))
 		case m.outcomeRow == item.id:
-			// Sticky Done/Failed until page leave or another action starts.
 			if m.outcomeOK {
 				value = ui.RenderStatusChip(m.theme, ui.StatusChipDone, ui.DoneLabel)
 			} else {
@@ -959,21 +1037,28 @@ func (m *Model) View() string {
 		if value != "" {
 			value = "  " + value
 		}
-		if rowFocused && m.contentFocused {
+		if rowFocused && m.contentFocused && m.editID == "" {
 			labelPart = ui.ApplyFocusStyle(labelPart, m.theme.RowFocus)
 		}
 		sections[idx].lines = append(sections[idx].lines, labelPart+value)
 	}
-	for _, sec := range sections {
+	out := make([]string, 0, len(sections))
+	for i, sec := range sections {
 		body := strings.Join(sec.lines, "\n")
 		if body == "" {
 			body = " "
 		}
-		// Borders are globally constant (surface border + accent title); the
-		// status meaning lives in the row values via StatusDot, not in the frame.
-		parts = append(parts, ui.RenderBorderedSection(m.theme, sec.title, body, inner))
+		width := inner
+		if wide && i > 0 {
+			restCount := len(sections) - 1
+			restIndex := i - 1
+			if !(restCount%2 == 1 && restIndex == restCount-1) {
+				width = half
+			}
+		}
+		out = append(out, ui.RenderBorderedSection(m.theme, sec.title, body, width))
 	}
-	return strings.Join(parts, "\n")
+	return out
 }
 
 func (m *Model) rows() []row {
@@ -983,8 +1068,9 @@ func (m *Model) rows() []row {
 	}
 	daemon := fmt.Sprintf("Version %s\nUptime %s\nHealth %s\nRevision %d\nConfig %s", valueOr(m.status.DaemonVersion, ui.UnknownLabel), uptime(m.status.StartedAt), valueOr(m.status.Health, ui.UnknownLabel), m.status.Revision, configState)
 	core := fmt.Sprintf("Status %s\nVersion %s\nPID %d\nRestarts %d", valueOr(m.core.Status, ui.UnknownLabel), valueOr(m.core.Version, ui.UnknownLabel), m.core.PID, m.core.Restarts)
-	rows := []row{{id: rowDaemon, section: ui.DaemonSectionTitle, label: ui.DaemonLabel, value: daemonValue(m.theme, m.status, !m.mutationsEnabled), detail: daemon}}
-	rows = append(rows, m.endpointRows()...)
+	rows := m.portRows()
+	rows = append(rows, row{id: rowDaemon, section: ui.DaemonSectionTitle, label: ui.DaemonLabel, value: daemonValue(m.theme, m.status, !m.mutationsEnabled), detail: daemon})
+	rows = append(rows, m.panelRows()...)
 	rows = append(rows, m.mihariUpdateRow())
 	rows = append(rows,
 		row{id: rowRunSetup, section: ui.DaemonSectionTitle, label: ui.RunSetupLabel, detail: ui.RunSetupDetail},
@@ -1031,25 +1117,35 @@ func (m *Model) mihariUpdateRow() row {
 	}
 }
 
-// endpointRows renders the Daemon endpoint rows: proxy and core API always,
-// then the installed Web GUI panels when the capability is present.
-func (m *Model) endpointRows() []row {
-	section := ui.DaemonSectionTitle
-	rows := []row{
-		{
-			id: rowProxyEndpoint, section: section,
-			label: padEndpointLabel(ui.ProxyEndpointLabel),
-			value: valueOr(m.onboarding.MixedAddr, ui.MissingValue), detail: ui.ProxyEndpointDetail,
-		},
-		{
-			id: rowCoreAPI, section: section,
-			label: padEndpointLabel(ui.MihomoCoreAPILabel),
-			value: valueOr(m.onboarding.ControllerAddr, ui.MissingValue), detail: ui.MihomoCoreAPIDetail,
-		},
+func (m *Model) portRows() []row {
+	return []row{
+		m.portRow(rowMixed, ui.MixedLabel, m.onboarding.MixedAddr, m.core.PID),
+		m.portRow(rowController, ui.ControllerPortLabel, m.onboarding.ControllerAddr, m.core.PID),
+		m.portRow(rowWeb, ui.WebPortLabel, m.onboarding.WebAddr, m.status.PID),
 	}
+}
+
+func (m *Model) portRow(id, label, addr string, ownerPID int) row {
+	hold := m.portHolds[id]
+	status := ui.RenderPortHold(m.theme, hold)
+	value := valueOr(addr, ui.MissingValue)
+	if status != "" {
+		value += "  " + status
+	}
+	detail := fmt.Sprintf("%s\n%s", valueOr(addr, ui.MissingValue), ui.FormatPortHoldLabel(hold))
+	if hold.PID > 0 {
+		detail += fmt.Sprintf("\nHolder PID %d", hold.PID)
+	}
+	_ = ownerPID
+	return row{id: id, section: ui.PortsConfigSectionTitle, label: padEndpointLabel(label), value: value, detail: detail}
+}
+
+// panelRows renders installed Web GUI panel rows (open browser).
+func (m *Model) panelRows() []row {
 	if !m.hasCapability(protocol.CapabilityWebGUI) {
-		return rows
+		return nil
 	}
+	var rows []row
 	webAddr := m.onboarding.WebAddr
 	if panelRow, ok := m.panelEndpointRow(panelIDZashboard, ui.ZashboardLabel, webAddr); ok {
 		rows = append(rows, panelRow)
@@ -1714,6 +1810,141 @@ func (m *Model) openPanelBrowser(panelID string) tea.Cmd {
 				return webGUIOpenResultMsg{rowID: panelID}
 			},
 		}
+	}
+}
+
+func (m *Model) probePortHolds() tea.Cmd {
+	listen := m.listenFree
+	if listen == nil {
+		listen = ui.ListenFree
+	}
+	lookup := m.lookupOccupant
+	if lookup == nil {
+		lookup = platform.LookupTCPOccupant
+	}
+	addrs := map[string]string{
+		rowMixed:      m.onboarding.MixedAddr,
+		rowController: m.onboarding.ControllerAddr,
+		rowWeb:        m.onboarding.WebAddr,
+	}
+	owners := map[string]int{
+		rowMixed:      m.core.PID,
+		rowController: m.core.PID,
+		rowWeb:        m.status.PID,
+	}
+	return func() tea.Msg {
+		holds := make(map[string]ui.PortHold, 3)
+		for id, addr := range addrs {
+			if strings.TrimSpace(addr) == "" {
+				holds[id] = ui.PortHold{Kind: ui.PortHoldUnknown}
+				continue
+			}
+			free := listen(addr)
+			var occ platform.TCPOccupant
+			if !free {
+				occ, _ = lookup(addr)
+			}
+			holds[id] = ui.ClassifyPortHold(free, occ.PID, occ.Process, owners[id])
+		}
+		return portHoldsMsg{holds: holds}
+	}
+}
+
+func (m *Model) beginPortEdit(id string) tea.Cmd {
+	if !m.mutationsEnabled || m.client == nil || !m.hasCapability(protocol.CapabilityOnboarding) {
+		return nil
+	}
+	addr := m.portAddr(id)
+	input := textinput.New()
+	input.Prompt = ""
+	input.CharLimit = 64
+	input.SetWidth(28)
+	input.SetValue(addr)
+	_ = input.Focus()
+	m.editID = id
+	m.editInput = input
+	return func() tea.Msg { return ui.InputModeMsg{Mode: ui.InputText} }
+}
+
+func (m *Model) cancelPortEdit() tea.Cmd {
+	m.editID = ""
+	m.editInput = textinput.Model{}
+	return func() tea.Msg { return ui.InputModeMsg{Mode: ui.InputNavigation} }
+}
+
+func (m *Model) updatePortEdit(message tea.Msg) (ui.Page, tea.Cmd) {
+	key, ok := message.(tea.KeyPressMsg)
+	if ok {
+		switch key.String() {
+		case "esc", "up", "down":
+			return m, m.cancelPortEdit()
+		case "enter":
+			return m, m.confirmPortEdit()
+		}
+	}
+	updated, cmd := m.editInput.Update(message)
+	m.editInput = updated
+	return m, cmd
+}
+
+func (m *Model) confirmPortEdit() tea.Cmd {
+	mixed, controller, web := m.onboarding.MixedAddr, m.onboarding.ControllerAddr, m.onboarding.WebAddr
+	next := strings.TrimSpace(m.editInput.Value())
+	switch m.editID {
+	case rowMixed:
+		mixed = next
+	case rowController:
+		controller = next
+	case rowWeb:
+		web = next
+	}
+	if err := ui.ValidateManagedEndpoints(mixed, controller, web); err != nil {
+		m.lastError = ui.InvalidPortEndpoint
+		return nil
+	}
+	occupied := [3]bool{
+		m.portHolds[rowMixed].Kind == ui.PortHoldOccupied,
+		m.portHolds[rowController].Kind == ui.PortHoldOccupied,
+		m.portHolds[rowWeb].Kind == ui.PortHoldOccupied,
+	}
+	probe := m.listenFree
+	if probe == nil {
+		probe = ui.ListenFree
+	}
+	fixed := ui.FindAvailablePorts([3]string{mixed, controller, web}, occupied, probe)
+	mixed, controller, web = fixed[0], fixed[1], fixed[2]
+	if mixed == m.onboarding.MixedAddr && controller == m.onboarding.ControllerAddr && web == m.onboarding.WebAddr {
+		return m.cancelPortEdit()
+	}
+	_ = m.cancelPortEdit()
+	revision, operationID := m.onboarding.Revision, m.newOperationID()
+	request := protocol.OnboardingUpdateRequest{
+		OperationID: operationID, IfRevision: &revision,
+		MixedAddr: &mixed, ControllerAddr: &controller, WebAddr: &web,
+	}
+	return func() tea.Msg {
+		return ui.ActionIntentMsg{
+			Action: ui.ActionApplyEndpointChange, Page: ui.PageSystem, Capability: protocol.CapabilityOnboarding,
+			Key: "system:ports", Title: ui.ReplaceConfigurationTitle, Object: ui.PortsConfigSectionTitle,
+			Impact: ui.ReplaceConfigurationImpact, Rollback: ui.ReplaceConfigurationRollback,
+			Execute: func() tea.Msg {
+				status, err := m.client.UpdateOnboarding(m.ctx, request)
+				return portsApplyResultMsg{status: status, err: err}
+			},
+		}
+	}
+}
+
+func (m *Model) portAddr(id string) string {
+	switch id {
+	case rowMixed:
+		return m.onboarding.MixedAddr
+	case rowController:
+		return m.onboarding.ControllerAddr
+	case rowWeb:
+		return m.onboarding.WebAddr
+	default:
+		return ""
 	}
 }
 

--- a/internal/tui/pages/system/model_test.go
+++ b/internal/tui/pages/system/model_test.go
@@ -2517,8 +2517,7 @@ func TestSystemPortEditApplySendsOnboardingPatch(t *testing.T) {
 	updated, _ := model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	model = updated.(*Model)
 	model.editInput.SetValue("127.0.0.1:19090")
-	updated, cmd := model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
-	model = updated.(*Model)
+	_, cmd := model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	if cmd == nil {
 		t.Fatal("missing apply intent")
 	}

--- a/internal/tui/pages/system/model_test.go
+++ b/internal/tui/pages/system/model_test.go
@@ -12,6 +12,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/mihari-proxy/mihari/internal/control/protocol"
 	"github.com/mihari-proxy/mihari/internal/elevate"
+	"github.com/mihari-proxy/mihari/internal/platform"
 	"github.com/mihari-proxy/mihari/internal/service"
 	"github.com/mihari-proxy/mihari/internal/tui/ui"
 	"github.com/mihari-proxy/mihari/internal/update"
@@ -72,6 +73,10 @@ type fakeClient struct {
 	openWebGUICalls int
 	lastOpenPanel   string
 	openWebGUIErr   error
+
+	updateOnboardingCalls int
+	lastOnboarding        protocol.OnboardingUpdateRequest
+	updateOnboardingErr   error
 }
 
 type fakeService struct {
@@ -114,6 +119,26 @@ func (f *fakeService) Status() (service.StatusKind, error) { return f.status, f.
 
 func (f *fakeClient) Onboarding(context.Context) (protocol.OnboardingStatus, error) {
 	f.onboardingCalls++
+	return f.onboarding, nil
+}
+
+func (f *fakeClient) UpdateOnboarding(_ context.Context, request protocol.OnboardingUpdateRequest) (protocol.OnboardingStatus, error) {
+	f.updateOnboardingCalls++
+	f.lastOnboarding = request
+	if f.updateOnboardingErr != nil {
+		return protocol.OnboardingStatus{}, f.updateOnboardingErr
+	}
+	if request.MixedAddr != nil {
+		f.onboarding.MixedAddr = *request.MixedAddr
+	}
+	if request.ControllerAddr != nil {
+		f.onboarding.ControllerAddr = *request.ControllerAddr
+	}
+	if request.WebAddr != nil {
+		f.onboarding.WebAddr = *request.WebAddr
+	}
+	f.onboarding.RestartRequired = true
+	f.onboarding.Revision++
 	return f.onboarding, nil
 }
 func (f *fakeClient) Core(context.Context) (protocol.CoreStatus, error) {
@@ -301,7 +326,7 @@ func TestSystemRendersCategorizedRowsWithoutStopDaemon(t *testing.T) {
 	updated, _ := model.Update(onboardingResultMsg{status: client.onboarding})
 	model = updated.(*Model)
 	view := model.View()
-	for _, want := range []string{"Daemon", "v0.4.0", "mihomo core", "v1.19.0", "Proxy endpoint", "127.0.0.1:9190", "Run Setup", "TUN", "Unavailable"} {
+	for _, want := range []string{"Daemon", "v0.4.0", "mihomo core", "v1.19.0", ui.PortsConfigSectionTitle, ui.MixedLabel, "127.0.0.1:9190", "Run Setup", "TUN", "Unavailable"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("missing %q in view=%s", want, view)
 		}
@@ -312,6 +337,9 @@ func TestSystemRendersCategorizedRowsWithoutStopDaemon(t *testing.T) {
 	}
 	if strings.Contains(view, "Stop Daemon") {
 		t.Fatalf("system page offered destructive self-stop: %s", view)
+	}
+	if strings.Contains(view, ui.ProxyEndpointLabel) || strings.Contains(view, ui.MihomoCoreAPILabel) {
+		t.Fatalf("daemon must not list address rows: %s", view)
 	}
 }
 
@@ -1483,8 +1511,7 @@ func TestSystemRendersPanelEndpointRowsWhenInstalled(t *testing.T) {
 	model = updated.(*Model)
 	view := model.View()
 	for _, want := range []string{
-		ui.ProxyEndpointLabel, "127.0.0.1:9190",
-		ui.MihomoCoreAPILabel, "127.0.0.1:9090",
+		ui.PortsConfigSectionTitle, ui.MixedLabel, "127.0.0.1:9190",
 		ui.ZashboardLabel, ui.MetaCubeXDLabel, "/__mihari/panels/",
 	} {
 		if !strings.Contains(view, want) {
@@ -1538,28 +1565,24 @@ func TestSystemHidesPanelRowsWithoutWebGUICapability(t *testing.T) {
 			t.Fatalf("panel row %q without web-gui capability: %s", banned, view)
 		}
 	}
-	if !strings.Contains(view, ui.ProxyEndpointLabel) || !strings.Contains(view, ui.MihomoCoreAPILabel) {
-		t.Fatalf("proxy/core endpoint rows must always render:\n%s", view)
+	if !strings.Contains(view, ui.PortsConfigSectionTitle) || !strings.Contains(view, ui.MixedLabel) {
+		t.Fatalf("ports config must always render:\n%s", view)
 	}
 }
 
 func TestSystemEndpointRowsOpenDetailPopup(t *testing.T) {
-	model := New(&fakeClient{onboarding: protocol.OnboardingStatus{MixedAddr: "127.0.0.1:9190", ControllerAddr: "127.0.0.1:9090"}}, func() string { return "system-op" })
-	model.SetSnapshot(protocol.Status{}, protocol.CoreStatus{})
-	for _, test := range []struct {
-		id         string
-		detailText string
-	}{
-		{rowProxyEndpoint, ui.ProxyEndpointDetail},
-		{rowCoreAPI, ui.MihomoCoreAPIDetail},
-	} {
-		model.focusID = test.id
-		model = updateKey(t, model, tea.KeyPressMsg{Code: tea.KeyEnter})
-		view := model.View()
-		if !strings.Contains(view, " details") || !strings.Contains(view, test.detailText) {
-			t.Fatalf("row=%s detail view=%s", test.id, view)
-		}
-		model = updateKey(t, model, tea.KeyPressMsg{Code: tea.KeyEscape})
+	// Ports rows no longer open a detail overlay; Enter starts an in-row edit.
+	model := New(&fakeClient{onboarding: protocol.OnboardingStatus{MixedAddr: "127.0.0.1:9190", ControllerAddr: "127.0.0.1:9090", WebAddr: "127.0.0.1:9191"}}, func() string { return "system-op" })
+	model.SetSnapshot(protocol.Status{Capabilities: []string{protocol.CapabilityOnboarding}}, protocol.CoreStatus{})
+	model.SetMutationsEnabled(true)
+	model.focusID = rowMixed
+	updated, cmd := model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	model = updated.(*Model)
+	if model.editID != rowMixed {
+		t.Fatalf("editID=%q", model.editID)
+	}
+	if cmd == nil {
+		t.Fatal("expected input-mode command")
 	}
 }
 
@@ -2248,7 +2271,7 @@ func TestSystemAboutRendersDescriptionAndGitHub(t *testing.T) {
 func TestSystemAboutRowsFollowNetworkAndKeepDaemonFocus(t *testing.T) {
 	model := New(&fakeClient{}, func() string { return "system-op" })
 	model.SetSnapshot(protocol.Status{}, protocol.CoreStatus{})
-	if model.focusID != rowDaemon {
+	if model.focusID != rowMixed {
 		t.Fatalf("default focus=%q", model.focusID)
 	}
 	rows := model.rows()
@@ -2393,5 +2416,149 @@ func TestSystemAboutGitHubEnterIgnoredWhilePending(t *testing.T) {
 	}
 	if calls != 0 {
 		t.Fatalf("browser calls=%d", calls)
+	}
+}
+
+func portsModel(t *testing.T) *Model {
+	t.Helper()
+	client := &fakeClient{onboarding: protocol.OnboardingStatus{
+		Revision: 3, MixedAddr: "127.0.0.1:9190", ControllerAddr: "127.0.0.1:9090", WebAddr: "127.0.0.1:9191",
+	}}
+	model := New(client, func() string { return "ports-op" })
+	model.SetSnapshot(protocol.Status{
+		Capabilities: []string{protocol.CapabilityOnboarding}, PID: 100,
+	}, protocol.CoreStatus{PID: 42, Status: "running"})
+	model.SetMutationsEnabled(true)
+	model.SetOnboarding(client.onboarding)
+	return model
+}
+
+func TestSystemPortsTwoColumnWhenWide(t *testing.T) {
+	model := portsModel(t)
+	model.SetSize(84, 40)
+	view := model.View()
+	if !strings.Contains(view, ui.PortsConfigSectionTitle) || !strings.Contains(view, ui.DaemonSectionTitle) {
+		t.Fatalf("view=%s", view)
+	}
+	// Half-width cards are narrower than a full 80-col section.
+	if !strings.Contains(view, "╭───"+ui.DaemonSectionTitle) && !strings.Contains(view, ui.DaemonSectionTitle) {
+		t.Fatalf("missing daemon card:\n%s", view)
+	}
+}
+
+func TestSystemPortStatusOwnedVsForeignMihomo(t *testing.T) {
+	model := portsModel(t)
+	model.listenFree = func(string) bool { return false }
+	model.lookupOccupant = func(addr string) (platform.TCPOccupant, bool) {
+		switch addr {
+		case "127.0.0.1:9190":
+			return platform.TCPOccupant{PID: 9736, Process: "mihomo.exe"}, true
+		case "127.0.0.1:9090":
+			return platform.TCPOccupant{PID: 42, Process: "mihomo.exe"}, true
+		case "127.0.0.1:9191":
+			return platform.TCPOccupant{PID: 100, Process: "mihari.exe"}, true
+		default:
+			return platform.TCPOccupant{}, false
+		}
+	}
+	updated, _ := model.Update(model.probePortHolds()())
+	model = updated.(*Model)
+	view := model.View()
+	if !strings.Contains(view, "Occupied by mihomo.exe (9736)") {
+		t.Fatalf("missing occupied mixed:\n%s", view)
+	}
+	if !strings.Contains(view, ui.PortOwned) {
+		t.Fatalf("missing owned:\n%s", view)
+	}
+	if model.portHolds[rowMixed].Kind != ui.PortHoldOccupied {
+		t.Fatalf("mixed=%#v", model.portHolds[rowMixed])
+	}
+	if model.portHolds[rowController].Kind != ui.PortHoldOwned || model.portHolds[rowWeb].Kind != ui.PortHoldOwned {
+		t.Fatalf("holds=%#v", model.portHolds)
+	}
+}
+
+func TestSystemPortMihariNameWithoutDaemonPIDIsOccupied(t *testing.T) {
+	model := portsModel(t)
+	model.status.PID = 0
+	model.listenFree = func(string) bool { return false }
+	model.lookupOccupant = func(string) (platform.TCPOccupant, bool) {
+		return platform.TCPOccupant{PID: 88, Process: "mihari.exe"}, true
+	}
+	updated, _ := model.Update(model.probePortHolds()())
+	model = updated.(*Model)
+	if model.portHolds[rowWeb].Kind != ui.PortHoldOccupied {
+		t.Fatalf("web=%#v", model.portHolds[rowWeb])
+	}
+}
+
+func TestSystemPortEditEscDoesNotWrite(t *testing.T) {
+	model := portsModel(t)
+	client := model.client.(*fakeClient)
+	model.focusID = rowController
+	updated, _ := model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	model = updated.(*Model)
+	model.editInput.SetValue("127.0.0.1:19090")
+	updated, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	model = updated.(*Model)
+	if model.editID != "" {
+		t.Fatal("edit should cancel")
+	}
+	if client.updateOnboardingCalls != 0 {
+		t.Fatalf("writes=%d", client.updateOnboardingCalls)
+	}
+}
+
+func TestSystemPortEditApplySendsOnboardingPatch(t *testing.T) {
+	model := portsModel(t)
+	client := model.client.(*fakeClient)
+	model.listenFree = func(string) bool { return true }
+	model.focusID = rowController
+	updated, _ := model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	model = updated.(*Model)
+	model.editInput.SetValue("127.0.0.1:19090")
+	updated, cmd := model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	model = updated.(*Model)
+	if cmd == nil {
+		t.Fatal("missing apply intent")
+	}
+	var intent ui.ActionIntentMsg
+	found := false
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, item := range batch {
+			if item == nil {
+				continue
+			}
+			if got, ok := item().(ui.ActionIntentMsg); ok {
+				intent, found = got, true
+			}
+		}
+	} else if got, ok := msg.(ui.ActionIntentMsg); ok {
+		intent, found = got, true
+	}
+	if !found || intent.Action != ui.ActionApplyEndpointChange || intent.Execute == nil {
+		t.Fatalf("intent=%#v msg=%T", intent, msg)
+	}
+	if intent.Execute == nil {
+		t.Fatal("missing execute")
+	}
+	result := intent.Execute().(portsApplyResultMsg)
+	if result.err != nil || client.updateOnboardingCalls != 1 || client.lastOnboarding.Complete != nil {
+		t.Fatalf("calls=%d complete=%v err=%v", client.updateOnboardingCalls, client.lastOnboarding.Complete, result.err)
+	}
+	if client.lastOnboarding.ControllerAddr == nil || *client.lastOnboarding.ControllerAddr != "127.0.0.1:19090" {
+		t.Fatalf("request=%#v", client.lastOnboarding)
+	}
+}
+
+func TestSystemPortEditBlockedWhenDisconnected(t *testing.T) {
+	model := portsModel(t)
+	model.SetMutationsEnabled(false)
+	model.focusID = rowMixed
+	updated, cmd := model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	model = updated.(*Model)
+	if model.editID != "" || cmd != nil {
+		t.Fatalf("editID=%q cmd=%v", model.editID, cmd)
 	}
 }

--- a/internal/tui/pages/system/section_test.go
+++ b/internal/tui/pages/system/section_test.go
@@ -34,8 +34,8 @@ func TestView_SectionGroups(t *testing.T) {
 	if strings.Contains(view, ui.MaintenanceSectionTitle) {
 		t.Fatalf("Maintenance section should be merged into Daemon:\n%s", view)
 	}
-	if !strings.Contains(view, ui.RunSetupLabel) || !strings.Contains(view, ui.ProxyEndpointLabel) {
-		t.Fatalf("merged Daemon rows missing labels:\n%s", view)
+	if !strings.Contains(view, ui.RunSetupLabel) || !strings.Contains(view, ui.PortsConfigSectionTitle) {
+		t.Fatalf("ports/daemon rows missing labels:\n%s", view)
 	}
 	if !strings.Contains(view, "v0.4.0") || !strings.Contains(view, "v1.19.0") {
 		t.Fatalf("status values missing:\n%s", view)

--- a/internal/tui/ui/endpoints.go
+++ b/internal/tui/ui/endpoints.go
@@ -1,0 +1,82 @@
+package ui
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"syscall"
+)
+
+// ValidateManagedEndpoints checks Mixed / Controller / Web the same way Setup does.
+func ValidateManagedEndpoints(mixedValue, controllerValue, webValue string) error {
+	mixed, err := netip.ParseAddrPort(mixedValue)
+	if err != nil || mixed.Port() == 0 {
+		return fmt.Errorf("mixed endpoint must be an IP address and valid port")
+	}
+	controller, err := netip.ParseAddrPort(controllerValue)
+	if err != nil || controller.Port() == 0 || !controller.Addr().IsLoopback() {
+		return fmt.Errorf("controller endpoint must use a loopback address and valid port")
+	}
+	web, err := netip.ParseAddrPort(webValue)
+	if err != nil || web.Port() == 0 || !web.Addr().IsLoopback() {
+		return fmt.Errorf("web endpoint must use a loopback address and valid port")
+	}
+	if mixed.Port() == controller.Port() || mixed.Port() == web.Port() || controller.Port() == web.Port() {
+		return fmt.Errorf("managed ports must be distinct")
+	}
+	return nil
+}
+
+// ListenFree reports whether addr accepted a short-lived TCP bind.
+func ListenFree(addr string) bool {
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return false
+	}
+	_ = listener.Close()
+	return true
+}
+
+// AddrInUse reports whether a listen error means the address is already bound.
+func AddrInUse(err error) bool {
+	var errno syscall.Errno
+	if !errors.As(err, &errno) {
+		return false
+	}
+	return errno == syscall.EADDRINUSE || errno == 10048
+}
+
+// FindAvailablePorts rewrites occupied endpoints to the next free port.
+// occupied[i] true means that slot should be moved. probe reports bindability.
+func FindAvailablePorts(current [3]string, occupied [3]bool, probe func(string) bool) [3]string {
+	if probe == nil {
+		probe = ListenFree
+	}
+	result := current
+	used := make(map[uint16]bool)
+	for index, addr := range current {
+		parsed, err := netip.ParseAddrPort(addr)
+		if err != nil {
+			continue
+		}
+		if !occupied[index] {
+			used[parsed.Port()] = true
+			continue
+		}
+		host := parsed.Addr()
+		for offset := 1; offset <= 1024; offset++ {
+			candidate := uint16(parsed.Port()) + uint16(offset)
+			if used[candidate] {
+				continue
+			}
+			candidateAddr := netip.AddrPortFrom(host, candidate).String()
+			if probe(candidateAddr) {
+				result[index] = candidateAddr
+				used[candidate] = true
+				break
+			}
+		}
+	}
+	return result
+}

--- a/internal/tui/ui/portstatus.go
+++ b/internal/tui/ui/portstatus.go
@@ -1,0 +1,85 @@
+package ui
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// PortHoldKind is the user-visible ownership of a managed listen address.
+type PortHoldKind uint8
+
+const (
+	// PortHoldUnknown means listen failed and no occupant could be identified.
+	PortHoldUnknown PortHoldKind = iota
+	// PortHoldAvailable means the address accepted a short-lived bind.
+	PortHoldAvailable
+	// PortHoldOwned means the occupant PID matches this instance's owner PID.
+	PortHoldOwned
+	// PortHoldOccupied means some other process holds the address.
+	PortHoldOccupied
+)
+
+// PortHold is the classified result for one managed endpoint.
+type PortHold struct {
+	Kind    PortHoldKind
+	Process string
+	PID     int
+}
+
+// ClassifyPortHold decides ownership using listen result and occupant PID only.
+// ownerPID is the PID that counts as self (core PID for mixed/controller, daemon
+// PID for web). Process name is never used to decide Owned.
+func ClassifyPortHold(listenFree bool, occupantPID int, occupantName string, ownerPID int) PortHold {
+	if listenFree {
+		return PortHold{Kind: PortHoldAvailable}
+	}
+	name := filepath.Base(strings.TrimSpace(occupantName))
+	if occupantPID > 0 && ownerPID > 0 && occupantPID == ownerPID {
+		return PortHold{Kind: PortHoldOwned, Process: name, PID: occupantPID}
+	}
+	if occupantPID > 0 {
+		return PortHold{Kind: PortHoldOccupied, Process: name, PID: occupantPID}
+	}
+	return PortHold{Kind: PortHoldUnknown}
+}
+
+// PortHoldTone maps a hold to the shared status-shell tone.
+func PortHoldTone(kind PortHoldKind) StatusTone {
+	switch kind {
+	case PortHoldOwned:
+		return TonePositive
+	case PortHoldOccupied:
+		return ToneNegative
+	default:
+		return ToneNeutral
+	}
+}
+
+// FormatPortHoldLabel is the row-trailing status text (no color).
+func FormatPortHoldLabel(hold PortHold) string {
+	switch hold.Kind {
+	case PortHoldOwned:
+		return PortOwned
+	case PortHoldAvailable:
+		return PortAvailable
+	case PortHoldOccupied:
+		name := strings.TrimSpace(hold.Process)
+		if name != "" && hold.PID > 0 {
+			return fmt.Sprintf(PortOccupiedByNamed, name, hold.PID)
+		}
+		if hold.PID > 0 {
+			return fmt.Sprintf(PortOccupiedByPID, hold.PID)
+		}
+		return PortOccupiedByOtherApp
+	default:
+		return UnknownLabel
+	}
+}
+
+// RenderPortHold paints StatusDot + colored label.
+func RenderPortHold(theme Theme, hold PortHold) string {
+	label := FormatPortHoldLabel(hold)
+	tone := PortHoldTone(hold.Kind)
+	return StatusDot(theme, tone, label)
+}

--- a/internal/tui/ui/portstatus_test.go
+++ b/internal/tui/ui/portstatus_test.go
@@ -1,0 +1,70 @@
+package ui
+
+import "testing"
+
+func TestClassifyPortHold_ListenFreeIsAvailable(t *testing.T) {
+	got := ClassifyPortHold(true, 9736, "mihomo.exe", 42)
+	if got.Kind != PortHoldAvailable {
+		t.Fatalf("kind=%v want available", got.Kind)
+	}
+}
+
+func TestClassifyPortHold_MatchingOwnerPIDIsOwned(t *testing.T) {
+	got := ClassifyPortHold(false, 42, "mihomo.exe", 42)
+	if got.Kind != PortHoldOwned || got.PID != 42 {
+		t.Fatalf("got=%#v", got)
+	}
+}
+
+func TestClassifyPortHold_SameMihomoNameDifferentPIDIsOccupied(t *testing.T) {
+	got := ClassifyPortHold(false, 9736, "mihomo.exe", 42)
+	if got.Kind != PortHoldOccupied || got.PID != 9736 || got.Process != "mihomo.exe" {
+		t.Fatalf("got=%#v", got)
+	}
+}
+
+func TestClassifyPortHold_MihariNameWithoutMatchingPIDIsOccupied(t *testing.T) {
+	got := ClassifyPortHold(false, 88, "mihari.exe", 0)
+	if got.Kind != PortHoldOccupied {
+		t.Fatalf("mihari.exe with no owner pid must not be owned: %#v", got)
+	}
+	got = ClassifyPortHold(false, 88, "mihari.exe", 99)
+	if got.Kind != PortHoldOccupied {
+		t.Fatalf("other mihari.exe must be occupied: %#v", got)
+	}
+}
+
+func TestClassifyPortHold_ZeroOwnerPIDNeverOwned(t *testing.T) {
+	got := ClassifyPortHold(false, 9736, "mihomo.exe", 0)
+	if got.Kind != PortHoldOccupied {
+		t.Fatalf("core pid 0 must treat any mihomo as occupied: %#v", got)
+	}
+}
+
+func TestClassifyPortHold_LookupMissIsUnknown(t *testing.T) {
+	got := ClassifyPortHold(false, 0, "", 42)
+	if got.Kind != PortHoldUnknown {
+		t.Fatalf("got=%#v", got)
+	}
+}
+
+func TestFormatPortHoldLabel_OccupiedIncludesPID(t *testing.T) {
+	if got := FormatPortHoldLabel(PortHold{Kind: PortHoldOccupied, Process: "mihomo.exe", PID: 9736}); got != "Occupied by mihomo.exe (9736)" {
+		t.Fatalf("got=%q", got)
+	}
+	if got := FormatPortHoldLabel(PortHold{Kind: PortHoldOccupied, PID: 9736}); got != "Occupied by PID 9736" {
+		t.Fatalf("got=%q", got)
+	}
+}
+
+func TestPortHoldTone_OccupiedIsDangerOwnedIsPositive(t *testing.T) {
+	if PortHoldTone(PortHoldOccupied) != ToneNegative {
+		t.Fatal("occupied must be danger")
+	}
+	if PortHoldTone(PortHoldOwned) != TonePositive {
+		t.Fatal("owned must be positive")
+	}
+	if PortHoldTone(PortHoldAvailable) != ToneNeutral || PortHoldTone(PortHoldUnknown) != ToneNeutral {
+		t.Fatal("available/unknown must be muted")
+	}
+}

--- a/internal/tui/ui/strings.go
+++ b/internal/tui/ui/strings.go
@@ -206,6 +206,19 @@ const (
 	AboutGitHubURL         = "https://github.com/mihari-proxy/mihari"
 	AboutGitHubOpenFailed  = "Could not open GitHub"
 
+	PortsConfigSectionTitle = "Ports Config"
+	MixedLabel              = "Mixed"
+	ControllerPortLabel     = "Controller"
+	WebPortLabel            = "Web"
+	PortOwned               = "Owned"
+	PortAvailable           = "Available"
+	PortOccupiedByNamed     = "Occupied by %s (%d)"
+	PortOccupiedByPID       = "Occupied by PID %d"
+	PortOccupiedByOtherApp  = "Occupied by other app"
+	FooterPortsEdit         = "Type address  Enter apply  Esc cancel  ? help  q quit"
+	InvalidPortEndpoint     = "Port address is invalid"
+	PortsApplyFailed        = "Could not update ports"
+
 	// Row-local short-verb labels for the Network action rows. The status row
 	// above (and the Network section) already names the object, so the action
 	// row only carries the verb, mirroring coreActionLabel's Install/Update.


### PR DESCRIPTION
System 页新增 Ports Config：可改 Mixed/Controller/Web；按 PID 显示 Owned / Occupied by name (pid)；宽屏双栏。GET /v1/status 加法可选 pid。