### PR TITLE
fix: 修复 dev prerelease 创建参数

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -289,8 +289,13 @@ jobs:
               -f "target_commitish=${SHA}" \
               -f "name=${DEV_RELEASE_NAME}" \
               -f "body=${DEV_RELEASE_BODY}" \
-              -F prerelease=true -F draft=false -F make_latest=false > /tmp/release-create.json 2> /tmp/release-create.err \
-              || { echo "::error::unable to create dev prerelease"; exit 1; }
+              -F prerelease=true -F draft=false -f make_latest=false > /tmp/release-create.json 2> /tmp/release-create.err \
+              || {
+                cat /tmp/release-create.json >&2
+                cat /tmp/release-create.err >&2
+                echo "::error::unable to create dev prerelease"
+                exit 1
+              }
           fi
           while IFS= read -r asset; do
             [ -n "${asset}" ] || continue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@
 
 ### Fixed
 
+## [v0.9.0] - 2026-08-23
+
+### Added
+
+- 增加受保护的 `dev` 集成分支与 canonical `vX.Y.Z-dev.N` GitHub prerelease 流程：固定源 commit SHA，构建六个平台并校验精确 14 个 assets，且不改变 stable `/releases/latest`（#120）。
+
+### Changed
+
+- Stable 发布改为固定 `main` commit SHA，并加固 stable AList 发布/撤回事务、索引恢复与通道隔离（#120）。
+
+### Fixed
+
+- Windows TUN 冲突探测避免把本实例的 mihomo 进程识别为外部冲突（#114）。
+- 修复 dev prerelease Create Release 的 `make_latest` 参数类型，并在创建失败时保留 GitHub API 响应与错误输出。
+
 ## [v0.8.2] - 2026-08-18
 
 ### Fixed

--- a/scripts/test_release_workflow.py
+++ b/scripts/test_release_workflow.py
@@ -555,7 +555,20 @@ def test_release_workflow_uses_policy_instead_of_write_only_get_fields():
     assert "github_release_policy.py release" in workflow
     assert "github_release_policy.py tag-chain" in workflow
     assert "github_release_policy.py latest" in workflow
-    assert "-F make_latest=false" in workflow
+
+
+def test_dev_release_create_uses_api_types_and_reports_api_errors():
+    document = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    create = next(
+        step["run"]
+        for step in document["jobs"]["publish"]["steps"]
+        if step.get("name") == "Create prerelease and upload missing assets"
+    )
+
+    assert "-F make_latest=false" not in create
+    assert "-F prerelease=true -F draft=false -f make_latest=false" in create
+    assert "cat /tmp/release-create.json >&2" in create
+    assert "cat /tmp/release-create.err >&2" in create
 
 
 def test_release_recovery_preflights_existing_assets_and_only_uploads_missing():


### PR DESCRIPTION
## 变更内容

- 修复 dev prerelease 创建时 `make_latest` 被作为 JSON boolean 发送，改为 GitHub API 要求的字符串枚举。
- 创建失败时输出 GitHub API 响应和 stderr，保留可诊断信息且不输出 token。
- 增加工作流回归测试，并准备 v0.9.0 更新日志。

## 验证

- `python -m pytest scripts -q`：241 passed, 2 skipped
- `actionlint .github/workflows/release-dev.yml`：通过
- `git diff --check origin/dev...HEAD`：通过
- 两轮独立 agent 审查：APPROVED，无 findings

## 发布恢复说明

首次真实 dev Action run 32589769690 的六平台构建和 AIO bundle 均成功，仅 Create Release 步骤失败。该运行已创建不可变 `v0.9.0-dev.1` tag，但没有 GitHub Release。合并后将使用新的 canonical dev 版本继续验证，不移动既有 tag。

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mihari-proxy/mihari/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

