### PR TITLE
docs: 在 README 中追加 LINUX DO 社区认可

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o bin/mihari ./cmd/mihari
 
 The architecture invariants, package boundaries, and contribution guidance are recorded in [AGENTS.md](AGENTS.md) and [CONTRIBUTING.md](.github/CONTRIBUTING.md). See [docs/RELEASE.md](docs/RELEASE.md) for the release process.
 
+## Community
+
+Mihari is fully open source. This project recognizes [LINUX DO](https://linux.do/) and thanks the community for supporting open-source software.
+
 ## License
 
 [GPL-3.0](LICENSE) © 2026 LeeShunEE

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -134,6 +134,10 @@ CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o bin/mihari ./cmd/mihari
 
 架构不变量、包边界与贡献指南见 [AGENTS.md](AGENTS.md) 与 [CONTRIBUTING.md](.github/CONTRIBUTING.md),发布流程见 [docs/RELEASE.md](docs/RELEASE.md)。
 
+## 社区
+
+本项目完整开源，认可 [LINUX DO](https://linux.do/) 社区，感谢其对开源项目的支持。
+
 ## 许可
 
 [GPL-3.0](LICENSE) © 2026 LeeShunEE


### PR DESCRIPTION
## Summary
- 在中英文 README 靠后、许可段之前追加对 [LINUX DO](https://linux.do/) 的链接认可
- 声明 Mihari 完整开源，以满足 LINUX DO 开源推广对「链接认可」的要求

## Test plan
- [x] 仅改动 `README.md` 与 `README.zh-CN.md`
- [x] 链接指向 `https://linux.do/`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Community section to both English and Chinese READMEs recognizing LINUX DO and stating Mihari is fully open source to meet LINUX DO’s link recognition requirement. No behavior changes.

**Review notes**
- Changes limited to `README.md` and `README.zh-CN.md`; link targets https://linux.do/.
- No code, build, or runtime impact.

<sup>Written for commit fadcf2bf7e5043c1d34553e29312e30b81fcf0eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mihari-proxy/mihari/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a Community section to the English and Simplified Chinese README files.
  - Clarified the project’s open-source status and acknowledged community support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->