### PR TITLE
docs: 补齐 TUN 冲突、端口配置与订阅代理说明

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -20,22 +20,34 @@ jobs:
           fetch-depth: 0
 
       - name: Check DCO
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+          BASE_REF: ${{ github.base_ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           # Check that all commits have Signed-off-by
           # --no-merges skips merge commits: on a pull_request the workflow runs
           # against a GitHub-generated merge commit that has no Signed-off-by.
-          if [ "${{ github.event_name }}" = "push" ]; then
-            before=${{ github.event.before }}
-            if [ "$before" = "0000000000000000000000000000000000000000" ] ||
-               ! git rev-parse --verify -q "$before^{commit}" >/dev/null 2>&1; then
-              # First push of the repository (all-zero before), or a force
-              # push that replaced the previous tip: check the whole history.
-              commits=$(git rev-list --no-merges ${{ github.sha }})
+          if [ "$EVENT_NAME" = "push" ]; then
+            if [ "$BEFORE" = "0000000000000000000000000000000000000000" ] ||
+               ! git rev-parse --verify -q "$BEFORE^{commit}" >/dev/null 2>&1; then
+              # First push of a new branch (GitHub sends all-zero before), or a
+              # force-push whose previous tip is gone. Check commits not already
+              # on the default branch. Do not walk the whole history: main
+              # contains GitHub merge commits without Signed-off-by.
+              if [ -n "$DEFAULT_BRANCH" ] &&
+                 git rev-parse --verify -q "origin/$DEFAULT_BRANCH^{commit}" >/dev/null 2>&1; then
+                commits=$(git rev-list --no-merges "origin/$DEFAULT_BRANCH".."$HEAD_SHA")
+              else
+                commits=$(git rev-list --no-merges -n 1 "$HEAD_SHA")
+              fi
             else
-              commits=$(git rev-list --no-merges "$before"..${{ github.sha }})
+              commits=$(git rev-list --no-merges "$BEFORE".."$HEAD_SHA")
             fi
           else
-            commits=$(git rev-list --no-merges origin/${{ github.base_ref }}..HEAD)
+            commits=$(git rev-list --no-merges "origin/$BASE_REF"..HEAD)
           fi
 
           for commit in $commits; do

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Mihari is a new, independent local manager for [mihomo](https://github.com/MetaC
 
 Specifically:
 
-- **Subscription management**: add, refresh, and switch subscription profiles, with offline switching and independent refresh intervals
+- **Subscription management**: add, refresh, and switch subscription profiles, with offline switching, independent refresh intervals, and per-profile fetch proxy
 - **Core management**: install, update, and restart the mihomo core
 - **Service supervision**: run in the background as an OS service, with crash auto-restart
-- **System proxy / TUN**: enable system proxy or TUN mode in one click
+- **System proxy / TUN**: enable system proxy or TUN; a foreign proxy or another TUN/mihomo instance requires confirmation or `--force`
 - **Web panels**: one-click install and open of the zashboard / MetaCubeXD panels
 - **Connections & rules**: live view of connections, proxy groups, and rules, with local GeoIP resolution
 
@@ -28,9 +28,10 @@ Specifically:
 
 - **One daemon, three surfaces**: CLI, TUI, and browser panels talk to the same daemon-owned control plane over a local named pipe / Unix domain socket. The control API never binds a TCP port.
 - **OS service supervision**: install as a Windows service / systemd unit / launchd agent, with crash backoff restart.
-- **Subscription profiles**: per-subscription independent caches, offline switching, per-profile refresh intervals, and validated atomic config generation with rollback.
+- **Subscription profiles**: per-subscription independent caches, offline switching, per-profile refresh intervals, per-profile fetch proxy (`direct` / `proxy` / `auto`, falling back to direct), and validated atomic config generation with rollback.
 - **Web panels**: one-click install / update / activate / rollback for zashboard and MetaCubeXD, served behind a loopback Web gateway with its own access credential.
-- **System proxy & TUN**: cross-platform system proxy control and managed TUN, both daemon-owned and persisted.
+- **System proxy & TUN**: cross-platform system proxy control and managed TUN, both daemon-owned and persisted. Enable refuses a foreign system proxy (`system_proxy_conflict`) or another TUN / mihomo instance (`tun_conflict`) unless `--force` (TUI asks for confirmation).
+- **Ports Config**: the System page can change Mixed / Controller / Web ports; occupancy shows `Owned` or `Occupied by name (pid)`. Applying a change typically requires a daemon restart.
 - **In-TUI Mihari updates**: the System page checks GitHub Releases on entry, shows `current · latest available` or `current · Up to date`, and—when Mihari was started with administrator/root privileges—replaces the binary, synchronizes and restarts an installed OS-service copy, verifies its daemon version, and automatically enters the updated TUI.
 - **Core channel**: the System page can switch the mihomo core between `stable` and `alpha`.
 
@@ -92,8 +93,8 @@ mihari sysproxy enable
 | View status | `mihari status` |
 | Core management | `mihari core status` · `mihari core restart` |
 | Proxy groups | `mihari proxy groups` · `mihari proxy select <GROUP> <PROXY>` |
-| Subscription management | `mihari sub add <NAME> <URL>` · `mihari sub use <ID>` · `mihari sub refresh <ID>` |
-| System proxy / TUN | `mihari sysproxy enable` · `mihari tun enable` |
+| Subscription management | `mihari sub add <NAME> <URL>` · `mihari sub set <ID> --proxy auto` · `mihari sub use <ID>` |
+| System proxy / TUN | `mihari sysproxy enable` · `mihari tun enable` · `mihari tun enable --force` |
 | Web panels | `mihari panel list` · `mihari panel open` |
 | Service control | `mihari service status` · `mihari service stop` |
 | Update mihari | System page `Update Mihari` · `mihari self update` |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Specifically:
 
 - **One daemon, three surfaces**: CLI, TUI, and browser panels talk to the same daemon-owned control plane over a local named pipe / Unix domain socket. The control API never binds a TCP port.
 - **OS service supervision**: install as a Windows service / systemd unit / launchd agent, with crash backoff restart.
-- **Subscription profiles**: per-subscription independent caches, offline switching, per-profile refresh intervals, per-profile fetch proxy (`direct` / `proxy` / `auto`, falling back to direct), and validated atomic config generation with rollback.
+- **Subscription profiles**: per-subscription independent caches, offline switching, per-profile refresh intervals, per-profile fetch proxy (`direct` / `proxy` / `auto`; `auto` falls back to direct), and validated atomic config generation with rollback.
 - **Web panels**: one-click install / update / activate / rollback for zashboard and MetaCubeXD, served behind a loopback Web gateway with its own access credential.
 - **System proxy & TUN**: cross-platform system proxy control and managed TUN, both daemon-owned and persisted. Enable refuses a foreign system proxy (`system_proxy_conflict`) or another TUN / mihomo instance (`tun_conflict`) unless `--force` (TUI asks for confirmation).
 - **Ports Config**: the System page can change Mixed / Controller / Web ports; occupancy shows `Owned` or `Occupied by name (pid)`. Applying a change typically requires a daemon restart.
@@ -94,7 +94,7 @@ mihari sysproxy enable
 | Core management | `mihari core status` · `mihari core restart` |
 | Proxy groups | `mihari proxy groups` · `mihari proxy select <GROUP> <PROXY>` |
 | Subscription management | `mihari sub add <NAME> <URL>` · `mihari sub set <ID> --proxy auto` · `mihari sub use <ID>` |
-| System proxy / TUN | `mihari sysproxy enable` · `mihari tun enable` · `mihari tun enable --force` |
+| System proxy / TUN | `mihari sysproxy enable` · `mihari sysproxy enable --force` · `mihari tun enable` · `mihari tun enable --force` |
 | Web panels | `mihari panel list` · `mihari panel open` |
 | Service control | `mihari service status` · `mihari service stop` |
 | Update mihari | System page `Update Mihari` · `mihari self update` |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -28,7 +28,7 @@ Mihari 是一款全新的、独立的 [mihomo](https://github.com/MetaCubeX/miho
 
 - **一个守护进程,三种界面**:CLI、TUI 和浏览器面板经本地命名管道 / Unix 域套接字连接同一守护进程控制面,控制 API 从不绑定 TCP 端口。
 - **OS 服务托管**:可安装为 Windows 服务 / systemd 单元 / launchd 代理,带崩溃退避重启。
-- **订阅配置**:每个订阅独立缓存、离线切换、按配置独立的刷新间隔、按订阅的拉取代理(`direct` / `proxy` / `auto`,失败回退直连),以及经过校验的原子化配置生成与回滚。
+- **订阅配置**:每个订阅独立缓存、离线切换、按配置独立的刷新间隔、按订阅的拉取代理(`direct` / `proxy` / `auto`;`auto` 在代理失败时回退直连),以及经过校验的原子化配置生成与回滚。
 - **Web 面板**:一键安装 / 更新 / 激活 / 回滚 zashboard 与 MetaCubeXD,置于带独立访问凭据的回环 Web 网关之后。
 - **系统代理与 TUN**:跨平台的系统代理控制与托管 TUN,均由守护进程持有并持久化。若其他产品已持有系统代理(`system_proxy_conflict`),或检测到其他 TUN / mihomo 实例(`tun_conflict`),enable 会失败,除非传入 `--force`(TUI 会要求确认)。
 - **端口配置**:System 页面可修改 Mixed / Controller / Web 端口;占用显示 `Owned` 或 `Occupied by name (pid)`。应用后通常需要重启守护进程。
@@ -94,7 +94,7 @@ mihari sysproxy enable
 | 核心管理 | `mihari core status` · `mihari core restart` |
 | 代理组 | `mihari proxy groups` · `mihari proxy select <GROUP> <PROXY>` |
 | 订阅管理 | `mihari sub add <NAME> <URL>` · `mihari sub set <ID> --proxy auto` · `mihari sub use <ID>` |
-| 系统代理 / TUN | `mihari sysproxy enable` · `mihari tun enable` · `mihari tun enable --force` |
+| 系统代理 / TUN | `mihari sysproxy enable` · `mihari sysproxy enable --force` · `mihari tun enable` · `mihari tun enable --force` |
 | Web 面板 | `mihari panel list` · `mihari panel open` |
 | 服务控制 | `mihari service status` · `mihari service stop` |
 | 更新 mihari | System 页 `Update Mihari` · `mihari self update` |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,10 +17,10 @@ Mihari 是一款全新的、独立的 [mihomo](https://github.com/MetaCubeX/miho
 
 具体功能:
 
-- **订阅管理**:添加、刷新、切换订阅配置,支持离线切换与独立的刷新间隔
+- **订阅管理**:添加、刷新、切换订阅配置,支持离线切换、独立刷新间隔与按订阅的拉取代理
 - **核心管理**:安装、更新、重启 mihomo 核心
 - **服务监控**:以 OS 服务方式在后台运行,崩溃自动重启
-- **系统代理 / TUN**:一键开启系统代理或 TUN 模式
+- **系统代理 / TUN**:开启系统代理或 TUN;若其他产品已占用系统代理或存在其他 TUN/mihomo 实例,需确认或传入 `--force`
 - **Web 面板**:一键安装并打开 zashboard / MetaCubeXD 面板
 - **连接与规则**:实时查看连接、代理组与规则,本地 GeoIP 解析
 
@@ -28,9 +28,10 @@ Mihari 是一款全新的、独立的 [mihomo](https://github.com/MetaCubeX/miho
 
 - **一个守护进程,三种界面**:CLI、TUI 和浏览器面板经本地命名管道 / Unix 域套接字连接同一守护进程控制面,控制 API 从不绑定 TCP 端口。
 - **OS 服务托管**:可安装为 Windows 服务 / systemd 单元 / launchd 代理,带崩溃退避重启。
-- **订阅配置**:每个订阅独立缓存、离线切换、按配置独立的刷新间隔,以及经过校验的原子化配置生成与回滚。
+- **订阅配置**:每个订阅独立缓存、离线切换、按配置独立的刷新间隔、按订阅的拉取代理(`direct` / `proxy` / `auto`,失败回退直连),以及经过校验的原子化配置生成与回滚。
 - **Web 面板**:一键安装 / 更新 / 激活 / 回滚 zashboard 与 MetaCubeXD,置于带独立访问凭据的回环 Web 网关之后。
-- **系统代理与 TUN**:跨平台的系统代理控制与托管 TUN,均由守护进程持有并持久化。
+- **系统代理与 TUN**:跨平台的系统代理控制与托管 TUN,均由守护进程持有并持久化。若其他产品已持有系统代理(`system_proxy_conflict`),或检测到其他 TUN / mihomo 实例(`tun_conflict`),enable 会失败,除非传入 `--force`(TUI 会要求确认)。
+- **端口配置**:System 页面可修改 Mixed / Controller / Web 端口;占用显示 `Owned` 或 `Occupied by name (pid)`。应用后通常需要重启守护进程。
 - **TUI 内更新 Mihari**：System 页面进入时检查 GitHub Releases，显示 `当前版本 · 最新版本 available` 或 `当前版本 · Up to date`；以管理员/root 权限启动时可替换二进制、同步并重启已安装的系统服务副本、验证 daemon 版本，并自动进入更新后的 TUI。
 - **内核通道**:System 页面可在 mihomo 的 `stable` / `alpha` 通道之间切换。
 
@@ -92,8 +93,8 @@ mihari sysproxy enable
 | 查看状态 | `mihari status` |
 | 核心管理 | `mihari core status` · `mihari core restart` |
 | 代理组 | `mihari proxy groups` · `mihari proxy select <GROUP> <PROXY>` |
-| 订阅管理 | `mihari sub add <NAME> <URL>` · `mihari sub use <ID>` · `mihari sub refresh <ID>` |
-| 系统代理 / TUN | `mihari sysproxy enable` · `mihari tun enable` |
+| 订阅管理 | `mihari sub add <NAME> <URL>` · `mihari sub set <ID> --proxy auto` · `mihari sub use <ID>` |
+| 系统代理 / TUN | `mihari sysproxy enable` · `mihari tun enable` · `mihari tun enable --force` |
 | Web 面板 | `mihari panel list` · `mihari panel open` |
 | 服务控制 | `mihari service status` · `mihari service stop` |
 | 更新 mihari | System 页 `Update Mihari` · `mihari self update` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,8 @@ Mihari 围绕一个由守护进程持有的控制面(control plane)设计,由 CL
 - Setup 第一步用短连接 `net.Listen` 预检三个托管端口的可用性:占用端口标红(Danger)并提供一键自动切换到下一个可用端口(从 `port+1` 起搜索,上限 `+1024`,三端口保持互异);权限等未知错误不标红、不阻塞,仍由守护进程启动时兜底校验。预检以 generation 守卫拒绝迟到的探测结果。
 - 进入 core / GeoIP 步骤时,Setup 经只读 `GET /v1/core`、`GET /v1/geoip/status` 探测本地资源就绪:已就绪显示版本并提示「将直接使用、无需下载」,失败回退静态文案且绝不阻塞流程。
 - Setup 审查页汇总端口(改端口且守护进程报告需重启时标注「需重启生效」)/ core 来源与版本(本地已有/新装/安装失败)/ 订阅 / GeoIP / mihari 服务注册状态(经 `GET /v1/service/status` 拉取);跳过项如实标注。各步结果在命令闭包内回写 Model,依赖 Bubble Tea 的 cmd→channel→Update happens-before 保证。
-- System 页面通过与 `mihari service` 相同的本地服务适配器管理 OS 服务(安装/卸载/启动/停止/重启/状态);这些操作要求进程已经提权,且不经过守护进程控制协议。当守护进程通告相应能力时,System 页面显示实时的系统代理与 TUN 状态,并通过本地控制 API 切换它们(开启外部代理需要强制确认;Mihari 从不清除其他产品的代理)。
+- System 页面通过与 `mihari service` 相同的本地服务适配器管理 OS 服务(安装/卸载/启动/停止/重启/状态);这些操作要求进程已经提权,且不经过守护进程控制协议。当守护进程通告相应能力时,System 页面显示实时的系统代理与 TUN 状态,并通过本地控制 API 切换它们(开启外部代理或其他 TUN / mihomo 实例需要强制确认;Mihari 从不清除其他产品的代理)。
+- System 页面的 Ports Config 可修改 Mixed / Controller / Web 端口;占用按本实例 PID 显示 `Owned`,或 `Occupied by name (pid)` / `Available`。写入复用 onboarding 更新,应用后通常 `RestartRequired`。没有对应 CLI。
 - System 页面还在进入时以只读方式检查 Mihari 的最新 GitHub Release,并用 `当前版本 · 最新版本 available` 或 `当前版本 · Up to date` 展示结果。确认更新后,本地 updater 在控制协议之外替换 Mihari 可执行文件并尝试重启已安装服务;该写操作要求 TUI 进程已经具备管理员/root 权限,不会自动触发 UAC 或 sudo。旧 Bubble Tea 程序先退出并恢复终端,随后平台适配器从已替换的二进制自动进入新 TUI。
 - System 页面的 `Core Channel` 行可在 `stable` / `alpha` 之间切换;切换后由守护进程按新通道重装核心。版本行显示 `ParseVersion(mihomo -v)` 的身份 token,从不显示 `Prerelease-Alpha`。
 - 规则顺序从不排序;onboarding、系统、provider、订阅、面板和浏览器变更都经由守护进程变更协调器,破坏性或大范围操作需要确认。
@@ -53,6 +54,7 @@ Mihari 围绕一个由守护进程持有的控制面(control plane)设计,由 CL
 
 - 订阅 URL 仅存储在守护进程私有的目录中,并从 list/show 响应与常规错误中省略。
 - 每个有效配置都有独立缓存,因此 `sub use` 在无 provider 网络访问时也能工作。
+- 每个订阅可独立配置拉取代理(`direct` / `proxy` / `auto`);失败回退直连。
 - 生成的配置总是在 `mihomo -t` 与重载之前恢复 Mihari 托管的内环回控制器、密钥与端口不变量。
 
 ## 系统代理与 TUN
@@ -61,6 +63,7 @@ Mihari 围绕一个由守护进程持有的控制面(control plane)设计,由 CL
 - `sysproxy disable` 只清除**由 Mihari 持有**的代理;它不会关闭外部代理。
 - 在 Windows 上,当 Mihari 作为 LocalSystem 服务运行时,它写入**交互式控制台用户**的 WinINET 配置单元(`HKEY_USERS\<SID>\…`),而不是 SYSTEM 自己的 `HKCU`,因此桌面浏览器能感知到变更。
 - `tun enable|disable` 持久化托管 TUN 块、将其注入生成的 mihomo 配置,并在可用时通过控制器实时生效。TUN 根据 OS 不同可能需要提权或安装服务。
+- `tun enable` 前检测其他 TUN 网卡与其他 mihomo 进程,并按本实例内核 PID 与 live `tun.device` 扣除自身;Down 状态的残留适配器忽略。冲突时以 `tun_conflict` 失败,除非传入 `--force`(TUI 会要求确认)。`--force` 只绕过冲突门控,不绕过 live 核对:内核未真正开启则回滚 Desired。
 
 ## GeoIP
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,7 +54,7 @@ Mihari 围绕一个由守护进程持有的控制面(control plane)设计,由 CL
 
 - 订阅 URL 仅存储在守护进程私有的目录中,并从 list/show 响应与常规错误中省略。
 - 每个有效配置都有独立缓存,因此 `sub use` 在无 provider 网络访问时也能工作。
-- 每个订阅可独立配置拉取代理(`direct` / `proxy` / `auto`);失败回退直连。
+- 每个订阅可独立配置拉取代理(`direct` / `proxy` / `auto`);`auto` 在代理失败时回退直连。
 - 生成的配置总是在 `mihomo -t` 与重载之前恢复 Mihari 托管的内环回控制器、密钥与端口不变量。
 
 ## 系统代理与 TUN

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -73,6 +73,7 @@ mihari logs --follow
 
 ```console
 mihari sub add NAME URL
+mihari sub add NAME URL --proxy auto
 mihari sub list
 mihari sub show ID
 mihari sub refresh ID
@@ -80,10 +81,11 @@ mihari sub use ID
 mihari sub enable ID
 mihari sub disable ID
 mihari sub set ID --interval 6h --auto-refresh=true
+mihari sub set ID --proxy auto
 mihari sub remove ID --yes
 ```
 
-订阅 URL 仅存储在守护进程私有的目录中,并从 list/show 响应与常规错误中省略。每个有效配置都有独立缓存,因此 `sub use` 在无 provider 网络访问时也能工作。生成的配置总是在 `mihomo -t` 与重载之前恢复 Mihari 托管的内环回控制器、密钥与端口不变量。
+订阅 URL 仅存储在守护进程私有的目录中,并从 list/show 响应与常规错误中省略。每个有效配置都有独立缓存,因此 `sub use` 在无 provider 网络访问时也能工作。`--proxy` 为该订阅的拉取代理:`direct`(默认)、`proxy` 或 `auto`;失败回退直连。生成的配置总是在 `mihomo -t` 与重载之前恢复 Mihari 托管的内环回控制器、密钥与端口不变量。
 
 ## 系统代理与 TUN
 
@@ -94,12 +96,13 @@ mihari sysproxy enable --force
 mihari sysproxy disable
 mihari tun status
 mihari tun enable
+mihari tun enable --force
 mihari tun disable
 ```
 
 `sysproxy enable` 将桌面 HTTP/HTTPS/SOCKS 系统代理指向 Mihari 的混合端点。如果另一产品已持有代理,enable 会以 `system_proxy_conflict` 失败,除非传入 `--force`(TUI 会要求确认)。`sysproxy disable` 只清除**由 Mihari 持有**的代理;它不会关闭外部代理。在 Windows 上,当 Mihari 作为 LocalSystem 服务运行时,它写入**交互式控制台用户**的 WinINET 配置单元(`HKEY_USERS\<SID>\…`),而不是 SYSTEM 自己的 `HKCU`,因此桌面浏览器能感知到变更。
 
-`tun enable|disable` 持久化托管 TUN 块、将其注入生成的 mihomo 配置,并在可用时通过控制器实时生效。TUN 根据 OS 不同可能需要提权或安装服务。
+`tun enable|disable` 持久化托管 TUN 块、将其注入生成的 mihomo 配置,并在可用时通过控制器实时生效。开启前会检测系统上的其他 TUN 网卡与其他 mihomo 进程(忽略 Down 状态的残留适配器);冲突时以 `tun_conflict` 失败,除非传入 `--force`(TUI 会要求确认)。`--force` 只绕过冲突门控:若内核未真正开启 TUN,Desired 会回滚。TUN 根据 OS 不同可能需要提权或安装服务。没有 CLI 改口命令;Mixed / Controller / Web 端口在 TUI System 页的 Ports Config 中修改。
 
 ## Web 面板
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -85,7 +85,7 @@ mihari sub set ID --proxy auto
 mihari sub remove ID --yes
 ```
 
-订阅 URL 仅存储在守护进程私有的目录中,并从 list/show 响应与常规错误中省略。每个有效配置都有独立缓存,因此 `sub use` 在无 provider 网络访问时也能工作。`--proxy` 为该订阅的拉取代理:`direct`(默认)、`proxy` 或 `auto`;失败回退直连。生成的配置总是在 `mihomo -t` 与重载之前恢复 Mihari 托管的内环回控制器、密钥与端口不变量。
+订阅 URL 仅存储在守护进程私有的目录中,并从 list/show 响应与常规错误中省略。每个有效配置都有独立缓存,因此 `sub use` 在无 provider 网络访问时也能工作。`--proxy` 为该订阅的拉取代理:`direct`(默认)、`proxy` 或 `auto`;`auto` 在代理失败时回退直连。生成的配置总是在 `mihomo -t` 与重载之前恢复 Mihari 托管的内环回控制器、密钥与端口不变量。
 
 ## 系统代理与 TUN
 
@@ -102,7 +102,7 @@ mihari tun disable
 
 `sysproxy enable` 将桌面 HTTP/HTTPS/SOCKS 系统代理指向 Mihari 的混合端点。如果另一产品已持有代理,enable 会以 `system_proxy_conflict` 失败,除非传入 `--force`(TUI 会要求确认)。`sysproxy disable` 只清除**由 Mihari 持有**的代理;它不会关闭外部代理。在 Windows 上,当 Mihari 作为 LocalSystem 服务运行时,它写入**交互式控制台用户**的 WinINET 配置单元(`HKEY_USERS\<SID>\…`),而不是 SYSTEM 自己的 `HKCU`,因此桌面浏览器能感知到变更。
 
-`tun enable|disable` 持久化托管 TUN 块、将其注入生成的 mihomo 配置,并在可用时通过控制器实时生效。开启前会检测系统上的其他 TUN 网卡与其他 mihomo 进程(忽略 Down 状态的残留适配器);冲突时以 `tun_conflict` 失败,除非传入 `--force`(TUI 会要求确认)。`--force` 只绕过冲突门控:若内核未真正开启 TUN,Desired 会回滚。TUN 根据 OS 不同可能需要提权或安装服务。没有 CLI 改口命令;Mixed / Controller / Web 端口在 TUI System 页的 Ports Config 中修改。
+`tun enable|disable` 持久化托管 TUN 块、将其注入生成的 mihomo 配置,并在可用时通过控制器实时生效。开启前会检测系统上的其他 TUN 网卡与其他 mihomo 进程(忽略 Down 状态的残留适配器);冲突时以 `tun_conflict` 失败,除非传入 `--force`(TUI 会要求确认)。`--force` 只绕过冲突门控:若内核未真正开启 TUN,Desired 会回滚。TUN 根据 OS 不同可能需要提权或安装服务。没有用于修改端口的 CLI 命令;Mixed / Controller / Web 端口在 TUI System 页的 Ports Config 中修改。
 
 ## Web 面板
 


### PR DESCRIPTION
## Summary
- 同步中英文 README：系统代理 / TUN 不再写成无条件「一键」，补上 `system_proxy_conflict` / `tun_conflict` 与 `--force` / TUI 确认。
- 补上 System 页 Ports Config（改 Mixed / Controller / Web 端口，占用显示 Owned / Occupied by name）。
- 补上订阅级拉取代理（`direct` / `proxy` / `auto`）。
- 同步 `docs/commands.md` 与 `docs/architecture.md`，避免 README 链出去仍缺 `--force` / `--proxy`。

## Why
这些能力已在 v0.4.0–v0.8.0 落地，README 上次功能向更新停在自更新与 core channel，容易让用户以为 TUN 总是一键成功，也找不到改口和 `--proxy`。

## Test plan
- [x] 对照 CLI（`sub --proxy`、`tun enable --force`）与 TUI 文案核过文档措辞
- [x] 仅改 markdown，无代码/契约变更
- [ ] 在 GitHub 预览中英 README 渲染与文档链接

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mihari-proxy/mihari/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented per-subscription proxy modes with direct fallback support.
  * Added guidance for configurable service, TUN, and port settings.
  * Clarified system proxy/TUN conflict detection, forced activation, and rollback behavior.
  * Updated command examples for automatic subscription proxies and forced TUN enablement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->