### PR TITLE
chore(release): 记录 v0.8.2 变更日志

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### Fixed
 
+## [v0.8.2] - 2026-08-18
+
+### Fixed
+
+- Windows TUN 冲突探测忽略 Down 状态的残留 Wintun 网卡，避免孤儿适配器显示为 Conflict（#111）。
+
 ## [v0.8.1] - 2026-08-18
 
 ### Fixed


### PR DESCRIPTION
## 变更内容

记录 v0.8.2 变更日志（#111）。覆盖：

- Windows TUN 冲突探测忽略 Down 状态的残留 Wintun 网卡，避免孤儿适配器显示为 Conflict（#111）

合并后打 annotated tag `v0.8.2` 触发 Release 工作流。

## 类型

- [x] docs: 文档
- [x] chore: 构建/工具

## 检查清单

- [ ] `go test -race ./...` 通过（文档-only，依赖 main 上 #111 的 CI）
- [x] `go vet ./...` 通过（无 Go 变更）
- [x] `gofmt -l cmd internal` 无输出（无 Go 变更）
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] 未修改 `internal/control/protocol` 契约、CLI 输出/退出码或跨平台行为（本 PR 只记已合并变更）

## 相关 Issues

#111