### PR TITLE
chore(release): 记录 v0.8.1 变更日志

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
 
 ### Fixed
 
+## [v0.8.1] - 2026-08-18
+
+### Fixed
+
+- TUI System 页改为始终单列，避免宽屏双列截断端口 URL 与 Network 状态（#106）。
+- TUI 侧栏 compact 宽度下 Overview 页签不再换行（#106）。
+
 ## [v0.8.0] - 2026-08-18
 
 ### Added


### PR DESCRIPTION
## 变更内容

记录 v0.8.1 变更日志（#106）。覆盖：

- TUI System 页改为始终单列，避免宽屏双列截断端口 URL 与 Network 状态（#106）
- TUI 侧栏 compact 宽度下 Overview 页签不再换行（#106）

合并后打 annotated tag `v0.8.1` 触发 Release 工作流。

## 类型

- [x] docs: 文档
- [x] chore: 构建/工具

## 检查清单

- [ ] `go test -race ./...` 通过（文档-only，依赖 main 上 #106 的 CI）
- [x] `go vet ./...` 通过（无 Go 变更）
- [x] `gofmt -l cmd internal` 无输出（无 Go 变更）
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] 未修改 `internal/control/protocol` 契约、CLI 输出/退出码或跨平台行为（本 PR 只记已合并变更）

## 相关 Issues

#106