### PR TITLE
fix(tun): 避免把本实例 mihomo 识别为外部进程

### DIFF
--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mihari-proxy/mihari/internal/geoip"
 	"github.com/mihari-proxy/mihari/internal/mihomo"
 	"github.com/mihari-proxy/mihari/internal/onboarding"
+	"github.com/mihari-proxy/mihari/internal/platform"
 	"github.com/mihari-proxy/mihari/internal/preferences"
 	"github.com/mihari-proxy/mihari/internal/state"
 	"github.com/mihari-proxy/mihari/internal/subscription"
@@ -100,6 +101,9 @@ type Options struct {
 	SysProxy sysproxy.Backend
 	// TunDetect is the TUN conflict detection backend. Nil installs the platform default in New.
 	TunDetect tundetect.Backend
+	// LookupTCPOccupant reports the PID listening on a host:port. Nil installs
+	// platform.LookupTCPOccupant. Tests inject a fake to avoid real socket tables.
+	LookupTCPOccupant func(string) (int, bool)
 	// SettingsPath is where config.Save writes settings after system-proxy (and related) mutations.
 	// Empty skips persistence (in-memory settings only).
 	SettingsPath string
@@ -142,6 +146,7 @@ type Manager struct {
 	webOpenToken      string
 	sysProxy          sysproxy.Backend
 	tunDetect         tundetect.Backend
+	lookupOccupant    func(string) (int, bool)
 	settingsPath      string
 	serviceStatus     func() (string, error)
 	onBackgroundError func(component string, err error)
@@ -182,6 +187,16 @@ func New(options Options) *Manager {
 	if tunDetect == nil {
 		tunDetect = tundetect.Platform()
 	}
+	lookupOccupant := options.LookupTCPOccupant
+	if lookupOccupant == nil {
+		lookupOccupant = func(addr string) (int, bool) {
+			occ, ok := platform.LookupTCPOccupant(addr)
+			if !ok {
+				return 0, false
+			}
+			return occ.PID, true
+		}
+	}
 	manager := &Manager{
 		store:             store,
 		coordinator:       coordinator,
@@ -205,6 +220,7 @@ func New(options Options) *Manager {
 		webOpenToken:      options.WebOpenToken,
 		sysProxy:          sysProxy,
 		tunDetect:         tunDetect,
+		lookupOccupant:    lookupOccupant,
 		settingsPath:      options.SettingsPath,
 		serviceStatus:     options.ServiceStatus,
 		onBackgroundError: options.OnBackgroundError,

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -952,6 +952,9 @@ func newTestManager(options Options) *Manager {
 	if options.TunDetect == nil {
 		options.TunDetect = &tundetect.FakeBackend{}
 	}
+	if options.LookupTCPOccupant == nil {
+		options.LookupTCPOccupant = func(string) (int, bool) { return 0, false }
+	}
 	manager := New(options)
 	manager.store = store
 	return manager

--- a/internal/runtime/tun.go
+++ b/internal/runtime/tun.go
@@ -336,12 +336,25 @@ func (m *Manager) detectTunConflict(ctx context.Context) *protocol.TunConflict {
 	return tundetect.Classify(detection, m.selfFromLive(ctx))
 }
 
-// selfFromLive builds the Classify identity from the running core PID and live
-// tun.enable / tun.device. Detection failures stay best-effort: a missing
-// controller or unreadable configs leave TunActive false so no adapter is
-// subtracted.
+// selfFromLive builds the Classify identity from the running core PID, the
+// process holding the controller address, this daemon's PID, the managed
+// core path, and live tun.enable / tun.device. Occupant lookup is
+// best-effort. A missing controller or unreadable configs leave TunActive
+// false so no adapter is subtracted.
 func (m *Manager) selfFromLive(ctx context.Context) tundetect.Self {
-	self := tundetect.Self{CorePID: m.store.Load().Core.PID}
+	self := tundetect.Self{
+		CorePID:    m.store.Load().Core.PID,
+		DaemonPID:  os.Getpid(),
+		BinaryPath: m.installRequest.BinaryPath,
+	}
+	m.settingsMu.Lock()
+	controllerAddr := m.settings.ControllerAddr
+	m.settingsMu.Unlock()
+	if m.lookupOccupant != nil && controllerAddr != "" {
+		if pid, ok := m.lookupOccupant(controllerAddr); ok && pid > 0 {
+			self.OccupantPID = pid
+		}
+	}
 	if m.controller == nil || ctx.Err() != nil {
 		return self
 	}

--- a/internal/runtime/tun.go
+++ b/internal/runtime/tun.go
@@ -347,6 +347,9 @@ func (m *Manager) selfFromLive(ctx context.Context) tundetect.Self {
 		DaemonPID:  os.Getpid(),
 		BinaryPath: m.installRequest.BinaryPath,
 	}
+	if m.controller == nil || ctx.Err() != nil {
+		return self
+	}
 	m.settingsMu.Lock()
 	controllerAddr := m.settings.ControllerAddr
 	m.settingsMu.Unlock()
@@ -354,9 +357,6 @@ func (m *Manager) selfFromLive(ctx context.Context) tundetect.Self {
 		if pid, ok := m.lookupOccupant(controllerAddr); ok && pid > 0 {
 			self.OccupantPID = pid
 		}
-	}
-	if m.controller == nil || ctx.Err() != nil {
-		return self
 	}
 	configs, err := m.controller.Configs(ctx)
 	if err != nil {

--- a/internal/runtime/tun_test.go
+++ b/internal/runtime/tun_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/mihari-proxy/mihari/internal/config"
 	"github.com/mihari-proxy/mihari/internal/control/protocol"
+	"github.com/mihari-proxy/mihari/internal/core"
 	"github.com/mihari-proxy/mihari/internal/state"
 	"github.com/mihari-proxy/mihari/internal/subscription"
 	"github.com/mihari-proxy/mihari/internal/tundetect"
@@ -561,4 +563,137 @@ func TestEnableTunNotGatedWhenDetectionFails(t *testing.T) {
 	if status.Conflict != nil {
 		t.Fatalf("conflict=%#v; detection failure must yield nil conflict evidence", status.Conflict)
 	}
+}
+
+func TestTunStatusSubtractsSelfWhenCorePIDZeroButOccupantMatches(t *testing.T) {
+	controller := &fakeController{configs: map[string]any{}}
+	settings := defaultTunSettings(nil)
+	manager := newTestManager(Options{
+		Controller:   controller,
+		SettingsPath: persistTunSettings(t, settings),
+		Settings:     settings,
+		TunDetect: &tundetect.FakeBackend{
+			Detection: tundetect.Detection{MihomoProcesses: []tundetect.Process{{Name: "mihomo.exe", PID: 43560}}},
+		},
+		LookupTCPOccupant: func(addr string) (int, bool) {
+			if addr != settings.ControllerAddr {
+				t.Fatalf("occupant lookup addr=%q want %q", addr, settings.ControllerAddr)
+			}
+			return 43560, true
+		},
+	})
+
+	status, err := manager.TunStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Conflict != nil {
+		t.Fatalf("conflict=%#v, want nil when controller occupant is our mihomo", status.Conflict)
+	}
+}
+
+func TestTunStatusSubtractsSelfWhenCorePIDZeroButParentMatches(t *testing.T) {
+	controller := &fakeController{configs: map[string]any{}}
+	settings := defaultTunSettings(nil)
+	manager := newTestManager(Options{
+		Controller:   controller,
+		SettingsPath: persistTunSettings(t, settings),
+		Settings:     settings,
+		TunDetect: &tundetect.FakeBackend{
+			Detection: tundetect.Detection{MihomoProcesses: []tundetect.Process{
+				{Name: "mihomo.exe", PID: 43560, ParentPID: os.Getpid()},
+			}},
+		},
+	})
+
+	status, err := manager.TunStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Conflict != nil {
+		t.Fatalf("conflict=%#v, want nil when parent is this daemon", status.Conflict)
+	}
+}
+
+func TestTunStatusSubtractsSelfWhenCorePIDZeroButPathMatches(t *testing.T) {
+	controller := &fakeController{configs: map[string]any{}}
+	settings := defaultTunSettings(nil)
+	corePath := filepath.Join(t.TempDir(), "mihomo.exe")
+	manager := newTestManager(Options{
+		Controller:     controller,
+		SettingsPath:   persistTunSettings(t, settings),
+		Settings:       settings,
+		InstallRequest: core.InstallRequest{BinaryPath: corePath},
+		TunDetect: &tundetect.FakeBackend{
+			Detection: tundetect.Detection{MihomoProcesses: []tundetect.Process{
+				{Name: "mihomo.exe", PID: 43560, Path: corePath},
+			}},
+		},
+	})
+
+	status, err := manager.TunStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Conflict != nil {
+		t.Fatalf("conflict=%#v, want nil when image path is the managed core", status.Conflict)
+	}
+}
+
+func TestTunStatusStaleCorePIDUsesOccupant(t *testing.T) {
+	controller := &fakeController{configs: map[string]any{}}
+	settings := defaultTunSettings(nil)
+	manager := newTestManager(Options{
+		Controller:   controller,
+		SettingsPath: persistTunSettings(t, settings),
+		Settings:     settings,
+		TunDetect: &tundetect.FakeBackend{
+			Detection: tundetect.Detection{MihomoProcesses: []tundetect.Process{{Name: "mihomo.exe", PID: 43560}}},
+		},
+		LookupTCPOccupant: func(string) (int, bool) { return 43560, true },
+	})
+	manager.store.Store(state.Snapshot{Health: "ok", Core: state.CoreState{PID: 11111}})
+
+	status, err := manager.TunStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Conflict != nil {
+		t.Fatalf("conflict=%#v, want nil when occupant matches live pid", status.Conflict)
+	}
+}
+
+func TestTunStatusKeepsForeignMihomoWhenIdentityDoesNotMatch(t *testing.T) {
+	controller := &fakeController{configs: map[string]any{}}
+	settings := defaultTunSettings(nil)
+	manager := newTestManager(Options{
+		Controller:     controller,
+		SettingsPath:   persistTunSettings(t, settings),
+		Settings:       settings,
+		InstallRequest: core.InstallRequest{BinaryPath: filepath.Join(t.TempDir(), "mihomo.exe")},
+		TunDetect: &tundetect.FakeBackend{
+			Detection: tundetect.Detection{MihomoProcesses: []tundetect.Process{
+				{Name: "Sparkle-mihomo.exe", PID: 99, ParentPID: 8, Path: `C:\Sparkle\mihomo.exe`},
+			}},
+		},
+		LookupTCPOccupant: func(string) (int, bool) { return 43560, true },
+	})
+	manager.store.Store(state.Snapshot{Health: "ok", Core: state.CoreState{PID: 43560}})
+
+	status, err := manager.TunStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Conflict == nil || len(status.Conflict.OtherMihomoProcesses) != 1 || status.Conflict.OtherMihomoProcesses[0] != "Sparkle-mihomo.exe (99)" {
+		t.Fatalf("conflict=%#v", status.Conflict)
+	}
+}
+
+func persistTunSettings(t *testing.T, settings config.Settings) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "settings.yaml")
+	if err := config.Save(path, settings); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }

--- a/internal/runtime/tun_test.go
+++ b/internal/runtime/tun_test.go
@@ -689,6 +689,39 @@ func TestTunStatusKeepsForeignMihomoWhenIdentityDoesNotMatch(t *testing.T) {
 	}
 }
 
+func TestSelfFromLiveSkipsOccupantLookupWithoutController(t *testing.T) {
+	calls := 0
+	manager := newTestManager(Options{
+		Settings: defaultTunSettings(nil),
+		LookupTCPOccupant: func(string) (int, bool) {
+			calls++
+			return 123, true
+		},
+	})
+	manager.controller = nil
+	manager.selfFromLive(context.Background())
+	if calls != 0 {
+		t.Fatalf("occupant lookup calls=%d, want 0 without controller", calls)
+	}
+}
+
+func TestSelfFromLiveSkipsOccupantLookupWhenContextCanceled(t *testing.T) {
+	calls := 0
+	manager := newTestManager(Options{
+		Settings: defaultTunSettings(nil),
+		LookupTCPOccupant: func(string) (int, bool) {
+			calls++
+			return 123, true
+		},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	manager.selfFromLive(ctx)
+	if calls != 0 {
+		t.Fatalf("occupant lookup calls=%d, want 0 when context is canceled", calls)
+	}
+}
+
 func persistTunSettings(t *testing.T, settings config.Settings) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "settings.yaml")

--- a/internal/tundetect/classify.go
+++ b/internal/tundetect/classify.go
@@ -2,6 +2,7 @@ package tundetect
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/mihari-proxy/mihari/internal/control/protocol"
@@ -16,11 +17,12 @@ import (
 // adapter only when mihomo's live tun.enable is true. When TunName is known,
 // the matching listed name is dropped; when it is empty, exactly one entry
 // is dropped (name unknown, so the count is conservative). Process
-// subtraction matches self.CorePID; a zero PID means identity is unknown
-// and nothing is dropped (signal B does not gate enable).
+// subtraction treats a process as self when any identity matches: CorePID,
+// controller OccupantPID, parent==DaemonPID, or managed BinaryPath. An empty
+// identity drops nothing (signal B does not gate enable).
 func Classify(d Detection, self Self) *protocol.TunConflict {
 	otherTun := subtractSelfTun(d.TunInterfaces, self)
-	otherMihomo := formatOtherProcesses(d.MihomoProcesses, self.CorePID)
+	otherMihomo := formatOtherProcesses(d.MihomoProcesses, self)
 	if len(otherTun) == 0 && len(otherMihomo) == 0 {
 		return nil
 	}
@@ -48,17 +50,40 @@ func subtractSelfTun(ifaces []string, self Self) []string {
 	return ifaces
 }
 
-func formatOtherProcesses(procs []Process, corePID int) []string {
+func formatOtherProcesses(procs []Process, self Self) []string {
 	var out []string
-	dropped := false
 	for _, p := range procs {
-		if !dropped && corePID != 0 && p.PID == corePID {
-			dropped = true
+		if isSelfProcess(p, self) {
 			continue
 		}
 		out = append(out, formatProcess(p))
 	}
 	return out
+}
+
+func isSelfProcess(p Process, self Self) bool {
+	if p.PID <= 0 {
+		return false
+	}
+	if self.CorePID != 0 && p.PID == self.CorePID {
+		return true
+	}
+	if self.OccupantPID != 0 && p.PID == self.OccupantPID {
+		return true
+	}
+	if self.DaemonPID != 0 && p.ParentPID != 0 && p.ParentPID == self.DaemonPID {
+		return true
+	}
+	return binaryPathMatch(p.Path, self.BinaryPath)
+}
+
+func binaryPathMatch(listed, want string) bool {
+	listed = strings.TrimSpace(listed)
+	want = strings.TrimSpace(want)
+	if listed == "" || want == "" {
+		return false
+	}
+	return strings.EqualFold(filepath.Clean(listed), filepath.Clean(want))
 }
 
 func formatProcess(p Process) string {

--- a/internal/tundetect/classify.go
+++ b/internal/tundetect/classify.go
@@ -3,6 +3,7 @@ package tundetect
 import (
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/mihari-proxy/mihari/internal/control/protocol"
@@ -65,16 +66,30 @@ func isSelfProcess(p Process, self Self) bool {
 	if p.PID <= 0 {
 		return false
 	}
-	if self.CorePID != 0 && p.PID == self.CorePID {
-		return true
-	}
 	if self.OccupantPID != 0 && p.PID == self.OccupantPID {
 		return true
 	}
 	if self.DaemonPID != 0 && p.ParentPID != 0 && p.ParentPID == self.DaemonPID {
 		return true
 	}
-	return binaryPathMatch(p.Path, self.BinaryPath)
+	if binaryPathMatch(p.Path, self.BinaryPath) {
+		return true
+	}
+	if self.CorePID == 0 || p.PID != self.CorePID {
+		return false
+	}
+	// A stored core PID may be stale and reused by a foreign process. When
+	// live identities are available, they must not contradict this process.
+	if self.OccupantPID != 0 && p.PID != self.OccupantPID {
+		return false
+	}
+	if self.DaemonPID != 0 && p.ParentPID != 0 && p.ParentPID != self.DaemonPID {
+		return false
+	}
+	if self.BinaryPath != "" && p.Path != "" && !binaryPathMatch(p.Path, self.BinaryPath) {
+		return false
+	}
+	return true
 }
 
 func binaryPathMatch(listed, want string) bool {
@@ -83,7 +98,11 @@ func binaryPathMatch(listed, want string) bool {
 	if listed == "" || want == "" {
 		return false
 	}
-	return strings.EqualFold(filepath.Clean(listed), filepath.Clean(want))
+	cleanListed, cleanWant := filepath.Clean(listed), filepath.Clean(want)
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(cleanListed, cleanWant)
+	}
+	return cleanListed == cleanWant
 }
 
 func formatProcess(p Process) string {

--- a/internal/tundetect/classify_test.go
+++ b/internal/tundetect/classify_test.go
@@ -2,6 +2,7 @@ package tundetect
 
 import (
 	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/mihari-proxy/mihari/internal/control/protocol"
@@ -170,11 +171,26 @@ func TestClassify_SubtractsByBinaryPathWhenCorePIDUnknown(t *testing.T) {
 }
 
 func TestClassify_BinaryPathMatchIgnoresCase(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("case-insensitive executable paths are Windows-specific")
+	}
 	got := Classify(Detection{
 		MihomoProcesses: []Process{{Name: "mihomo.exe", PID: 43560, Path: `C:\ProgramData\Mihari\mihomo.exe`}},
 	}, Self{BinaryPath: `c:\programdata\mihari\mihomo.exe`})
 	if got != nil {
 		t.Fatalf("got=%#v, want nil after case-insensitive path match", got)
+	}
+}
+
+func TestClassify_BinaryPathMatchKeepsDifferentCaseForeignProcessOnUnix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix paths are case-sensitive")
+	}
+	got := Classify(Detection{
+		MihomoProcesses: []Process{{Name: "mihomo", PID: 43560, Path: "/opt/Mihari/mihomo"}},
+	}, Self{BinaryPath: "/opt/mihari/mihomo"})
+	if got == nil || len(got.OtherMihomoProcesses) != 1 {
+		t.Fatalf("got=%#v, want differently cased foreign process retained", got)
 	}
 }
 
@@ -184,6 +200,18 @@ func TestClassify_StaleCorePIDStillSubtractsByOccupant(t *testing.T) {
 	}, Self{CorePID: 11111, OccupantPID: 43560})
 	if got != nil {
 		t.Fatalf("got=%#v, want nil when occupant matches live pid", got)
+	}
+}
+
+func TestClassify_StaleCorePIDKeepsForeignAndSubtractsOccupant(t *testing.T) {
+	got := Classify(Detection{
+		MihomoProcesses: []Process{
+			{Name: "foreign-mihomo", PID: 11111, ParentPID: 999},
+			{Name: "mihomo", PID: 43560, ParentPID: 999},
+		},
+	}, Self{CorePID: 11111, OccupantPID: 43560})
+	if got == nil || len(got.OtherMihomoProcesses) != 1 || got.OtherMihomoProcesses[0] != "foreign-mihomo (11111)" {
+		t.Fatalf("got=%#v", got)
 	}
 }
 

--- a/internal/tundetect/classify_test.go
+++ b/internal/tundetect/classify_test.go
@@ -141,3 +141,60 @@ func TestClassify_UnknownPIDKeepsAllProcesses(t *testing.T) {
 		t.Fatalf("got=%#v", got)
 	}
 }
+
+func TestClassify_SubtractsByOccupantPIDWhenCorePIDUnknown(t *testing.T) {
+	got := Classify(Detection{
+		MihomoProcesses: []Process{{Name: "mihomo.exe", PID: 43560}},
+	}, Self{OccupantPID: 43560})
+	if got != nil {
+		t.Fatalf("got=%#v, want nil after occupant match", got)
+	}
+}
+
+func TestClassify_SubtractsByParentPIDWhenCorePIDUnknown(t *testing.T) {
+	got := Classify(Detection{
+		MihomoProcesses: []Process{{Name: "mihomo.exe", PID: 43560, ParentPID: 36560}},
+	}, Self{DaemonPID: 36560})
+	if got != nil {
+		t.Fatalf("got=%#v, want nil after parent match", got)
+	}
+}
+
+func TestClassify_SubtractsByBinaryPathWhenCorePIDUnknown(t *testing.T) {
+	got := Classify(Detection{
+		MihomoProcesses: []Process{{Name: "mihomo.exe", PID: 43560, Path: `C:\ProgramData\mihari\mihomo.exe`}},
+	}, Self{BinaryPath: `C:\ProgramData\mihari\mihomo.exe`})
+	if got != nil {
+		t.Fatalf("got=%#v, want nil after path match", got)
+	}
+}
+
+func TestClassify_BinaryPathMatchIgnoresCase(t *testing.T) {
+	got := Classify(Detection{
+		MihomoProcesses: []Process{{Name: "mihomo.exe", PID: 43560, Path: `C:\ProgramData\Mihari\mihomo.exe`}},
+	}, Self{BinaryPath: `c:\programdata\mihari\mihomo.exe`})
+	if got != nil {
+		t.Fatalf("got=%#v, want nil after case-insensitive path match", got)
+	}
+}
+
+func TestClassify_StaleCorePIDStillSubtractsByOccupant(t *testing.T) {
+	got := Classify(Detection{
+		MihomoProcesses: []Process{{Name: "mihomo.exe", PID: 43560}},
+	}, Self{CorePID: 11111, OccupantPID: 43560})
+	if got != nil {
+		t.Fatalf("got=%#v, want nil when occupant matches live pid", got)
+	}
+}
+
+func TestClassify_KeepsForeignWhenFallbacksDoNotMatch(t *testing.T) {
+	got := Classify(Detection{
+		MihomoProcesses: []Process{
+			{Name: "mihomo.exe", PID: 43560, ParentPID: 36560, Path: `C:\ProgramData\mihari\mihomo.exe`},
+			{Name: "Sparkle-mihomo.exe", PID: 99, ParentPID: 8, Path: `C:\Sparkle\mihomo.exe`},
+		},
+	}, Self{CorePID: 43560, DaemonPID: 36560, OccupantPID: 43560, BinaryPath: `C:\ProgramData\mihari\mihomo.exe`})
+	if got == nil || len(got.OtherMihomoProcesses) != 1 || got.OtherMihomoProcesses[0] != "Sparkle-mihomo.exe (99)" {
+		t.Fatalf("got=%#v", got)
+	}
+}

--- a/internal/tundetect/process_identity.go
+++ b/internal/tundetect/process_identity.go
@@ -1,0 +1,42 @@
+package tundetect
+
+import (
+	"strconv"
+	"strings"
+)
+
+// parseLinuxStatPPID reads the parent pid from a /proc/<pid>/stat payload.
+// The comm field is parenthesis-delimited and may contain spaces.
+func parseLinuxStatPPID(stat string) (int, bool) {
+	end := strings.LastIndex(stat, ")")
+	if end < 0 || end+1 >= len(stat) {
+		return 0, false
+	}
+	fields := strings.Fields(stat[end+1:])
+	if len(fields) < 2 {
+		return 0, false
+	}
+	ppid, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return 0, false
+	}
+	return ppid, true
+}
+
+// parseDarwinProcessLine parses `ps -eo comm=,pid=,ppid=` output. comm may be a
+// path, so pid and ppid are the last two fields.
+func parseDarwinProcessLine(line string) (name string, pid, ppid int, ok bool) {
+	fields := strings.Fields(line)
+	if len(fields) < 3 {
+		return "", 0, 0, false
+	}
+	ppid, err := strconv.Atoi(fields[len(fields)-1])
+	if err != nil {
+		return "", 0, 0, false
+	}
+	pid, err = strconv.Atoi(fields[len(fields)-2])
+	if err != nil {
+		return "", 0, 0, false
+	}
+	return strings.Join(fields[:len(fields)-2], " "), pid, ppid, true
+}

--- a/internal/tundetect/process_identity.go
+++ b/internal/tundetect/process_identity.go
@@ -23,20 +23,30 @@ func parseLinuxStatPPID(stat string) (int, bool) {
 	return ppid, true
 }
 
-// parseDarwinProcessLine parses `ps -eo comm=,pid=,ppid=` output. comm may be a
-// path, so pid and ppid are the last two fields.
+// parseDarwinProcessLine parses `ps -eo pid=,ppid=,comm=` output. The command
+// remainder may be a path containing repeated whitespace.
 func parseDarwinProcessLine(line string) (name string, pid, ppid int, ok bool) {
-	fields := strings.Fields(line)
-	if len(fields) < 3 {
+	rest := strings.TrimLeft(line, " \t")
+	firstEnd := strings.IndexAny(rest, " \t")
+	if firstEnd < 0 {
 		return "", 0, 0, false
 	}
-	ppid, err := strconv.Atoi(fields[len(fields)-1])
+	pid, err := strconv.Atoi(rest[:firstEnd])
 	if err != nil {
 		return "", 0, 0, false
 	}
-	pid, err = strconv.Atoi(fields[len(fields)-2])
+	rest = strings.TrimLeft(rest[firstEnd:], " \t")
+	secondEnd := strings.IndexAny(rest, " \t")
+	if secondEnd < 0 {
+		return "", 0, 0, false
+	}
+	ppid, err = strconv.Atoi(rest[:secondEnd])
 	if err != nil {
 		return "", 0, 0, false
 	}
-	return strings.Join(fields[:len(fields)-2], " "), pid, ppid, true
+	name = strings.TrimLeft(rest[secondEnd:], " \t")
+	if name == "" {
+		return "", 0, 0, false
+	}
+	return name, pid, ppid, true
 }

--- a/internal/tundetect/process_identity_test.go
+++ b/internal/tundetect/process_identity_test.go
@@ -1,0 +1,39 @@
+package tundetect
+
+import "testing"
+
+func TestParseLinuxStatPPID_SimpleComm(t *testing.T) {
+	got, ok := parseLinuxStatPPID("43560 (mihomo) S 36560 36560 36560 0 -1")
+	if !ok || got != 36560 {
+		t.Fatalf("got=%d ok=%v", got, ok)
+	}
+}
+
+func TestParseLinuxStatPPID_CommWithSpaces(t *testing.T) {
+	got, ok := parseLinuxStatPPID("10 (mihomo extra) R 1 2 3")
+	if !ok || got != 1 {
+		t.Fatalf("got=%d ok=%v", got, ok)
+	}
+}
+
+func TestParseLinuxStatPPID_RejectsMalformed(t *testing.T) {
+	if _, ok := parseLinuxStatPPID("no-paren S 1"); ok {
+		t.Fatal("expected reject")
+	}
+	if _, ok := parseLinuxStatPPID("1 (mihomo) S"); ok {
+		t.Fatal("expected reject missing ppid")
+	}
+}
+
+func TestParseDarwinProcessLine(t *testing.T) {
+	name, pid, ppid, ok := parseDarwinProcessLine("/usr/local/bin/mihomo 43560 36560")
+	if !ok || name != "/usr/local/bin/mihomo" || pid != 43560 || ppid != 36560 {
+		t.Fatalf("name=%q pid=%d ppid=%d ok=%v", name, pid, ppid, ok)
+	}
+}
+
+func TestParseDarwinProcessLine_RejectsShort(t *testing.T) {
+	if _, _, _, ok := parseDarwinProcessLine("mihomo 123"); ok {
+		t.Fatal("expected reject")
+	}
+}

--- a/internal/tundetect/process_identity_test.go
+++ b/internal/tundetect/process_identity_test.go
@@ -26,8 +26,15 @@ func TestParseLinuxStatPPID_RejectsMalformed(t *testing.T) {
 }
 
 func TestParseDarwinProcessLine(t *testing.T) {
-	name, pid, ppid, ok := parseDarwinProcessLine("/usr/local/bin/mihomo 43560 36560")
+	name, pid, ppid, ok := parseDarwinProcessLine("43560 36560 /usr/local/bin/mihomo")
 	if !ok || name != "/usr/local/bin/mihomo" || pid != 43560 || ppid != 36560 {
+		t.Fatalf("name=%q pid=%d ppid=%d ok=%v", name, pid, ppid, ok)
+	}
+}
+
+func TestParseDarwinProcessLine_PreservesRepeatedWhitespaceInCommand(t *testing.T) {
+	name, pid, ppid, ok := parseDarwinProcessLine("43560 36560 /Applications/Mihari  2/mihomo")
+	if !ok || name != "/Applications/Mihari  2/mihomo" || pid != 43560 || ppid != 36560 {
 		t.Fatalf("name=%q pid=%d ppid=%d ok=%v", name, pid, ppid, ok)
 	}
 }

--- a/internal/tundetect/tundetect.go
+++ b/internal/tundetect/tundetect.go
@@ -6,8 +6,9 @@
 // take routes (Windows: IfOperStatusUp only; leftover Down Wintun devices are
 // ignored) and every mihomo process on the system. Classify then subtracts this
 // daemon's own adapter/process using a Self identity supplied by the runtime
-// layer (live tun.enable / tun.device and the supervised core PID). Keeping
-// detection stateless lets it stay testable and free of runtime dependencies.
+// layer (live tun.enable / tun.device, supervised core PID, controller
+// occupant, parent PID, and managed binary path). Keeping detection
+// stateless lets it stay testable and free of runtime dependencies.
 //
 // Platform backends implement unexported detect:
 //   - Windows: IP adapter table (wintun) + toolhelp process snapshot
@@ -20,11 +21,14 @@ package tundetect
 
 import "context"
 
-// Process is one observed mihomo process. Classify subtracts by PID and
-// formats the remainder as "name (pid)" for the protocol layer.
+// Process is one observed mihomo process. Classify subtracts by identity
+// (supervised PID, controller occupant, parent PID, or managed binary path)
+// and formats the remainder as "name (pid)" for the protocol layer.
 type Process struct {
-	Name string
-	PID  int
+	Name      string
+	PID       int
+	ParentPID int
+	Path      string
 }
 
 // Self is this daemon's identity used by Classify to subtract our own
@@ -36,6 +40,12 @@ type Self struct {
 	TunName string
 	// CorePID is the supervised mihomo PID; zero means unknown.
 	CorePID int
+	// OccupantPID is the process listening on this daemon's controller address.
+	OccupantPID int
+	// DaemonPID is this daemon process; a mihomo whose parent matches is self.
+	DaemonPID int
+	// BinaryPath is the managed core executable; a matching image path is self.
+	BinaryPath string
 }
 
 // Detection is the system observation after dropping adapters that cannot

--- a/internal/tundetect/tundetect_darwin.go
+++ b/internal/tundetect/tundetect_darwin.go
@@ -5,7 +5,6 @@ package tundetect
 import (
 	"context"
 	"os/exec"
-	"strconv"
 	"strings"
 )
 
@@ -39,27 +38,29 @@ func enumerateDarwinTun(ctx context.Context) ([]string, error) {
 	return tun, nil
 }
 
-// enumerateDarwinMihomo lists mihomo processes via "ps -eo comm=,pid=". The
-// comm column may carry a full path; the trailing field is the pid.
+// enumerateDarwinMihomo lists mihomo processes via "ps -eo comm=,pid=,ppid=".
+// The comm column may carry a full path; pid and ppid are the last two fields.
 func enumerateDarwinMihomo(ctx context.Context) ([]Process, error) {
-	out, err := exec.CommandContext(ctx, "ps", "-eo", "comm=,pid=").Output()
+	out, err := exec.CommandContext(ctx, "ps", "-eo", "comm=,pid=,ppid=").Output()
 	if err != nil {
 		return nil, err
 	}
 	var procs []Process
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		fields := strings.Fields(line)
-		if len(fields) < 2 {
+		name, pid, ppid, ok := parseDarwinProcessLine(line)
+		if !ok {
 			continue
 		}
-		comm := fields[0]
-		pid, err := strconv.Atoi(fields[len(fields)-1])
-		if err != nil {
-			continue
-		}
-		if strings.Contains(strings.ToLower(comm), "mihomo") {
-			procs = append(procs, Process{Name: comm, PID: pid})
+		if strings.Contains(strings.ToLower(name), "mihomo") {
+			procs = append(procs, Process{Name: name, PID: pid, ParentPID: ppid, Path: darwinProcessPath(name)})
 		}
 	}
 	return procs, nil
+}
+
+func darwinProcessPath(comm string) string {
+	if strings.Contains(comm, "/") {
+		return comm
+	}
+	return ""
 }

--- a/internal/tundetect/tundetect_darwin.go
+++ b/internal/tundetect/tundetect_darwin.go
@@ -38,10 +38,10 @@ func enumerateDarwinTun(ctx context.Context) ([]string, error) {
 	return tun, nil
 }
 
-// enumerateDarwinMihomo lists mihomo processes via "ps -eo comm=,pid=,ppid=".
-// The comm column may carry a full path; pid and ppid are the last two fields.
+// enumerateDarwinMihomo lists mihomo processes via "ps -eo pid=,ppid=,comm=".
+// PID and parent PID precede comm so command-path whitespace is preserved.
 func enumerateDarwinMihomo(ctx context.Context) ([]Process, error) {
-	out, err := exec.CommandContext(ctx, "ps", "-eo", "comm=,pid=,ppid=").Output()
+	out, err := exec.CommandContext(ctx, "ps", "-eo", "pid=,ppid=,comm=").Output()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tundetect/tundetect_linux.go
+++ b/internal/tundetect/tundetect_linux.go
@@ -67,9 +67,34 @@ func enumerateLinuxMihomo() ([]Process, error) {
 		if err != nil {
 			continue
 		}
-		procs = append(procs, Process{Name: name, PID: pid})
+		procs = append(procs, Process{
+			Name:      name,
+			PID:       pid,
+			ParentPID: linuxParentPID(e.Name()),
+			Path:      linuxProcessPath(e.Name()),
+		})
 	}
 	return procs, nil
+}
+
+func linuxParentPID(pid string) int {
+	stat, err := os.ReadFile(filepath.Join("/proc", pid, "stat"))
+	if err != nil {
+		return 0
+	}
+	ppid, ok := parseLinuxStatPPID(string(stat))
+	if !ok {
+		return 0
+	}
+	return ppid
+}
+
+func linuxProcessPath(pid string) string {
+	path, err := os.Readlink(filepath.Join("/proc", pid, "exe"))
+	if err != nil {
+		return ""
+	}
+	return path
 }
 
 func isAllDigits(s string) bool {

--- a/internal/tundetect/tundetect_linux.go
+++ b/internal/tundetect/tundetect_linux.go
@@ -94,7 +94,11 @@ func linuxProcessPath(pid string) string {
 	if err != nil {
 		return ""
 	}
-	return path
+	return trimDeletedProcessPath(path)
+}
+
+func trimDeletedProcessPath(path string) string {
+	return strings.TrimSuffix(path, " (deleted)")
 }
 
 func isAllDigits(s string) bool {

--- a/internal/tundetect/tundetect_linux_test.go
+++ b/internal/tundetect/tundetect_linux_test.go
@@ -1,0 +1,11 @@
+//go:build linux
+
+package tundetect
+
+import "testing"
+
+func TestLinuxProcessPathStripsDeletedSuffix(t *testing.T) {
+	if got := trimDeletedProcessPath("/opt/mihomo (deleted)"); got != "/opt/mihomo" {
+		t.Fatalf("got=%q", got)
+	}
+}

--- a/internal/tundetect/tundetect_windows.go
+++ b/internal/tundetect/tundetect_windows.go
@@ -69,7 +69,12 @@ func enumerateMihomoProcesses() ([]Process, error) {
 	for {
 		exe := windows.UTF16ToString(entry.ExeFile[:])
 		if strings.Contains(strings.ToLower(exe), "mihomo") {
-			procs = append(procs, Process{Name: exe, PID: int(entry.ProcessID)})
+			procs = append(procs, Process{
+				Name:      exe,
+				PID:       int(entry.ProcessID),
+				ParentPID: int(entry.ParentProcessID),
+				Path:      windowsProcessPath(entry.ProcessID),
+			})
 		}
 		if err := windows.Process32Next(snapshot, &entry); err != nil {
 			if err == windows.ERROR_NO_MORE_FILES {
@@ -79,4 +84,18 @@ func enumerateMihomoProcesses() ([]Process, error) {
 		}
 	}
 	return procs, nil
+}
+
+func windowsProcessPath(pid uint32) string {
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, pid)
+	if err != nil {
+		return ""
+	}
+	defer windows.CloseHandle(handle)
+	buf := make([]uint16, 32768)
+	size := uint32(len(buf))
+	if err := windows.QueryFullProcessImageName(handle, 0, &buf[0], &size); err != nil {
+		return ""
+	}
+	return windows.UTF16ToString(buf[:size])
 }

--- a/internal/tundetect/tundetect_windows_test.go
+++ b/internal/tundetect/tundetect_windows_test.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package tundetect
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWindowsProcessPathMatchesExecutable(t *testing.T) {
+	got := windowsProcessPath(uint32(os.Getpid()))
+	if got == "" {
+		t.Fatal("empty image path")
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.EqualFold(filepath.Clean(got), filepath.Clean(exe)) {
+		t.Fatalf("got=%q want=%q", got, exe)
+	}
+}


### PR DESCRIPTION
## 摘要

TUI 会把 Mihari 自己监督的 `mihomo.exe` 画成 `Conflict · N TUN + 1 mihomo`。根因是 `Classify` 只按 `store.Core.PID` 扣自身；PID 为 0 或过期时，本实例进程会留在信号 B 里。

现在除监督器 PID 外，下面任一命中也视为自身：

1. 占着本实例控制器口的进程
2. 父进程等于本 daemon
3. 映像路径等于托管的 core 二进制（Windows 忽略大小写）

对不上的第二份 mihomo（例如 Sparkle）仍会留下。`/v1` DTO、错误码、Enable 只靠信号 A 门控都不改。

## 实现

- `tundetect.Self` 增加 `OccupantPID` / `DaemonPID` / `BinaryPath`；`Process` 增加 `ParentPID` / `Path`
- 各平台 Detect 填父 PID 和映像路径
- `runtime.selfFromLive` 注入 daemon PID、托管路径，并 best-effort 查控制器口占用者（可注入，测试不读真实套接字表）

## 测试

- Classify：occupant / parent / path / 过期 Core.PID / 真正的外部进程
- TunStatus：Core.PID=0 时靠 occupant、parent、path 扣自身；外部进程仍报 Conflict
- Windows：`windowsProcessPath` 对当前进程与 `os.Executable` 一致
- Linux/Darwin 解析器表驱动

本地已跑：`go test ./internal/tundetect ./internal/runtime`（含 `-race`）、`go test ./internal/integration -run Tun|SysProxy`、`go vet`、`CGO_ENABLED=0` 交叉编译 windows/linux/darwin。

## 不在本次范围

- 不改 TUI 文案或 Conflict 徽章语义
- 不从系统里结束外部 mihomo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TUN status detection when the core process ID is missing or outdated.
  * Reduced false process conflicts by reliably identifying the managed process through its controller connection, parent process, or executable path.
  * Preserved detection of unrelated Mihomo processes as genuine conflicts.
  * Improved process identification across Linux, macOS, and Windows, including handling of varied process names and executable-path casing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->