### PR TITLE
fix: 冲突探测忽略 Down 状态的残留 TUN

### DIFF
--- a/internal/tundetect/tundetect.go
+++ b/internal/tundetect/tundetect.go
@@ -2,10 +2,11 @@
 // conflict with this daemon's managed mihomo TUN: other TUN network adapters
 // (signal A) and other mihomo processes (signal B).
 //
-// The package only observes. Detect reports every TUN adapter and every mihomo
-// process on the system without filtering; Classify then subtracts this daemon's
-// own adapter/process using a Self identity supplied by the runtime layer
-// (live tun.enable / tun.device and the supervised core PID). Keeping
+// The package only observes. Detect reports TUN adapters that can currently
+// take routes (Windows: IfOperStatusUp only; leftover Down Wintun devices are
+// ignored) and every mihomo process on the system. Classify then subtracts this
+// daemon's own adapter/process using a Self identity supplied by the runtime
+// layer (live tun.enable / tun.device and the supervised core PID). Keeping
 // detection stateless lets it stay testable and free of runtime dependencies.
 //
 // Platform backends implement unexported detect:
@@ -37,11 +38,12 @@ type Self struct {
 	CorePID int
 }
 
-// Detection is the raw, unfiltered system observation. Neither field has this
-// daemon's own adapter/process subtracted; that happens in Classify.
+// Detection is the system observation after dropping adapters that cannot
+// take routes. Neither field has this daemon's own adapter/process
+// subtracted; that happens in Classify.
 type Detection struct {
-	// TunInterfaces lists every TUN adapter friendly name on the system
-	// (Windows wintun, Linux tun, macOS utun).
+	// TunInterfaces lists TUN adapters that can currently take routes
+	// (Windows wintun/Meta/WireGuard with IfOperStatusUp; Linux tun; macOS utun).
 	TunInterfaces []string
 	// MihomoProcesses lists every mihomo process on the system.
 	MihomoProcesses []Process

--- a/internal/tundetect/tundetect_windows.go
+++ b/internal/tundetect/tundetect_windows.go
@@ -26,8 +26,8 @@ func detect(ctx context.Context) (Detection, error) {
 	return Detection{TunInterfaces: tun, MihomoProcesses: mihomo}, nil
 }
 
-// enumerateWintunAdapters lists network adapters whose description or friendly
-// name marks them as Windows TUN tunnels (wintun, Meta Tunnel / mihomo, WireGuard).
+// enumerateWintunAdapters lists Up Windows TUN tunnels (wintun, Meta Tunnel /
+// mihomo, WireGuard). Down leftover adapters cannot take routes and are omitted.
 func enumerateWintunAdapters() ([]string, error) {
 	var size uint32
 	if err := windows.GetAdaptersAddresses(0, 0x20 /* GAA_FLAG_INCLUDE_FRIENDLY_NAME — fill FriendlyName for friendlier display */, 0, nil, &size); err != nil && err != windows.ERROR_BUFFER_OVERFLOW {
@@ -41,22 +41,15 @@ func enumerateWintunAdapters() ([]string, error) {
 	if err := windows.GetAdaptersAddresses(0, 0x20 /* GAA_FLAG_INCLUDE_FRIENDLY_NAME */, 0, addr, &size); err != nil {
 		return nil, err
 	}
-	var adapters []string
+	var candidates []windowsTunCandidate
 	for a := addr; a != nil; a = a.Next {
-		desc := windows.UTF16PtrToString(a.Description)
-		friendly := windows.UTF16PtrToString(a.FriendlyName)
-		if !isWintun(desc, friendly) {
-			continue
-		}
-		adapters = append(adapters, formatAdapterName(desc, friendly))
+		candidates = append(candidates, windowsTunCandidate{
+			desc:       windows.UTF16PtrToString(a.Description),
+			friendly:   windows.UTF16PtrToString(a.FriendlyName),
+			operStatus: a.OperStatus,
+		})
 	}
-	return adapters, nil
-}
-
-// isWintun reports whether an adapter's description or friendly name identifies
-// it as a Windows TUN tunnel (wintun, Meta Tunnel / mihomo, WireGuard).
-func isWintun(desc, friendly string) bool {
-	return isWindowsTunAdapter(desc, friendly)
+	return collectWindowsTunNames(candidates), nil
 }
 
 // enumerateMihomoProcesses lists running processes whose executable name

--- a/internal/tundetect/windows_names.go
+++ b/internal/tundetect/windows_names.go
@@ -2,6 +2,44 @@ package tundetect
 
 import "strings"
 
+// IfOperStatus values from iptypes.h, duplicated so this file stays
+// OS-agnostic and unit-testable without golang.org/x/sys/windows.
+const (
+	ifOperStatusUp             = 1
+	ifOperStatusDown           = 2
+	ifOperStatusTesting        = 3
+	ifOperStatusUnknown        = 4
+	ifOperStatusDormant        = 5
+	ifOperStatusNotPresent     = 6
+	ifOperStatusLowerLayerDown = 7
+)
+
+// windowsTunCandidate is one GetAdaptersAddresses row before name/status
+// classification. OperStatus is IfOperStatus.
+type windowsTunCandidate struct {
+	desc       string
+	friendly   string
+	operStatus uint32
+}
+
+func isWindowsTunUp(operStatus uint32) bool {
+	return operStatus == ifOperStatusUp
+}
+
+func collectWindowsTunNames(candidates []windowsTunCandidate) []string {
+	var adapters []string
+	for _, candidate := range candidates {
+		if !isWindowsTunUp(candidate.operStatus) {
+			continue
+		}
+		if !isWindowsTunAdapter(candidate.desc, candidate.friendly) {
+			continue
+		}
+		adapters = append(adapters, formatAdapterName(candidate.desc, candidate.friendly))
+	}
+	return adapters
+}
+
 func isWindowsTunAdapter(desc, friendly string) bool {
 	haystack := strings.ToLower(desc + " " + friendly)
 	for _, needle := range []string{"wintun", "meta tunnel", "wireguard"} {

--- a/internal/tundetect/windows_names_test.go
+++ b/internal/tundetect/windows_names_test.go
@@ -1,6 +1,9 @@
 package tundetect
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestIsWindowsTunAdapter(t *testing.T) {
 	tests := []struct {
@@ -37,5 +40,58 @@ func TestFormatAdapterName(t *testing.T) {
 	}
 	if got := formatAdapterName("Wintun Userspace Tunnel", ""); got != "Wintun Userspace Tunnel" {
 		t.Fatalf("got=%q", got)
+	}
+}
+
+func TestCollectWindowsTunNames_SkipsDownLeftover(t *testing.T) {
+	got := collectWindowsTunNames([]windowsTunCandidate{
+		{desc: "Wintun Userspace Tunnel", friendly: "本地连接", operStatus: ifOperStatusDown},
+		{desc: "Meta Tunnel", friendly: "Meta", operStatus: ifOperStatusUp},
+	})
+	want := []string{"Meta (Meta Tunnel)"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got=%q want=%q", got, want)
+	}
+}
+
+func TestCollectWindowsTunNames_DownOnlyIsEmpty(t *testing.T) {
+	got := collectWindowsTunNames([]windowsTunCandidate{
+		{desc: "Wintun Userspace Tunnel", friendly: "本地连接", operStatus: ifOperStatusDown},
+	})
+	if len(got) != 0 {
+		t.Fatalf("got=%q", got)
+	}
+}
+
+func TestCollectWindowsTunNames_KeepsUpCompeting(t *testing.T) {
+	got := collectWindowsTunNames([]windowsTunCandidate{
+		{desc: "Meta Tunnel", friendly: "mihomo", operStatus: ifOperStatusUp},
+	})
+	want := []string{"mihomo (Meta Tunnel)"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got=%q want=%q", got, want)
+	}
+}
+
+func TestIsWindowsTunUp(t *testing.T) {
+	tests := []struct {
+		name       string
+		operStatus uint32
+		want       bool
+	}{
+		{"up", ifOperStatusUp, true},
+		{"down leftover", ifOperStatusDown, false},
+		{"testing", ifOperStatusTesting, false},
+		{"unknown", ifOperStatusUnknown, false},
+		{"dormant", ifOperStatusDormant, false},
+		{"not present", ifOperStatusNotPresent, false},
+		{"lower layer down", ifOperStatusLowerLayerDown, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isWindowsTunUp(tt.operStatus); got != tt.want {
+				t.Fatalf("got=%v want=%v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## 摘要

Windows 上 mihomo / Clash / Sparkle 退出后，Wintun 适配器经常以 **Down / Disconnected** 留在「网络连接」里（现场名常见为「本地连接」）。这类网卡没有会话、没有地址，不能占默认路由，但原先只要描述含 `wintun` 就会进入信号 A，TUI 显示 `Conflict · 1 TUN`。

现在 Windows 信号 A **只收 `IfOperStatusUp`**。Down / Disabled / Dormant 等一律不算冲突。真正在抢路由的 Up 网卡（Sparkle `mihomo (Meta Tunnel)`、另一个 mihomo、WireGuard）仍会门控 Enable。

## 行为变化

- 残留 Down Wintun 不再进入 `TunConflict.OtherTunInterfaces`，不再弹 `CodeTunConflict` / force。
- Up 的竞争 TUN 行为不变。
- `/v1` DTO、错误码、Enable/Disable 不对称门控都不改。

## 实现

- 把 `GetAdaptersAddresses` 行抽成可单测的 `collectWindowsTunNames`（`windows_names.go`）。
- `enumerateWintunAdapters` 带上 `OperStatus` 再分类。
- Linux / Darwin 枚举不变（那边设备通常随 fd 消失）。

## 测试

- `TestCollectWindowsTunNames_SkipsDownLeftover`：Down「本地连接」+ Up `Meta` → 只保留 Meta
- `TestCollectWindowsTunNames_DownOnlyIsEmpty`
- `TestCollectWindowsTunNames_KeepsUpCompeting`
- `TestIsWindowsTunUp`：非 Up 状态全部为 false

本地已跑：`go test ./internal/tundetect`（含 `-race`）、`go test ./internal/runtime ./internal/cli ./internal/control/protocol ./internal/tui/pages/system`、`go vet ./...`。

## 不在本次范围

- 不修 `GAA_FLAG` 注释误写（`0x20` 实际是 `SKIP_FRIENDLY_NAME`）。
- 不从系统里删除残留适配器。
- 不改 Linux / macOS 探测。