### PR TITLE
chore(release): 记录 v0.8.0 变更日志

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@
 
 ### Fixed
 
+## [v0.8.0] - 2026-08-18
+
+### Added
+
+- TUI System 页增加 Ports Config：可改 Mixed / Controller / Web 端口；占用按 PID 显示 Owned 或 Occupied by name (pid)；宽屏双栏（#101）。
+- `GET /v1/status` 增加可选 `pid` 字段（加法，不改既有语义）（#101）。
+
+### Fixed
+
+- TUI Overview 双栏卡片不再从词中间截断 Core / Web GUI 数值（#84, #85）。
+
 ## [v0.7.5] - 2026-08-17
 
 ### Added


### PR DESCRIPTION
## 变更内容

记录 v0.8.0 变更日志（#101, #85）。覆盖：

- TUI System 页 Ports Config 与 `GET /v1/status` 可选 `pid`（#101）
- Overview 双栏卡片截断 Core / Web GUI 数值（#84, #85）

合并后打 annotated tag `v0.8.0` 触发 Release 工作流。

## 类型

- [x] docs: 文档
- [x] chore: 构建/工具

## 检查清单

- [ ] `go test -race ./...` 通过（文档-only，依赖 main 上 #101 / #85 的 CI）
- [x] `go vet ./...` 通过（无 Go 变更）
- [x] `gofmt -l cmd internal` 无输出（无 Go 变更）
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] 未修改 `internal/control/protocol` 契约、CLI 输出/退出码或跨平台行为（本 PR 只记已合并变更）

## 相关 Issues

#101 #84 #85
