### PR TITLE
fix: 固定发版构建输入

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 
 ### 要求
 
-- Go 1.26 或更高版本（见 `go.mod`，CI 使用 `go-version-file` 自动选择）
+- Go 1.26.5（`go.mod` 的语言版本为 1.26.0，并用 `toolchain go1.26.5` 钉死工具链；CI 与发布 workflow 均通过 `go-version-file: go.mod` 选择该版本）
 - Git
 
 ### Fork 并 Clone
@@ -26,8 +26,18 @@ CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o bin/mihari ./cmd/mihari
 发布构建会额外注入版本号：
 
 ```sh
-CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X github.com/mihari-proxy/mihari/internal/buildinfo.Version=<tag>" -o bin/mihari ./cmd/mihari
+CGO_ENABLED=0 go build -buildvcs=false -trimpath -ldflags "-s -w -X github.com/mihari-proxy/mihari/internal/buildinfo.Version=<tag>" -o bin/mihari ./cmd/mihari
 ```
+
+发布构建必须同时使用 `-buildvcs=false -trimpath`。前者避免同一 commit 在创建 tag 前后被 Go 写入不同的 VCS/module 元数据，后者去除本机构建路径；版本身份仍只由上面的 `buildinfo.Version` 注入。
+
+all-in-one 发布输入固定在仓库内的 `scripts/release-inputs.lock.json`。发布 workflow 只消费该文件，不在发版时查询 mihomo 的 latest release 或 GeoIP 的可变分支。需要更新上游输入时，维护者应在独立的 release-prep PR 中运行：
+
+```sh
+go run ./scripts/resolve-release-inputs --channel stable --out scripts/release-inputs.lock.json
+```
+
+解析器会校验并锁定精确的 mihomo release/assets 和 GeoIP commit/digests；受 GitHub API 限流影响时可通过环境变量 `GITHUB_TOKEN` 提供凭据。生成后必须审核 lock diff，并在 PR 验证通过后才合并。不要在 release workflow 中运行解析器。
 
 ### 运行测试
 
@@ -45,7 +55,7 @@ go test -race ./...
 确保代码通过 `gofmt` 检查：
 
 ```sh
-gofmt -l cmd internal
+gofmt -l .
 # 无输出表示格式正确
 ```
 
@@ -172,8 +182,6 @@ main ──同步 PR──> dev
 ```
 
 普通功能和修复从 `feat/*` 或 `fix/*` 分支通过 PR 合并到 `dev`，在 dev 集成验证后再通过晋级 PR 进入 `main`。紧急修复从 `main` 创建 `hotfix/*`，通过 PR 合并到 `main`，随后必须用同步 PR 将 `main` 合并回 `dev`。普通 PR 使用 squash merge；`dev → main` 晋级和 `main → dev` 同步使用 merge commit，以保留发布历史和避免重复显示已发布提交。不得直接推送 `main` 或 `dev`。
-
-在 `dev` 创建并受保护前，Issue #115 的 bootstrap 变更使用一次性 main PR；这不是直接推送或直接提交 `main` 的例外。合并后恢复上述常规流。
 
 1. **创建分支**
    ```sh

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -88,7 +88,7 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
         run: |
           OUT="mihari-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}"
-          go build -trimpath -ldflags "-s -w -X github.com/mihari-proxy/mihari/internal/buildinfo.Version=${VERSION}" -o "dist/${OUT}" ./cmd/mihari
+          go build -buildvcs=false -trimpath -ldflags "-s -w -X github.com/mihari-proxy/mihari/internal/buildinfo.Version=${VERSION}" -o "dist/${OUT}" ./cmd/mihari
 
       - uses: actions/upload-artifact@v7
         with:
@@ -122,10 +122,10 @@ jobs:
           merge-multiple: true
 
       - name: Build all-in-one bundles
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          go run ./scripts/build-all-in-one --mihari-dir dist --out bundles --platforms "${PLATFORMS}"
+          go run ./scripts/build-all-in-one \
+            --lock scripts/release-inputs.lock.json \
+            --mihari-dir dist --out bundles --platforms "${PLATFORMS}"
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
           # internal/update SelectSelfAsset and the install scripts rely on the
           # fixed prefix, and it keeps the /releases/latest/download/ URL stable.
           OUT="mihari-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}"
-          go build -trimpath -ldflags "-s -w -X github.com/mihari-proxy/mihari/internal/buildinfo.Version=${VERSION}" -o "dist/${OUT}" ./cmd/mihari
+          go build -buildvcs=false -trimpath -ldflags "-s -w -X github.com/mihari-proxy/mihari/internal/buildinfo.Version=${VERSION}" -o "dist/${OUT}" ./cmd/mihari
           ls -la dist/
 
       - name: Upload artifact
@@ -171,12 +171,10 @@ jobs:
           merge-multiple: true
 
       - name: Build all-in-one bundles
-        # One mihomo release fetch + shared GeoIP download, then 6 platform packs
-        # (design §4.1). GITHUB_TOKEN raises the unauthenticated API rate ceiling.
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Reviewed mihomo and GeoIP inputs, then 6 platform packs (design §4.1).
         run: |
           go run ./scripts/build-all-in-one \
+            --lock scripts/release-inputs.lock.json \
             --mihari-dir dist --out bundles --platforms "${PLATFORMS}"
           ls -la bundles/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-## [v0.9.0] - 2026-08-23
+## [v0.9.0] - 2026-08-24
 
 ### Added
 
@@ -22,6 +22,8 @@
 
 - Windows TUN 冲突探测避免把本实例的 mihomo 进程识别为外部冲突（#114）。
 - 修复 dev prerelease Create Release 的 `make_latest` 参数类型，并在创建失败时保留 GitHub API 响应与错误输出。
+- 修复同一 commit 在创建 release tag 前后因 Go VCS/module 元数据变化而产生不同二进制的问题；发布构建改用 `-buildvcs=false -trimpath`。
+- all-in-one 构建改为消费已审核的不可变 mihomo/GeoIP 输入 lock，避免发版重试期间上游 latest/ref 漂移并导致 asset checksum 冲突。
 
 ## [v0.8.2] - 2026-08-18
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -97,7 +97,7 @@ go run ./scripts/build-all-in-one \
   --mihari-dir dist --out bundles --platforms "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"
 ```
 
-`--out` 必须是专用的受管 bundle 目录，不能是当前工作目录、lock 所在路径或任何输入目录，也不能与这些目录互相包含。bundler 会先在临时目录完成构建与校验，再提交整个输出；不要把其他文件放进该目录。
+`--out` 必须是专用的受管 bundle 目录；允许使用当前工作目录下的专用子目录（例如 `./bundles`），但不得等于或包含当前工作目录，也不得等于或包含 lock 文件。输出目录与 `--mihari-dir`、`--scripts-dir` 两个输入目录必须双向不重叠。bundler 会先在临时目录完成构建与校验，再提交整个输出；不要把其他文件放进该目录。
 
 在 commit、版本号、Go toolchain、lock 和仓库内安装脚本均相同时，重跑应产生逐字节一致的 6 个原始二进制、6 个 AIO 包和 2 个 checksum 文件。发布仍固定为下面列出的 **14 个 assets**；lock 只是构建输入，不上传到 GitHub Release 或 AList。
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -7,7 +7,7 @@
 | 工作流 | 触发条件 | 运行内容 |
 |--------|----------|----------|
 | **CI** | 推送到 `main`、`dev`、`master` 分支<br>Pull Request | ✅ 代码格式检查 (`gofmt`)<br>✅ 静态分析 (`go vet`)<br>✅ 单元测试 (`go test ./...` + `-race`)<br>✅ 交叉编译验证（6 平台） |
-| **Release** | 推送 `v*` 标签<br>从 `main` 执行 `workflow_dispatch`（必填 `version` + `commit_sha`） | ✅ 版本闸门（拒绝 `-` 预发布后缀）<br>✅ 6 平台构建 + 版本号注入<br>✅ 打包 6 个 all-in-one 整合包<br>✅ 生成 SHA256 校验和（全量 + aio 专用）<br>✅ 创建 GitHub Release<br>✅ `ALIST_URL` 存在时上传整合包到 AList 网盘 |
+| **Release** | 主路径：从 `main` 执行 `workflow_dispatch`（必填 `version` + `commit_sha`）<br>兼容入口：推送 `v*` 标签 | ✅ 版本闸门（拒绝 `-` 预发布后缀）<br>✅ 6 平台构建 + 版本号注入<br>✅ 打包 6 个 all-in-one 整合包<br>✅ 生成 SHA256 校验和（全量 + aio 专用）<br>✅ 创建 GitHub Release<br>✅ `ALIST_URL` 存在时上传整合包到 AList 网盘 |
 | **Retract** | 从 `main` 执行 `workflow_dispatch`（必填 `version` + `confirm`） | ✅ 彻底撤回致命错误版本（GitHub release + AList 目录 + index 重建） |
 | **DCO** | 推送到任何分支<br>Pull Request | ✅ 校验每个提交的 `Signed-off-by` 签名 |
 
@@ -15,26 +15,28 @@
 
 | Workflow | 触发方式 | 通道 | 允许写入 |
 |----------|----------|------|----------|
-| `release.yml` | `v*` tag push；从 `main` 手动 dispatch（稳定 `version` + `commit_sha`） | Stable | GitHub stable Release；`/mihari-release/mihari` 及其 stable `index.txt` |
-| `release-dev.yml` | 代码已准备，远程 dev/试发需另行授权 | Dev | 获授权并从受保护 `dev` dispatch 后，仅写 GitHub dev tag、prerelease 与 14 个 assets；不写 AList |
+| `release.yml` | 主路径：从 `main` 手动 dispatch（稳定 `version` + 精确 `commit_sha`）；兼容 `v*` tag push | Stable | GitHub stable Release；`/mihari-release/mihari` 及其 stable `index.txt` |
+| `release-dev.yml` | 从受保护的 `dev` 手动 dispatch（dev `version`） | Dev | 仅写 GitHub dev tag、prerelease 与精确 14 个 assets；不写 AList |
 | `retract.yml` | 从 `main` 手动 dispatch（稳定 `version` + `confirm`） | Stable | 删除 stable Release 及其 assets、保留 canonical stable tag，并删除 `/mihari-release/mihari/<version>/`；必要时重建 stable `index.txt` |
 
-Batch A 中，dev 发布代码已准备，远程 dev/试发需授权。P2 AList 发布与撤回 workflow 尚不可用，因此没有 dev AList 发布、撤回或下载命令；稳定 AList、stable `index.txt` 与 `/releases/latest` 不受 dev 准备代码影响。
+GitHub dev prerelease 流程已经实际发布并验收 `v0.9.0-dev.2`（精确 14 个 assets，且不写 AList）。dev AList 发布与 dev retract workflow 仍不可用，因此没有 dev AList 版本目录、下载命令或撤回入口；稳定 AList、stable `index.txt` 与 `/releases/latest` 不受 dev 发布影响。
 
-> **关键点**：推送标签时只触发 **Release** 工作流，不会重复运行 CI 测试。`Release` 与 `Retract` 仅手动或标签触发。
+远端 active tag ruleset 覆盖 `refs/tags/v*`，禁止删除、更新和 non-fast-forward；canonical stable/dev tag 一旦创建不得改写。`v*` tag push 保留为兼容触发入口，但当前稳定发版操作使用 `main` 上的 `workflow_dispatch`。
 
 ## Stable 与 Dev 发布通道
 
 | 通道 | 来源与版本 | GitHub Release | AList 根目录 | 稳定入口影响 |
 |------|------------|----------------|--------------|--------------|
-| Stable | `main` 上的 `vX.Y.Z` | 正式 release，参与 `/releases/latest` | `/mihari-release/mihari` | 更新稳定 `index.txt`，供稳定安装器使用 |
-| Dev | `dev` 上的 `vX.Y.Z-dev.N` | 代码已准备；另行授权后创建 GitHub tag、prerelease 与 14 个 assets | P2 尚不可用 | 不写稳定 `index.txt`、版本目录或 `/releases/latest` |
+| Stable | `dev → main` 晋级 PR 合并后的精确 40 位 `main` commit SHA；`vX.Y.Z` | 正式 release，参与 `/releases/latest` | `/mihari-release/mihari` | 更新稳定 `index.txt`，供稳定安装器使用 |
+| Dev | `dev` 上的 `vX.Y.Z-dev.N` | GitHub tag、prerelease 与 14 个 assets；`v0.9.0-dev.2` 已通过实际验收 | 尚不可用 | 不写稳定 `index.txt`、版本目录或 `/releases/latest` |
 
-Dev 发布实现固定 `refs/heads/dev` 来源并校验 canonical `vX.Y.Z-dev.N` 版本身份；已有同名 tag 时必须验证其 commit，身份不符即拒绝且不覆盖。Batch A 只完成代码准备，远程 dev/试发需授权。P2 AList 发布与撤回 workflow 尚不可用；在其交付并另获授权前，不提供 dev AList 操作入口。
+Dev 发布固定 `refs/heads/dev` 来源并校验 canonical `vX.Y.Z-dev.N` 版本身份；已有同名 tag 时必须验证其 commit，身份不符即拒绝且不覆盖。dev AList 发布与 dev retract workflow 尚不可用，不提供 dev AList 操作入口。
 
 ## 发版流程
 
-### 1. 确保代码已合并到 main
+### 1. 通过晋级 PR 合并到 main
+
+将已经通过 dev 集成验证的 release-prep 变更通过 `dev → main` 晋级 PR 合并；不要直接推送或提交 `main`。
 
 ```bash
 git checkout main
@@ -45,27 +47,63 @@ git pull origin main
 
 推送代码到 `main` 后，CI 工作流会自动运行。在 GitHub Actions 页面确认所有检查通过后再继续。
 
-### 3. 更新本文档的变更日志
+### 3. 记录精确 main commit
 
-把本次发布的变更整理进下面的「更新日志」章节。
-
-### 4. 创建版本标签
+确认 CHANGELOG 与 release input lock 已随晋级 PR 进入 `main`，记录远端 `main` 当前精确的 40 位小写 commit SHA：
 
 ```bash
-git tag -a v0.1.0 -m "Release v0.1.0: 初始开源发布"
-git push origin v0.1.0
+git rev-parse origin/main
 ```
 
-### 5. 自动发布
+### 4. 从 GitHub Actions 触发 stable release
 
-推送标签后，GitHub Actions Release 工作流会自动：
+在 GitHub Actions 选择 `release` workflow，ref 选择 `main`，执行 `workflow_dispatch`：
+
+- `version`：canonical stable 版本，例如 `v0.9.0`；
+- `commit_sha`：上一步记录的、与当前 checkout 后 `main` 完全相等的 40 位 SHA。
+
+`release.yml` 会自行创建或验证 canonical stable tag。不要把本地创建并推送 tag 作为当前稳定发版操作。
+
+### 5. 自动发布与验收
+
+手动 dispatch 后，GitHub Actions Release 工作流会自动：
 
 1. 版本闸门校验（build / release 各一层，拒绝 `-` 预发布后缀）；
-2. 交叉编译 linux / darwin / windows（各 amd64 + arm64），注入版本号（`-X .../buildinfo.Version=<version>`）；
-3. 打包 6 个 all-in-one 整合包（mihari + mihomo 核心 + GeoIP）；
+2. 使用 Go 1.26.5 交叉编译 linux / darwin / windows（各 amd64 + arm64），以 `-buildvcs=false -trimpath` 构建并注入版本号（`-X .../buildinfo.Version=<version>`）；
+3. 只从仓库内已审核的 `scripts/release-inputs.lock.json` 读取精确 mihomo 与 GeoIP 输入，打包 6 个 all-in-one 整合包；
 4. 生成 SHA256 校验和（全量 `SHA256SUMS.txt` + aio 专用 `AIO_SHA256SUMS.txt`）；
 5. 创建 GitHub Release 并上传全部产物；
 6. `ALIST_URL` 存在时进入 AList mutation，上传整合包到网盘版本目录、更新 `index.txt`、追加离线安装命令到 release notes；只有 `ALIST_URL` 缺失时才走 GitHub-only skip，不阻塞 GitHub 发布。URL 已存在但 `ALIST_USERNAME` 或 `ALIST_PASSWORD` 任一缺失时，客户端必须 fail closed，workflow 失败且不得静默跳过。
+
+## 可复现构建输入
+
+稳定和 dev 发布 workflow 都通过 `go-version-file: go.mod` 使用其中钉死的 Go 1.26.5 toolchain。Mihari 二进制同时使用 `-buildvcs=false -trimpath`：`-buildvcs=false` 防止同一 commit 在 tag 创建前后产生不同的 Go VCS/module 元数据，`-trimpath` 去除本机构建路径；用户可见版本继续由 `buildinfo.Version` 的 ldflags 注入。
+
+all-in-one 的外部输入固定在仓库内的 `scripts/release-inputs.lock.json`。lock 记录精确的 mihomo release、六个平台 asset ID/URL/大小/SHA-256，以及 GeoIP commit、不可变 URL 和 SHA-256。构建阶段只读取 lock，**不会**解析 mihomo latest release 或 GeoIP 的可变 `release` ref，也不会在 workflow 中自动更新 lock。
+
+维护者只应在独立的 release-prep PR 中更新它：
+
+```bash
+go run ./scripts/resolve-release-inputs --channel stable --out scripts/release-inputs.lock.json
+```
+
+若需要提高 GitHub API 限额，可设置环境变量 `GITHUB_TOKEN` 后运行同一命令。解析器会下载并验证候选输入，再以原子替换写入 lock；命令失败时旧 lock 保持不变。提交前必须人工审核 lock diff，确认 repository、channel、release/tag、六个平台资产、GeoIP commit 与摘要均符合本次发版意图。release workflow 绝不能调用该解析器。
+
+workflow 调用 bundler 时必须显式提供 lock：
+
+```bash
+go run ./scripts/build-all-in-one \
+  --lock scripts/release-inputs.lock.json \
+  --mihari-dir dist --out bundles --platforms "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"
+```
+
+`--out` 必须是专用的受管 bundle 目录，不能是当前工作目录、lock 所在路径或任何输入目录，也不能与这些目录互相包含。bundler 会先在临时目录完成构建与校验，再提交整个输出；不要把其他文件放进该目录。
+
+在 commit、版本号、Go toolchain、lock 和仓库内安装脚本均相同时，重跑应产生逐字节一致的 6 个原始二进制、6 个 AIO 包和 2 个 checksum 文件。发布仍固定为下面列出的 **14 个 assets**；lock 只是构建输入，不上传到 GitHub Release 或 AList。
+
+相同 SHA 重建的逐字节稳定性由固定 toolchain、构建参数与 lock 保证。仅 `release-dev.yml` 对已有同版本 Release 执行 existing-asset preflight：若报告 `existing release asset checksum conflicts with this build`，表示已发布 dev asset 与本次构建并非逐字节相同；dev workflow 会在 tag/asset mutation 前 fail closed，不得删除、覆盖或把冲突当成成功重试。先核对源 commit、版本、toolchain 与 lock；若现存 dev tag/release 来自旧的非确定性构建，保留现场并使用更高的 canonical dev 版本重新发布。
+
+`release.yml` 当前不提供同等的 existing-asset preflight；stable 发布与重试仍遵循现有 stable Action 的创建/上传、AList 事务与最终校验契约。不要从 dev 的 fail-closed preflight 推断 stable 具有相同覆盖保护。
 
 ## 版本命名规范
 
@@ -107,6 +145,8 @@ AIO_SHA256SUMS.txt
 
 `mihari-all-in-one-*` 是 all-in-one 整合包（mihari 二进制 + mihomo 核心 + GeoIP×2），供墙内用户离线安装，详见 [分发方案](distribution.md)。`SHA256SUMS.txt` 覆盖全部产物，`AIO_SHA256SUMS.txt` 仅覆盖 6 个整合包（AList 版本目录内同名）。
 
+以上清单是固定的 14-asset 契约。`scripts/release-inputs.lock.json` 不属于发布产物，也不会上传到 GitHub Release 或 AList。
+
 ## 校验下载
 
 下载后验证完整性：
@@ -126,19 +166,19 @@ Get-FileHash mihari-windows-amd64.exe -Algorithm SHA256
 - `version`：如 `v0.3.0`，必须匹配上述 canonical stable 格式，不接受前导零或预发布后缀；
 - `commit_sha`：必填的 **40 位十六进制**提交 SHA。workflow 会将该 SHA 与 checkout 后的源代码核对，身份不一致时 fail closed。
 
-标签触发的稳定发布从标签（lightweight 或 annotated）最终解析/peel 到的 commit 推导提交身份，而不是信任可变分支名。稳定发布和 AList 写入均须通过 CI、版本闸门及维护者审批；审批前不得执行生产分发写操作。
+这是当前稳定发版的主路径：release-prep 先经 `dev → main` 晋级 PR，随后以 `main` ref、canonical `version` 和精确 40 位 `main` `commit_sha` dispatch。workflow 会核对 checkout 后的 `main` 与输入 SHA，身份不一致即 fail closed。稳定发布和 AList 写入均须通过 CI、版本闸门及维护者审批；审批前不得执行生产分发写操作。
 
-Workflow 在发布前后都会重新读取并 peel 当前 stable tag，但这种前后复核并非原子操作，只能检测两个检查点观察到的身份变化，不能阻止检查间隔内的 tag 更新。当前远端尚未配置 stable tag-target ruleset，本批也未获授权修改该设置；真实 stable 发布前，必须另行取得授权，配置并回读 stable tag-target ruleset，禁止更新和删除 canonical stable tag。
+兼容入口仍接受 `v*` tag push：它会将 lightweight 或 annotated tag 最终 peel 到 commit，并要求该 commit 可从可信 `main` 到达。它用于兼容既有自动化，不作为当前人工 runbook。无论入口为何，workflow 都在发布前后重新读取并 peel stable tag；该复核不是原子操作，因此还依赖已 active、覆盖 `refs/tags/v*` 的 tag ruleset 禁止删除、更新和 non-fast-forward。
 
 > **为什么必填 version**：`workflow_dispatch` 从分支触发时 `GITHUB_REF_NAME` 是分支名而非版本号。显式输入统一全链路取值（build 注入的版本号、Release 的 `tag_name`、AList 版本目录名），避免二进制版本号被污染。版本闸门在 build / release 两个 job 各校验一次。
 
 ### Dev 手动发布
 
-Batch A 只完成 dev 发布代码准备，远程 dev/试发需另行授权。实现会校验 `refs/heads/dev` 来源和上述 canonical `vX.Y.Z-dev.N` 格式（各数字段不允许前导零）；获授权并从受保护 `dev` dispatch 后，只创建 GitHub dev tag、prerelease 并上传精确 14 个 assets，不写 AList。在获得单独授权前，不应运行远程 dev 发布。
+从 GitHub Actions 选择 `release-dev` workflow 和受保护的 `dev` ref，填写符合 canonical `vX.Y.Z-dev.N` 格式的版本（各数字段不允许前导零）。workflow 只创建或复用 GitHub dev tag、prerelease 并上传精确 14 个 assets，不写 AList。`v0.9.0-dev.2` 已按该路径发布并完成公开资产验收。
 
-Dev workflow 会在 mutation 前和最终验收时重新读取并 peel 当前 dev tag，但 dev 前后复核并非原子操作，只能发现两个检查点已经可见的身份变化。当前远端尚未配置 dev tag-target ruleset，也未获授权修改该设置；真实 dev 发布前，必须另行授权，配置并回读 dev tag-target ruleset，禁止更新和删除 canonical dev tag。
+Dev workflow 会在 mutation 前和最终验收时重新读取并 peel 当前 dev tag；前后复核不是原子操作，因此还依赖已 active、覆盖 `refs/tags/v*` 的 tag ruleset 禁止删除、更新和 non-fast-forward。对已有同版本 Release 的 checksum 冲突会在 tag mutation 前 fail closed。
 
-Dev 发布还要求仓库已经存在至少一个合法的 stable GitHub Release，且 `/releases/latest` 能返回非 draft、非 prerelease 的稳定版本；缺少该前置条件时 workflow 会在任何 dev mutation 前 fail closed。P2 AList 发布与撤回 workflow 尚不可用，因此这里不提供 dev AList 命令或路径。
+Dev 发布还要求仓库已经存在至少一个合法的 stable GitHub Release，且 `/releases/latest` 能返回非 draft、非 prerelease 的稳定版本；缺少该前置条件时 workflow 会在任何 dev mutation 前 fail closed。dev AList 发布与 dev retract workflow 尚不可用，因此这里不提供 dev AList 命令、版本目录或撤回入口。
 
 ## 回滚发布（致命错误撤回）
 
@@ -156,14 +196,16 @@ AList 不提供 compare-and-swap（CAS），因此事务前检查与单次 PUT �
 
 > 旧的手动删标签 + 网页删 Release 方式仅删 GitHub 侧、不重建 AList index，已由 `retract` workflow 取代。
 
-P2 AList 发布与撤回 workflow 尚不可用；dev 撤回尚无可执行入口。后续设计仍要求 dev 操作不得触碰稳定目录、稳定 `index.txt` 或 `/releases/latest`，但本阶段不执行任何远程 dev 撤回。
+Dev AList 发布与 dev retract workflow 尚不可用；dev 撤回没有可执行入口。任何后续 dev 分发操作仍不得触碰稳定目录、稳定 `index.txt` 或 `/releases/latest`。
 
 ## CI/CD 检查项
 
 每次发布前确保：
 
 - [ ] 所有测试通过 (`go test -race ./...`)
-- [ ] 代码格式正确 (`gofmt -l cmd internal`)
+- [ ] 代码格式正确 (`gofmt -l .`)
 - [ ] 静态分析通过 (`go vet ./...`)
 - [ ] [CHANGELOG.md](../CHANGELOG.md) 已更新
 - [ ] 标签版本号与 CHANGELOG.md 一致
+- [ ] `go.mod` 仍钉死 Go 1.26.5，发布构建仍使用 `-buildvcs=false -trimpath`
+- [ ] `scripts/release-inputs.lock.json` 已在 release-prep PR 中更新（如需）并审核 diff；release workflow 未动态解析 latest/ref

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -88,7 +88,7 @@ go run ./scripts/build-all-in-one \
   --platforms "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"
 ```
 
-`--out` 必须是专用的受管 bundle 目录，不能是当前工作目录、lock 路径或任何输入目录，也不能与这些目录互相包含；目录内不得混放非 bundle 文件。bundler 在临时目录完成全部构建与校验后才整体提交输出。lock 只用于构建，不会进入 bundle，也不会作为 GitHub Release/AList 资产上传，因此固定的 14-asset 发布契约不变。
+`--out` 必须是专用的受管 bundle 目录；允许使用当前工作目录下的专用子目录（例如 `./bundles`），但输出目录不得等于或包含当前工作目录，也不得等于或包含 lock 文件。它与 `--mihari-dir`、`--scripts-dir` 两个输入目录之间还必须双向不重叠：输出不能包含输入，输入也不能包含输出。目录内不得混放非 bundle 文件。bundler 在临时目录完成全部构建与校验后才整体提交输出。lock 只用于构建，不会进入 bundle，也不会作为 GitHub Release/AList 资产上传，因此固定的 14-asset 发布契约不变。
 
 Mihari 原始二进制由 Go 1.26.5 以 `-buildvcs=false -trimpath` 构建，避免同一 commit 在 tag 创建前后因 VCS/module 元数据变化而改变字节。相同 commit、版本、toolchain、lock 和仓库内脚本的重试应逐字节复现全部 14 个 assets。仅 dev release workflow 会在已有同版本 Release 时做 existing-asset checksum preflight，并在字节冲突时于 mutation 前 fail closed；stable release workflow 不提供同等 preflight，仍遵循现有 stable Action 发布与 AList 事务契约。
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -37,7 +37,7 @@ curl -fsSL https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/insta
 
 > 命令中的网址是 AList 网盘的固定公开直链（签名已关闭），永久不变，复制即用。
 
-Batch A 中，dev 发布代码已准备，远程 dev/试发需另行授权；获授权后的 P1 只写 GitHub dev tag、prerelease 与 14 个 assets，不写 AList。P1 试发的前置条件是 `/releases/latest` 已能返回合法的 stable GitHub Release，缺少时会在 dev mutation 前 fail closed。P2 AList 发布与撤回 workflow 尚不可用，因此当前没有 dev AList 版本目录或下载命令；稳定安装入口不会指向 dev。
+GitHub dev prerelease `v0.9.0-dev.2` 已发布并完成精确 14 个 assets 的公开验收，且未写 AList。dev AList 发布与 dev retract workflow 仍不可用，因此没有 dev AList 版本目录、下载命令或撤回入口；稳定安装入口不会指向 dev。
 
 脚本3 下载器的执行流程：
 
@@ -71,9 +71,28 @@ sh install-aio.sh        # Windows: powershell -File install-aio.ps1
 
 ## 二、核心通道与 sidecar
 
-`scripts/build-all-in-one` 默认打包 **stable** 内核。需要预置 alpha 时传入 `--channel alpha`，bundler 从 GitHub 滚动 tag `Prerelease-Alpha` 选取标准资产（非 `-compatible` / `-v3` / `-goNNN` 变体）。
+`scripts/build-all-in-one` 不解析滚动 tag、latest release 或 GeoIP 可变分支。它要求显式传入仓库内已审核的 `scripts/release-inputs.lock.json`，并只下载 lock 中精确记录且有 SHA-256 的六个平台 mihomo 资产和两份 GeoIP 数据。当前 checked-in lock 使用 **stable** 内核；预置通道由 lock 的 `mihomo.channel` 决定，而不是由 bundler 在发版时动态选择。
 
-无论 `--channel` 是 `stable` 还是 `alpha`，bundle 都会写入 sidecar `data/bin/core-channel`（UTF-8 文本）：
+维护者只在独立的 release-prep PR 中更新 lock：
+
+```sh
+go run ./scripts/resolve-release-inputs --channel stable --out scripts/release-inputs.lock.json
+```
+
+GitHub API 限流时可设置 `GITHUB_TOKEN` 环境变量。必须审核生成的 diff 后再合并；稳定和 dev release workflow 都只消费 lock，绝不运行解析器。实际打包命令必须显式传入 lock，例如：
+
+```sh
+go run ./scripts/build-all-in-one \
+  --lock scripts/release-inputs.lock.json \
+  --mihari-dir dist --out bundles \
+  --platforms "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"
+```
+
+`--out` 必须是专用的受管 bundle 目录，不能是当前工作目录、lock 路径或任何输入目录，也不能与这些目录互相包含；目录内不得混放非 bundle 文件。bundler 在临时目录完成全部构建与校验后才整体提交输出。lock 只用于构建，不会进入 bundle，也不会作为 GitHub Release/AList 资产上传，因此固定的 14-asset 发布契约不变。
+
+Mihari 原始二进制由 Go 1.26.5 以 `-buildvcs=false -trimpath` 构建，避免同一 commit 在 tag 创建前后因 VCS/module 元数据变化而改变字节。相同 commit、版本、toolchain、lock 和仓库内脚本的重试应逐字节复现全部 14 个 assets。仅 dev release workflow 会在已有同版本 Release 时做 existing-asset checksum preflight，并在字节冲突时于 mutation 前 fail closed；stable release workflow 不提供同等 preflight，仍遵循现有 stable Action 发布与 AList 事务契约。
+
+无论 lock 中的 `mihomo.channel` 是 `stable` 还是 `alpha`，bundle 都会写入 sidecar `data/bin/core-channel`（UTF-8 文本）：
 
 ```
 <stable|alpha>
@@ -90,7 +109,7 @@ settings 新增可选字段 `core-channel` 与 `core-channel-bundle`（schema �
 
 ## 三、AList 网盘目录结构
 
-AList base path 不是可配置入口：策略层将 stable 固定为 `/mihari-release/mihari`，将后续 P2 dev 通道固定为 `/mihari-release/mihari-dev`；传入其他路径会被拒绝。当前可用的 stable 目录如下：
+AList base path 不是可配置入口：策略层将 stable 固定为 `/mihari-release/mihari`，并为尚未实现的 dev AList 通道保留 `/mihari-release/mihari-dev`；传入其他路径会被拒绝。当前可用的 stable 目录如下：
 
 ```
 stable（仅稳定通道）：
@@ -107,7 +126,7 @@ stable（仅稳定通道）：
 └── v0.1.0/
 ```
 
-dev 发布代码已准备，远程 dev/试发需另行授权。`/mihari-release/mihari-dev` 只是策略层为后续 P2 保留的固定路径；P2 AList 发布与撤回 workflow 尚不可用，故本阶段不创建或操作该目录。稳定 `index.txt` 和 `/releases/latest` 不受 dev 准备代码影响。
+`/mihari-release/mihari-dev` 只是为后续 dev 分发保留的固定策略路径。dev AList 发布与 dev retract workflow 尚不可用，当前不创建或操作该目录；已发布的 GitHub dev prerelease 不改变稳定 `index.txt` 或 `/releases/latest`。
 
 > **AList 拓扑 quirk（读路径 / 下载）**：**公开下载 URL** 需在 `/p` 后加 `/public` 挂载点前缀，即 `https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/…`（`alist_client.public_url` 自动处理）。
 >
@@ -171,7 +190,7 @@ Writer 在首次 mutation 前把原状态写入 runner 的 `stable/` 备份目�
 2. 读 `index.txt` 判断撤回版本是否为当前 latest；
 3. **仅当撤回的是 latest**，先排除目标目录，重建 `index.txt`：latest 改为现存最高且完整（含 `COMPLETE`）的版本（sha256 从该目录的 `SHA256SUMS.txt` 读取）；无完整版本 → `index.txt` 置空。写入后必须回读验证成功，才进入删除；
 4. 永久删除 AList 版本目录 `<base_path>/<version>/`；撤回非 latest 时 index 保持原始字节不变；
-5. `gh release delete <version> --yes` 永久删除 GitHub Release 及其 assets，但保留 canonical stable tag；tag 继续受 stable tag-target ruleset 保护，不为撤回配置删除 bypass。
+5. `gh release delete <version> --yes` 永久删除 GitHub Release 及其 assets，但保留 canonical stable tag；tag 继续受覆盖 `refs/tags/v*` 的 active tag ruleset 保护，不为撤回配置删除 bypass。
 
 若 latest 的替代或空 index 已验证、但目录删除失败，index 保持已切换状态，不回退；目标目录成为不再被 index 引用的遗留目录，同一撤回重跑会继续删除它。幂等：对已撤回的版本重跑不报错。
 

--- a/docs/superpowers/plans/2026-08-24-reproducible-release-inputs.md
+++ b/docs/superpowers/plans/2026-08-24-reproducible-release-inputs.md
@@ -1,0 +1,106 @@
+# Reproducible Release Inputs Implementation Plan
+
+> **For agentic workers:** Use `superpowers:subagent-driven-development` task by task. For every behavioral change, apply `superpowers:test-driven-development`; before any completion claim apply `superpowers:verification-before-completion`.
+
+**Goal:** Make stable and dev release retries byte-reproducible by suppressing tag-dependent Go metadata and pinning every external AIO input in a strict checked-in lock.
+
+**Architecture:** Release workflows build from their approved immutable source SHA with an exactly pinned Go toolchain and `-buildvcs=false`. The AIO builder loads a validated source-tree lock before any I/O and consumes only exact mihomo/GeoIP artifacts. A separate, manually invoked resolver updates that lock atomically during release preparation.
+
+**Tech stack:** Go 1.26.5, GitHub Actions YAML, Python workflow regression tests, `httptest`, standard-library JSON/HTTP/crypto packages.
+
+**Spec:** `docs/superpowers/specs/2026-08-24-reproducible-release-inputs-design.md`
+
+---
+
+## Task 1: Define and strictly validate the release input lock
+
+**Files:**
+
+- Create: `scripts/build-all-in-one/release_lock.go`
+- Create: `scripts/build-all-in-one/release_lock_test.go`
+- Create: `scripts/release-inputs.lock.json`
+
+1. Write table-driven failing tests for valid decoding, size limit, unknown/trailing JSON, schema/repository/channel validation, exact six-platform membership, numeric IDs/sizes, SHA-256 values, immutable HTTPS URL shape, and exact GeoIP commit paths.
+2. Run only the new tests and confirm they fail because the loader does not exist.
+3. Implement the smallest typed schema, bounded strict decoder, canonical encoder, and semantic validator that makes the tests pass.
+4. Add the approved v1.19.30/GeoIP commit inputs to the checked-in lock and verify it loads successfully.
+5. Run the package tests and format changed Go files.
+
+## Task 2: Add locked-digest GeoIP downloads without changing runtime behavior
+
+**Files:**
+
+- Modify: `internal/geoip/downloader.go`
+- Modify: `internal/geoip/downloader_test.go`
+
+1. Add failing tests showing an inline expected SHA-256 succeeds without requesting a sidecar, a mismatch is rejected, and zero or two checksum sources fail before any request.
+2. Run the focused tests and confirm behavioral failures.
+3. Add `ExpectedSHA256` to `DownloadSpec`, validate exactly one checksum mode, and reuse the existing bounded download/checksum comparison path.
+4. Run the GeoIP package tests and confirm all legacy checksum-URL callers remain green.
+
+## Task 3: Implement an atomic release-input resolver
+
+**Files:**
+
+- Modify: `internal/core/release.go`
+- Modify: related `internal/core/*_test.go`
+- Create: `scripts/resolve-release-inputs/main.go`
+- Create: `scripts/resolve-release-inputs/main_test.go`
+- If sharing is necessary, move lock DTO/validation into the smallest importable package under `scripts/internal/` and update Task 1 files accordingly.
+
+1. Add failing tests for decoding GitHub numeric release/asset IDs, selecting exactly the six supported assets, resolving GeoIP `release` to a 40-hex commit, hashing every downloaded payload, canonical output, and preserving an existing lock after failure.
+2. Run focused tests and confirm the missing resolver behavior.
+3. Implement the resolver with injectable HTTP clients/base URLs, bounded downloads, existing core selection semantics, and same-directory temporary-file plus rename.
+4. Run the resolver against fixtures, then run the relevant core and resolver package tests.
+5. Regenerate `scripts/release-inputs.lock.json` with the production command and confirm the semantic content matches the reviewed upstream inputs.
+
+## Task 4: Make the AIO builder consume only the checked-in lock
+
+**Files:**
+
+- Modify: `scripts/build-all-in-one/main.go`
+- Modify: `scripts/build-all-in-one/main_test.go`
+
+1. Replace mutable-discovery fixture expectations with failing tests that require `--lock`, prove invalid locks fail before requests/output creation, assert no latest-release or mutable GeoIP request occurs, reject locked size/digest mismatches, and build all six platforms from locked fixtures.
+2. Add a failing repeat-build test asserting byte-identical archives.
+3. Add failing cross-host metadata tests: repack identical stages under different filesystem permissions, require identical bytes, and assert canonical `0755`/`0644` entry modes in both tar and ZIP.
+4. Implement lock-first loading and direct construction of the selected core/GeoIP inputs; remove the builder's latest-release and GeoIP-base discovery options, and write fixed archive metadata instead of host-derived modes.
+5. Run builder tests twice and compare output digests.
+
+## Task 5: Wire deterministic inputs into both release workflows
+
+**Files:**
+
+- Modify: `.github/workflows/release.yml`
+- Modify: `.github/workflows/release-dev.yml`
+- Modify: `scripts/test_release_workflow.py`
+
+1. Add failing workflow tests that parse both workflow documents and require `go-version-file: go.mod`, `go build -buildvcs=false -trimpath`, and `build-all-in-one --lock scripts/release-inputs.lock.json`.
+2. Run the focused Python test and confirm failure against current YAML.
+3. Update both workflows with the deterministic build flag and explicit lock path.
+4. Run workflow policy tests and a local two-build check around a temporary exact-version tag/ref without mutating protected remote tags.
+
+## Task 6: Document the release-input update and retry contract
+
+**Files:**
+
+- Modify: `docs/RELEASE.md`
+- Modify: `docs/distribution.md`
+- Modify: `.github/CONTRIBUTING.md`
+- Modify: `CHANGELOG.md`
+
+1. Document that release workflows never resolve latest inputs, how maintainers regenerate and review the lock, and why `-buildvcs=false` is required.
+2. Document that the lock is not a public asset and that the 14-file release contract remains unchanged.
+3. Add an unreleased changelog entry for reproducible release retries.
+4. Check commands and file names against the implementation.
+
+## Task 7: Verify, review, and integrate through dev
+
+1. Run focused package and workflow tests.
+2. Run `gofmt -l` on changed Go files, `go test ./...`, `go test -race ./...`, and `go vet ./...`.
+3. Run CGO-disabled builds for Windows/Linux/macOS amd64/arm64 without writing tracked artifacts.
+4. Inspect `git diff` for secrets, mutable URLs in workflow build paths, untracked artifacts, and unrelated edits.
+5. Request independent code review and resolve only verified findings.
+6. Commit with DCO, push the fix branch, open a PR to `dev`, wait for required checks/bot review, and merge after user-approved policy allows it.
+7. Preserve the immutable, pre-fix `v0.9.0-dev.2` release. Dispatch a new `v0.9.0-dev.3` release through Actions, verify its 14 assets, then re-run `v0.9.0-dev.3` and confirm the existing release/assets are accepted unchanged.
+8. Promote `dev` to `main` by PR, dispatch the stable `v0.9.0` Action from the exact main SHA, and verify GitHub/AList downloads and checksums before completing the goal.

--- a/docs/superpowers/plans/2026-08-24-reproducible-release-inputs.md
+++ b/docs/superpowers/plans/2026-08-24-reproducible-release-inputs.md
@@ -16,14 +16,14 @@
 
 **Files:**
 
-- Create: `scripts/build-all-in-one/release_lock.go`
-- Create: `scripts/build-all-in-one/release_lock_test.go`
+- Create: `scripts/internal/releaseinputs/lock.go`
+- Create: `scripts/internal/releaseinputs/lock_test.go`
 - Create: `scripts/release-inputs.lock.json`
 
 1. Write table-driven failing tests for valid decoding, size limit, unknown/trailing JSON, schema/repository/channel validation, exact six-platform membership, numeric IDs/sizes, SHA-256 values, immutable HTTPS URL shape, and exact GeoIP commit paths.
 2. Run only the new tests and confirm they fail because the loader does not exist.
 3. Implement the smallest typed schema, bounded strict decoder, canonical encoder, and semantic validator that makes the tests pass.
-4. Add the approved v1.19.30/GeoIP commit inputs to the checked-in lock and verify it loads successfully.
+4. Add the approved mihomo v1.19.30 inputs and the exact GeoIP inputs to the checked-in lock: commit `69986b5d098c8d723a2c4d56317bc10cd5669c02`, Country SHA-256 `26a2c3c3791b36303a1c70bac18320c4e6bd40950286224a38f2756c0f7d0ca2`, and ASN SHA-256 `82abcabdf4d0ecb34da45e4f0f9bc30bf933cfbfec446b89a2215fae5b1fdbdc`. Verify the resulting lock loads successfully.
 5. Run the package tests and format changed Go files.
 
 ## Task 2: Add locked-digest GeoIP downloads without changing runtime behavior
@@ -46,7 +46,7 @@
 - Modify: related `internal/core/*_test.go`
 - Create: `scripts/resolve-release-inputs/main.go`
 - Create: `scripts/resolve-release-inputs/main_test.go`
-- If sharing is necessary, move lock DTO/validation into the smallest importable package under `scripts/internal/` and update Task 1 files accordingly.
+- Use: `scripts/internal/releaseinputs` for the shared lock DTO, canonical encoder, and validation created in Task 1.
 
 1. Add failing tests for decoding GitHub numeric release/asset IDs, selecting exactly the six supported assets, resolving GeoIP `release` to a 40-hex commit, hashing every downloaded payload, canonical output, and preserving an existing lock after failure.
 2. Run focused tests and confirm the missing resolver behavior.

--- a/docs/superpowers/specs/2026-08-24-reproducible-release-inputs-design.md
+++ b/docs/superpowers/specs/2026-08-24-reproducible-release-inputs-design.md
@@ -46,7 +46,7 @@ The repository already pins the build environment through `go 1.26.0`, `toolchai
 - GeoIP repository and exact 40-hex commit;
 - Country and ASN file names, immutable raw URLs, and SHA-256 values.
 
-The six required platform keys are Linux, macOS, and Windows on amd64 and arm64. JSON is canonical and ends in one newline; it has no generated timestamp.
+The exact six required `GOOS/GOARCH` platform keys are `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`. JSON is canonical and ends in one newline; it has no generated timestamp.
 
 The loader reads at most 1 MiB, requires UTF-8 JSON, rejects unknown fields and trailing JSON, validates every identifier/digest/size, enforces the exact platform set, and constrains URLs to the expected HTTPS hosts and repository/tag/commit paths. Validation happens before network requests or output mutation.
 

--- a/docs/superpowers/specs/2026-08-24-reproducible-release-inputs-design.md
+++ b/docs/superpowers/specs/2026-08-24-reproducible-release-inputs-design.md
@@ -1,0 +1,94 @@
+# Reproducible Release Inputs Design
+
+**Date:** 2026-08-24
+
+## Problem
+
+Re-running the `v0.9.0-dev.2` release from the same source commit produced different Mihari binaries. The first build ran before the release tag existed and Go recorded a pseudo-version in module metadata; the second ran after the tag existed and recorded `v0.9.0-dev.2`. The injected user-facing version was unchanged, but the executable bytes and therefore every all-in-one archive checksum changed. The release preflight correctly rejected those conflicting assets.
+
+The all-in-one builder also resolves the latest mihomo release and GeoIP's mutable `release` branch during every workflow run. Even after removing VCS metadata from Mihari binaries, an upstream change could still make a retry produce different bytes.
+
+## Goals
+
+- The same source commit, version, toolchain, and checked-in input lock produce byte-identical raw Mihari binaries and all-in-one bundles before and after a release tag exists.
+- Release workflows never discover mutable upstream inputs while building.
+- Every downloaded mihomo and GeoIP payload is bounded and SHA-256 verified.
+- Runtime GeoIP refresh behavior remains backward compatible.
+- The public release asset set remains exactly the existing 14 files; the lock is source metadata, not a release artifact.
+
+## Non-goals
+
+- Replacing GitHub Actions, AList publication, or the existing release/tag policy.
+- Changing the stable/dev version formats or public archive layout.
+- Automatically updating the lock during a release workflow.
+- Adding a new dependency or changing a persisted runtime format.
+
+## Design
+
+### Deterministic Mihari binaries
+
+Both stable and dev workflows build with:
+
+```console
+go build -buildvcs=false -trimpath ...
+```
+
+`-buildvcs=false` prevents tag-dependent VCS/module metadata from changing the binary. `-trimpath` continues to remove checkout-path differences. The canonical release version remains injected through `internal/buildinfo.Version` with `-ldflags -X`.
+
+The repository already pins the build environment through `go 1.26.0`, `toolchain go1.26.5`, and `actions/setup-go` using `go-version-file: go.mod`. Tests will guard that workflow wiring.
+
+### Checked-in all-in-one input lock
+
+`scripts/release-inputs.lock.json` is the single source of truth for upstream AIO inputs. Its schema is `mihari-aio-input-lock/v1` and contains:
+
+- mihomo repository, channel, release ID, tag, and exactly six platform assets;
+- each mihomo asset's numeric asset ID, exact name, immutable versioned URL, byte size, and SHA-256;
+- GeoIP repository and exact 40-hex commit;
+- Country and ASN file names, immutable raw URLs, and SHA-256 values.
+
+The six required platform keys are Linux, macOS, and Windows on amd64 and arm64. JSON is canonical and ends in one newline; it has no generated timestamp.
+
+The loader reads at most 1 MiB, requires UTF-8 JSON, rejects unknown fields and trailing JSON, validates every identifier/digest/size, enforces the exact platform set, and constrains URLs to the expected HTTPS hosts and repository/tag/commit paths. Validation happens before network requests or output mutation.
+
+### Builder behavior
+
+`scripts/build-all-in-one` requires `--lock scripts/release-inputs.lock.json`. It no longer calls the GitHub latest-release endpoint and no longer reads GeoIP from a mutable branch. It downloads the exact locked assets and verifies their locked sizes and digests before packaging.
+
+GeoIP's downloader gains an optional expected-SHA-256 verification mode. Exactly one checksum source is allowed:
+
+- existing runtime callers provide `ChecksumURL` and keep current behavior;
+- the AIO builder provides `ExpectedSHA256`, so it performs no checksum-sidecar request.
+
+Archive metadata is canonical rather than inherited from the build host. Entries
+are ordered deterministically and use fixed timestamps. `mihari`, `mihomo`, and
+`install-aio.sh` are archived as `0755`; PowerShell installers, `core-channel`,
+and both MMDB files are archived as `0644`. Tar and ZIP therefore remain
+byte-identical even when checkout or staging permissions differ across hosts.
+
+### Resolver command
+
+An independently invoked maintenance command updates the lock:
+
+```console
+go run ./scripts/resolve-release-inputs --channel stable --out scripts/release-inputs.lock.json
+```
+
+It is used while preparing and reviewing a release PR, never by a release workflow. It resolves one mihomo release, selects the exact supported assets, resolves GeoIP's `release` ref to an exact commit, downloads and validates every payload, then atomically replaces the lock through a same-directory temporary file. Any error leaves the previous lock untouched.
+
+### Failure and security properties
+
+- Missing, malformed, incomplete, or unexpected lock data fails closed.
+- Redirects may not downgrade HTTPS, and locked URLs may not contain credentials, queries, or fragments.
+- Downloads remain context-aware, status checked, size bounded, and digest verified.
+- No secret, token, or complete sensitive URL is emitted in errors.
+- Release retries compare against identical locally rebuilt bytes, so the existing preflight remains a meaningful conflict detector.
+
+## Verification
+
+- Unit tests for strict lock decoding and validation.
+- Unit tests for GeoIP expected-digest mode and mutually exclusive checksum modes.
+- Resolver tests using local HTTP fixtures, including atomic failure preservation.
+- Builder tests proving it performs no mutable discovery and produces identical bundles on repeated runs.
+- Workflow tests that inspect parsed YAML and verify both release builds use `-buildvcs=false`, the pinned Go file, and the checked-in lock.
+- A local before/after-tag reproducibility check for a release binary.
+- Full Go tests, race tests, vet, formatting, and cross-platform CGO-free builds before integration.

--- a/internal/core/install_test.go
+++ b/internal/core/install_test.go
@@ -685,6 +685,39 @@ func TestLatestReleaseExport(t *testing.T) {
 	}
 }
 
+func TestLatestReleasePreservesGitHubNumericIDs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/repos/MetaCubeX/mihomo/releases/latest" {
+			http.NotFound(response, request)
+			return
+		}
+		_, _ = response.Write([]byte(`{
+			"id": 371291937,
+			"tag_name": "v1.19.30",
+			"assets": [{
+				"id": 516687180,
+				"name": "mihomo-linux-amd64-compatible-v1.19.30.gz",
+				"browser_download_url": "https://github.com/MetaCubeX/mihomo/releases/download/v1.19.30/mihomo-linux-amd64-compatible-v1.19.30.gz",
+				"size": 18899951,
+				"digest": "sha256:db214c7a2517e63c150d123178d16d102e03a241ccdae4e5e07ffbe9cf56c6f9"
+			}]
+		}`))
+	}))
+	defer server.Close()
+
+	installer := Installer{HTTPClient: server.Client(), APIBase: server.URL, Repository: "MetaCubeX/mihomo"}
+	release, err := installer.LatestRelease(context.Background(), "stable")
+	if err != nil {
+		t.Fatalf("LatestRelease: %v", err)
+	}
+	if release.ID != 371291937 {
+		t.Fatalf("release ID = %d, want 371291937", release.ID)
+	}
+	if got := release.Assets[0].ID; got != 516687180 {
+		t.Fatalf("asset ID = %d, want 516687180", got)
+	}
+}
+
 func TestLatestReleaseAlphaHitsPrereleaseTag(t *testing.T) {
 	var requested []string
 	server := alphaReleaseFixture(t, "mihomo-linux-amd64-alpha-e183c58.gz", gzipFixture(t, []byte("payload")), &requested)

--- a/internal/core/release.go
+++ b/internal/core/release.go
@@ -13,6 +13,7 @@ import (
 const maxReleaseResponseSize = 2 << 20
 
 type Asset struct {
+	ID     int64  `json:"id"`
 	Name   string `json:"name"`
 	URL    string `json:"browser_download_url"`
 	Size   int64  `json:"size"`
@@ -20,6 +21,7 @@ type Asset struct {
 }
 
 type Release struct {
+	ID      int64   `json:"id"`
 	TagName string  `json:"tag_name"`
 	Assets  []Asset `json:"assets"`
 }

--- a/internal/geoip/downloader.go
+++ b/internal/geoip/downloader.go
@@ -21,9 +21,10 @@ const defaultMaxDatabaseBytes int64 = 128 << 20
 
 // DownloadSpec identifies one database, its checksum, and its local destination.
 type DownloadSpec struct {
-	URL         string
-	ChecksumURL string
-	Destination string
+	URL            string
+	ChecksumURL    string
+	ExpectedSHA256 string
+	Destination    string
 }
 
 // Downloader prepares bounded, checksum-verified MMDB candidates.
@@ -49,8 +50,21 @@ func (d Downloader) Prepare(ctx context.Context, spec DownloadSpec) (_ *FileCand
 	if err := validateDownloadURL(spec.URL, d.AllowHTTP); err != nil {
 		return nil, err
 	}
-	if err := validateDownloadURL(spec.ChecksumURL, d.AllowHTTP); err != nil {
-		return nil, err
+	if (spec.ChecksumURL == "") == (spec.ExpectedSHA256 == "") {
+		return nil, errors.New("exactly one geoip checksum source is required")
+	}
+	var want [sha256.Size]byte
+	if spec.ChecksumURL != "" {
+		if err := validateDownloadURL(spec.ChecksumURL, d.AllowHTTP); err != nil {
+			return nil, err
+		}
+	}
+	if spec.ExpectedSHA256 != "" {
+		var err error
+		want, err = parseExpectedSHA256(spec.ExpectedSHA256)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if spec.Destination == "" || d.StagingDir == "" {
 		return nil, errors.New("geoip download paths are required")
@@ -59,9 +73,12 @@ func (d Downloader) Prepare(ctx context.Context, spec DownloadSpec) (_ *FileCand
 	if client == nil {
 		client = &http.Client{Timeout: 2 * time.Minute}
 	}
-	want, err := downloadChecksum(ctx, client, spec.ChecksumURL, d.AllowHTTP)
-	if err != nil {
-		return nil, err
+	if spec.ChecksumURL != "" {
+		var err error
+		want, err = downloadChecksum(ctx, client, spec.ChecksumURL, d.AllowHTTP)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if err := os.MkdirAll(d.StagingDir, 0o700); err != nil {
 		return nil, fmt.Errorf("create geoip staging directory: %w", err)
@@ -105,6 +122,24 @@ func (d Downloader) Prepare(ctx context.Context, spec DownloadSpec) (_ *FileCand
 		return nil, fmt.Errorf("validate geoip candidate: %w", err)
 	}
 	return &FileCandidate{staged: staged, destination: spec.Destination, digest: got}, nil
+}
+
+func parseExpectedSHA256(raw string) ([sha256.Size]byte, error) {
+	var result [sha256.Size]byte
+	if len(raw) != sha256.Size*2 {
+		return result, errors.New("expected geoip SHA-256 must be 64 lowercase hexadecimal characters")
+	}
+	for _, character := range raw {
+		if !((character >= '0' && character <= '9') || (character >= 'a' && character <= 'f')) {
+			return result, errors.New("expected geoip SHA-256 must be 64 lowercase hexadecimal characters")
+		}
+	}
+	decoded, err := hex.DecodeString(raw)
+	if err != nil {
+		return result, errors.New("expected geoip SHA-256 must be 64 lowercase hexadecimal characters")
+	}
+	copy(result[:], decoded)
+	return result, nil
 }
 
 func validateDownloadURL(raw string, allowHTTP bool) error {

--- a/internal/geoip/downloader.go
+++ b/internal/geoip/downloader.go
@@ -19,6 +19,8 @@ import (
 
 const defaultMaxDatabaseBytes int64 = 128 << 20
 
+var errInvalidExpectedSHA256 = errors.New("expected geoip SHA-256 must be 64 lowercase hexadecimal characters")
+
 // DownloadSpec identifies one database, its checksum, and its local destination.
 type DownloadSpec struct {
 	URL            string
@@ -127,16 +129,14 @@ func (d Downloader) Prepare(ctx context.Context, spec DownloadSpec) (_ *FileCand
 func parseExpectedSHA256(raw string) ([sha256.Size]byte, error) {
 	var result [sha256.Size]byte
 	if len(raw) != sha256.Size*2 {
-		return result, errors.New("expected geoip SHA-256 must be 64 lowercase hexadecimal characters")
+		return result, errInvalidExpectedSHA256
 	}
-	for _, character := range raw {
-		if !((character >= '0' && character <= '9') || (character >= 'a' && character <= 'f')) {
-			return result, errors.New("expected geoip SHA-256 must be 64 lowercase hexadecimal characters")
-		}
+	if raw != strings.ToLower(raw) {
+		return result, errInvalidExpectedSHA256
 	}
 	decoded, err := hex.DecodeString(raw)
 	if err != nil {
-		return result, errors.New("expected geoip SHA-256 must be 64 lowercase hexadecimal characters")
+		return result, errInvalidExpectedSHA256
 	}
 	copy(result[:], decoded)
 	return result, nil

--- a/internal/geoip/downloader_test.go
+++ b/internal/geoip/downloader_test.go
@@ -228,14 +228,17 @@ func TestDownloader_PreparesCandidateFromInlineChecksumWithoutSidecarRequest(t *
 	}
 }
 
-func TestDownloader_RejectsMalformedInlineChecksumBeforeSideEffects(t *testing.T) {
+func TestDownloader_RejectsInvalidInlineChecksumBeforeSideEffects(t *testing.T) {
 	checksums := []struct {
-		name  string
-		value string
+		name    string
+		value   string
+		wantErr string
 	}{
-		{name: "too short", value: strings.Repeat("0", 63)},
-		{name: "non-hexadecimal", value: strings.Repeat("0", 63) + "g"},
-		{name: "uppercase", value: "Ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"},
+		{name: "empty", wantErr: "exactly one"},
+		{name: "too short", value: strings.Repeat("0", 63), wantErr: "64 lowercase hexadecimal"},
+		{name: "too long", value: strings.Repeat("0", 65), wantErr: "64 lowercase hexadecimal"},
+		{name: "non-hexadecimal", value: strings.Repeat("0", 63) + "g", wantErr: "64 lowercase hexadecimal"},
+		{name: "uppercase", value: "Ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", wantErr: "64 lowercase hexadecimal"},
 	}
 	for _, checksum := range checksums {
 		t.Run(checksum.name, func(t *testing.T) {
@@ -252,7 +255,7 @@ func TestDownloader_RejectsMalformedInlineChecksumBeforeSideEffects(t *testing.T
 			_, err := downloader.Prepare(context.Background(), DownloadSpec{
 				URL: server.URL + "/database.mmdb", ExpectedSHA256: checksum.value, Destination: filepath.Join(root, "database.mmdb"),
 			})
-			if err == nil || !strings.Contains(err.Error(), "64 lowercase hexadecimal") {
+			if err == nil || !strings.Contains(err.Error(), checksum.wantErr) {
 				t.Fatalf("err=%v", err)
 			}
 			if len(requests) != 0 {
@@ -294,5 +297,43 @@ func TestDownloader_InlineChecksumMismatchRemovesStagedCandidate(t *testing.T) {
 	}
 	if len(entries) != 0 {
 		t.Fatalf("staging entries=%v", entries)
+	}
+}
+
+func TestParseExpectedSHA256_ValidatesCanonicalDigest(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr bool
+	}{
+		{name: "empty", raw: "", wantErr: true},
+		{name: "63 characters", raw: strings.Repeat("0", 63), wantErr: true},
+		{name: "65 characters", raw: strings.Repeat("0", 65), wantErr: true},
+		{name: "uppercase", raw: strings.Repeat("A", 64), wantErr: true},
+		{name: "non-hexadecimal", raw: strings.Repeat("g", 64), wantErr: true},
+		{name: "valid", raw: strings.Repeat("0", 64)},
+	}
+	var canonicalErr error
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := parseExpectedSHA256(test.raw)
+			if test.wantErr {
+				if err == nil || err.Error() != "expected geoip SHA-256 must be 64 lowercase hexadecimal characters" {
+					t.Fatalf("err=%v", err)
+				}
+				if canonicalErr == nil {
+					canonicalErr = err
+				} else if err != canonicalErr {
+					t.Fatalf("error is not the canonical invalid-digest error: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != ([sha256.Size]byte{}) {
+				t.Fatalf("digest=%x", got)
+			}
+		})
 	}
 }

--- a/internal/geoip/downloader_test.go
+++ b/internal/geoip/downloader_test.go
@@ -147,3 +147,152 @@ func TestDownloader_PropagatesContextCancellation(t *testing.T) {
 		t.Fatalf("err=%v", err)
 	}
 }
+
+func TestDownloader_RequiresExactlyOneChecksumSourceBeforeSideEffects(t *testing.T) {
+	requests := make(chan string, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests <- request.URL.Path
+		writer.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	root := t.TempDir()
+	staging := filepath.Join(root, "staging")
+	downloader := Downloader{Client: server.Client(), StagingDir: staging, AllowHTTP: true}
+
+	_, err := downloader.Prepare(context.Background(), DownloadSpec{
+		URL: server.URL + "/database.mmdb", Destination: filepath.Join(root, "database.mmdb"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "exactly one") {
+		t.Fatalf("err=%v", err)
+	}
+	if _, statErr := os.Stat(staging); !os.IsNotExist(statErr) {
+		t.Fatalf("staging directory created before checksum validation: %v", statErr)
+	}
+
+	_, err = downloader.Prepare(context.Background(), DownloadSpec{
+		URL:            server.URL + "/database.mmdb",
+		ChecksumURL:    server.URL + "/database.mmdb.sha256sum",
+		ExpectedSHA256: strings.Repeat("0", 64),
+		Destination:    filepath.Join(root, "database.mmdb"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "exactly one") {
+		t.Fatalf("err=%v", err)
+	}
+	if _, statErr := os.Stat(staging); !os.IsNotExist(statErr) {
+		t.Fatalf("staging directory created before checksum validation: %v", statErr)
+	}
+	if len(requests) != 0 {
+		t.Fatalf("network request made before checksum source validation: %q", <-requests)
+	}
+}
+
+func TestDownloader_PreparesCandidateFromInlineChecksumWithoutSidecarRequest(t *testing.T) {
+	requests := make(chan string, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests <- request.URL.Path
+		_, _ = io.WriteString(writer, "abc")
+	}))
+	defer server.Close()
+	root := t.TempDir()
+	downloader := Downloader{
+		Client: server.Client(), StagingDir: filepath.Join(root, "staging"), AllowHTTP: true,
+		Validate: func(path string) error {
+			got, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			if string(got) != "abc" {
+				return errors.New("unexpected candidate contents")
+			}
+			return nil
+		},
+	}
+
+	candidate, err := downloader.Prepare(context.Background(), DownloadSpec{
+		URL:            server.URL + "/database.mmdb",
+		ExpectedSHA256: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+		Destination:    filepath.Join(root, "database.mmdb"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer candidate.Cleanup()
+	if !candidate.Valid() {
+		t.Fatal("prepared candidate is invalid")
+	}
+	if len(requests) != 1 {
+		t.Fatalf("network request count=%d", len(requests))
+	}
+	if path := <-requests; path != "/database.mmdb" {
+		t.Fatalf("requested path=%q", path)
+	}
+}
+
+func TestDownloader_RejectsMalformedInlineChecksumBeforeSideEffects(t *testing.T) {
+	checksums := []struct {
+		name  string
+		value string
+	}{
+		{name: "too short", value: strings.Repeat("0", 63)},
+		{name: "non-hexadecimal", value: strings.Repeat("0", 63) + "g"},
+		{name: "uppercase", value: "Ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"},
+	}
+	for _, checksum := range checksums {
+		t.Run(checksum.name, func(t *testing.T) {
+			requests := make(chan string, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				requests <- request.URL.Path
+				_, _ = io.WriteString(writer, "abc")
+			}))
+			defer server.Close()
+			root := t.TempDir()
+			staging := filepath.Join(root, "staging")
+			downloader := Downloader{Client: server.Client(), StagingDir: staging, AllowHTTP: true}
+
+			_, err := downloader.Prepare(context.Background(), DownloadSpec{
+				URL: server.URL + "/database.mmdb", ExpectedSHA256: checksum.value, Destination: filepath.Join(root, "database.mmdb"),
+			})
+			if err == nil || !strings.Contains(err.Error(), "64 lowercase hexadecimal") {
+				t.Fatalf("err=%v", err)
+			}
+			if len(requests) != 0 {
+				t.Fatalf("network request made before checksum validation: %q", <-requests)
+			}
+			if _, statErr := os.Stat(staging); !os.IsNotExist(statErr) {
+				t.Fatalf("staging directory created before checksum validation: %v", statErr)
+			}
+		})
+	}
+}
+
+func TestDownloader_InlineChecksumMismatchRemovesStagedCandidate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(writer, "wrong")
+	}))
+	defer server.Close()
+	root := t.TempDir()
+	staging := filepath.Join(root, "staging")
+	downloader := Downloader{
+		Client: server.Client(), StagingDir: staging, AllowHTTP: true,
+		Validate: func(string) error {
+			t.Fatal("checksum-mismatched candidate was validated")
+			return nil
+		},
+	}
+
+	_, err := downloader.Prepare(context.Background(), DownloadSpec{
+		URL:            server.URL + "/database.mmdb",
+		ExpectedSHA256: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+		Destination:    filepath.Join(root, "database.mmdb"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("err=%v", err)
+	}
+	entries, readErr := os.ReadDir(staging)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("staging entries=%v", entries)
+	}
+}

--- a/scripts/build-all-in-one/main.go
+++ b/scripts/build-all-in-one/main.go
@@ -724,24 +724,30 @@ func publishBundles(ctx context.Context, source, destination string, platforms [
 
 func ensureSafePublishParent(ctx context.Context, parent string) ([]string, error) {
 	var missing []string
-	for current := parent; ; current = filepath.Dir(current) {
+	current := parent
+	for {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
 		info, err := os.Lstat(current)
-		switch {
-		case err == nil:
+		if err == nil {
 			if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
 				return nil, errors.New("bundle destination path must not cross a link or non-directory")
 			}
-		case os.IsNotExist(err):
-			missing = append(missing, current)
-		default:
-			return nil, err
-		}
-		if filepath.Dir(current) == current {
+			// Stop at the first existing real directory. Walking to the
+			// filesystem root would reject macOS paths whose only link is a
+			// system ancestor such as /var -> /private/var.
 			break
 		}
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+		next := filepath.Dir(current)
+		if next == current {
+			return nil, errors.New("bundle destination path has no existing ancestor")
+		}
+		missing = append(missing, current)
+		current = next
 	}
 	created := make([]string, 0, len(missing))
 	for index := len(missing) - 1; index >= 0; index-- {

--- a/scripts/build-all-in-one/main.go
+++ b/scripts/build-all-in-one/main.go
@@ -91,9 +91,11 @@ func run(o options) error {
 	if o.ScriptsDir == "" {
 		o.ScriptsDir = "scripts/install"
 	}
-	if err := validateOutputIsolation(o.Out, o.LockPath, o.MihariDir, o.ScriptsDir); err != nil {
+	resolvedOutput, err := validateOutputIsolation(o.Out, o.LockPath, o.MihariDir, o.ScriptsDir)
+	if err != nil {
 		return err
 	}
+	o.Out = resolvedOutput
 	if err := validateRequestedPlatforms(o.Platforms, lock.Mihomo.Assets); err != nil {
 		return err
 	}
@@ -145,30 +147,45 @@ func run(o options) error {
 	return nil
 }
 
-func validateOutputIsolation(output, lockPath, mihariDir, scriptsDir string) error {
+func validateOutputIsolation(output, lockPath, mihariDir, scriptsDir string) (string, error) {
 	workingDirectory, err := os.Getwd()
 	if err != nil {
-		return errUnsafeBundleOutput
+		return "", errUnsafeBundleOutput
 	}
-	output, err = canonicalOverlapPath(output)
+	output, err = canonicalOutputPath(output)
 	if err != nil {
-		return errUnsafeBundleOutput
+		return "", errUnsafeBundleOutput
 	}
 	workingDirectory, err = canonicalOverlapPath(workingDirectory)
 	if err != nil || pathContains(output, workingDirectory) {
-		return errUnsafeBundleOutput
+		return "", errUnsafeBundleOutput
 	}
 	lockPath, err = canonicalOverlapPath(lockPath)
 	if err != nil || pathContains(output, lockPath) {
-		return errUnsafeBundleOutput
+		return "", errUnsafeBundleOutput
 	}
 	for _, inputDirectory := range []string{mihariDir, scriptsDir} {
 		inputDirectory, err = canonicalOverlapPath(inputDirectory)
 		if err != nil || pathContains(output, inputDirectory) || pathContains(inputDirectory, output) {
-			return errUnsafeBundleOutput
+			return "", errUnsafeBundleOutput
 		}
 	}
-	return nil
+	return output, nil
+}
+
+func canonicalOutputPath(path string) (string, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	if info, statErr := os.Lstat(filepath.Clean(absolute)); statErr == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return "", errUnsafeBundleOutput
+		}
+	} else if !os.IsNotExist(statErr) {
+		return "", statErr
+	}
+	return canonicalOverlapPath(absolute)
 }
 
 func canonicalOverlapPath(path string) (string, error) {

--- a/scripts/build-all-in-one/main.go
+++ b/scripts/build-all-in-one/main.go
@@ -1,8 +1,7 @@
 // Command build-all-in-one packs mihari + mihomo core + GeoIP×2 + the local
 // install-aio installer into per-platform all-in-one bundles for offline
-// distribution. It reuses the runtime core.LatestRelease/Download/SelectAsset
-// (mihomo) and geoip.Downloader (GeoIP, same checksum mechanism as the daemon);
-// extraction and smoke checks are bundler-local per design §4.1.
+// distribution. Every external input comes from a reviewed release-input lock;
+// the builder never discovers a latest release or a mutable GeoIP ref.
 package main
 
 import (
@@ -24,45 +23,48 @@ import (
 
 	"github.com/mihari-proxy/mihari/internal/core"
 	"github.com/mihari-proxy/mihari/internal/geoip"
+	"github.com/mihari-proxy/mihari/scripts/internal/releaseinputs"
 )
 
-var defaultPlatforms = []string{
-	"linux/amd64", "linux/arm64",
-	"darwin/amd64", "darwin/arm64",
-	"windows/amd64", "windows/arm64",
-}
+var defaultPlatforms = releaseinputs.RequiredPlatforms()
 
 const maxMihomoBinary int64 = 256 << 20
 
+const publishCleanupWarning = "old bundle backup cleanup failed; manual cleanup may be required"
+
+var errUnsafeBundleOutput = errors.New("--out must be a dedicated managed bundle directory")
+
 type options struct {
-	MihariDir   string // dist/ — CI cross-build artifacts (mihari-<os>-<arch>[.exe])
-	Out         string // bundles/
-	ScriptsDir  string // directory holding install-aio.sh / install-aio.ps1 (scripts/install in CI)
-	Platforms   []string
-	GitHubToken string // optional; adds Authorization: Bearer when set
-	Channel     string // mihomo channel: stable (default) or alpha
+	LockPath   string
+	MihariDir  string // dist/ — CI cross-build artifacts (mihari-<os>-<arch>[.exe])
+	Out        string // bundles/
+	ScriptsDir string // directory holding install-aio.sh / install-aio.ps1 (scripts/install in CI)
+	Platforms  []string
 
 	// Test seams (zero-valued in production).
+	Context       context.Context
 	HTTPClient    *http.Client
-	APIBase       string // override GitHub API base
-	Repository    string // override "MetaCubeX/mihomo"
-	GeoIPBase     string // override GeoIP root (empty → geoip.Default*URL)
 	GeoIPValidate func(string) error
 	Runner        core.CommandRunner // linux/amd64 `-v` smoke; defaults to OSCommandRunner
+	PublishFault  func(operation, path string) error
+	WarningSink   func(message string)
+	CopyChunkHook func()
 }
 
 func main() {
+	lockPath := flag.String("lock", "", "reviewed release input lock (required)")
 	mihariDir := flag.String("mihari-dir", "dist", "directory with mihari-<os>-<arch>[.exe] build artifacts")
 	out := flag.String("out", "bundles", "output directory for all-in-one bundles")
 	platforms := flag.String("platforms", strings.Join(defaultPlatforms, ","), "comma-separated goos/goarch targets")
 	scriptsDir := flag.String("scripts-dir", "scripts/install", "directory holding install-aio.sh / install-aio.ps1")
-	token := flag.String("github-token", os.Getenv("GITHUB_TOKEN"), "GitHub API token (default $GITHUB_TOKEN)")
-	channel := flag.String("channel", "stable", "mihomo channel: stable or alpha")
 	flag.Parse()
 
 	if err := run(options{
-		MihariDir: *mihariDir, Out: *out, ScriptsDir: *scriptsDir,
-		Platforms: splitPlatforms(*platforms), GitHubToken: *token, Channel: *channel,
+		LockPath: *lockPath, MihariDir: *mihariDir, Out: *out, ScriptsDir: *scriptsDir,
+		Platforms: splitPlatforms(*platforms),
+		WarningSink: func(message string) {
+			fmt.Fprintln(os.Stderr, "build-all-in-one: warning:", message)
+		},
 	}); err != nil {
 		fmt.Fprintln(os.Stderr, "build-all-in-one:", err)
 		os.Exit(1)
@@ -70,6 +72,13 @@ func main() {
 }
 
 func run(o options) error {
+	if o.LockPath == "" {
+		return errors.New("--lock is required")
+	}
+	lock, err := releaseinputs.Load(o.LockPath)
+	if err != nil {
+		return fmt.Errorf("load release input lock: %w", err)
+	}
 	if o.MihariDir == "" {
 		return errors.New("--mihari-dir is required")
 	}
@@ -82,24 +91,29 @@ func run(o options) error {
 	if o.ScriptsDir == "" {
 		o.ScriptsDir = "scripts/install"
 	}
-	if o.Channel == "" {
-		o.Channel = "stable"
+	if err := validateOutputIsolation(o.Out, o.LockPath, o.MihariDir, o.ScriptsDir); err != nil {
+		return err
 	}
-	if err := os.MkdirAll(o.Out, 0o755); err != nil {
-		return fmt.Errorf("create bundles directory: %w", err)
+	if err := validateRequestedPlatforms(o.Platforms, lock.Mihomo.Assets); err != nil {
+		return err
 	}
 	client := o.HTTPClient
 	if client == nil {
-		client = newClient(o.GitHubToken)
+		client = newClient()
 	}
-	installer := core.Installer{HTTPClient: client, APIBase: o.APIBase, Repository: o.Repository, Runner: o.Runner}
-	ctx := context.Background()
-
-	// Exactly one mihomo API request returns every platform asset.
-	release, err := installer.LatestRelease(ctx, o.Channel)
+	client = secureRedirectClient(client)
+	installer := core.Installer{HTTPClient: client, Runner: o.Runner}
+	ctx := o.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	bundleDir, err := os.MkdirTemp("", "aio-bundles-")
 	if err != nil {
-		return fmt.Errorf("fetch mihomo release: %w", err)
+		return fmt.Errorf("create temporary bundles directory: %w", err)
 	}
+	defer os.RemoveAll(bundleDir)
+	buildOptions := o
+	buildOptions.Out = bundleDir
 
 	// GeoIP×2 is shared across all platforms — download once.
 	geoipDir, err := os.MkdirTemp("", "aio-geoip-")
@@ -107,7 +121,7 @@ func run(o options) error {
 		return err
 	}
 	defer os.RemoveAll(geoipDir)
-	countryPath, asnPath, err := downloadGeoIP(ctx, client, geoipDir, o)
+	countryPath, asnPath, err := downloadGeoIP(ctx, client, geoipDir, lock.GeoIP, o.GeoIPValidate)
 	if err != nil {
 		return fmt.Errorf("download geoip: %w", err)
 	}
@@ -117,23 +131,111 @@ func run(o options) error {
 		if err != nil {
 			return fmt.Errorf("platform %q: %w", platform, err)
 		}
-		if err := buildPlatform(ctx, installer, release, goos, goarch, o, countryPath, asnPath); err != nil {
+		lockedAsset, ok := lock.Mihomo.Assets[platform]
+		if !ok {
+			return fmt.Errorf("platform %q is not present in release input lock", platform)
+		}
+		if err := buildPlatform(ctx, installer, lock.Mihomo, lockedAsset, goos, goarch, buildOptions, countryPath, asnPath); err != nil {
 			return fmt.Errorf("build %s: %w", platform, err)
+		}
+	}
+	if err := publishBundles(ctx, bundleDir, o.Out, o.Platforms, o.PublishFault, o.WarningSink, o.CopyChunkHook); err != nil {
+		return fmt.Errorf("publish bundles: %w", err)
+	}
+	return nil
+}
+
+func validateOutputIsolation(output, lockPath, mihariDir, scriptsDir string) error {
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		return errUnsafeBundleOutput
+	}
+	output, err = canonicalOverlapPath(output)
+	if err != nil {
+		return errUnsafeBundleOutput
+	}
+	workingDirectory, err = canonicalOverlapPath(workingDirectory)
+	if err != nil || pathContains(output, workingDirectory) {
+		return errUnsafeBundleOutput
+	}
+	lockPath, err = canonicalOverlapPath(lockPath)
+	if err != nil || pathContains(output, lockPath) {
+		return errUnsafeBundleOutput
+	}
+	for _, inputDirectory := range []string{mihariDir, scriptsDir} {
+		inputDirectory, err = canonicalOverlapPath(inputDirectory)
+		if err != nil || pathContains(output, inputDirectory) || pathContains(inputDirectory, output) {
+			return errUnsafeBundleOutput
 		}
 	}
 	return nil
 }
 
-func buildPlatform(ctx context.Context, installer core.Installer, release core.Release, goos, goarch string, o options, countryPath, asnPath string) error {
+func canonicalOverlapPath(path string) (string, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	current := filepath.Clean(absolute)
+	var missing []string
+	for {
+		if _, err := os.Lstat(current); err == nil {
+			break
+		} else if !os.IsNotExist(err) {
+			return "", err
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", errors.New("path has no existing ancestor")
+		}
+		missing = append(missing, filepath.Base(current))
+		current = parent
+	}
+	resolved, err := filepath.EvalSymlinks(current)
+	if err != nil {
+		return "", err
+	}
+	for index := len(missing) - 1; index >= 0; index-- {
+		resolved = filepath.Join(resolved, missing[index])
+	}
+	return filepath.Clean(resolved), nil
+}
+
+func pathContains(parent, child string) bool {
+	relative, err := filepath.Rel(parent, child)
+	if err != nil || filepath.IsAbs(relative) {
+		return false
+	}
+	return relative == "." || (relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)))
+}
+
+func validateRequestedPlatforms(platforms []string, assets map[string]releaseinputs.MihomoAsset) error {
+	seen := make(map[string]struct{}, len(platforms))
+	for _, platform := range platforms {
+		if _, _, err := splitPlatform(platform); err != nil {
+			return fmt.Errorf("platform %q: %w", platform, err)
+		}
+		if _, ok := assets[platform]; !ok {
+			return fmt.Errorf("platform %q is not present in release input lock", platform)
+		}
+		if _, duplicate := seen[platform]; duplicate {
+			return fmt.Errorf("platform %q is duplicated", platform)
+		}
+		seen[platform] = struct{}{}
+	}
+	return nil
+}
+
+func buildPlatform(ctx context.Context, installer core.Installer, inputs releaseinputs.MihomoInputs, lockedAsset releaseinputs.MihomoAsset, goos, goarch string, o options, countryPath, asnPath string) error {
 	stage, err := os.MkdirTemp("", "aio-stage-")
 	if err != nil {
 		return err
 	}
 	defer os.RemoveAll(stage)
 
-	asset, err := core.SelectAsset(release, goos, goarch, o.Channel)
-	if err != nil {
-		return err
+	asset := core.Asset{
+		ID: lockedAsset.AssetID, Name: lockedAsset.Name, URL: lockedAsset.URL,
+		Size: lockedAsset.Size, Digest: "sha256:" + lockedAsset.SHA256,
 	}
 	// core.Download opens the destination with O_WRONLY|O_TRUNC (no O_CREATE);
 	// create it first, mirroring Prepare's CreateTemp contract (Task 7).
@@ -153,10 +255,10 @@ func buildPlatform(ctx context.Context, installer core.Installer, release core.R
 		mihomoName = "mihomo.exe"
 	}
 	mihomoDest := filepath.Join(stage, "data", "bin", mihomoName)
-	if err := extractMihomo(archivePath, asset.Name, mihomoDest); err != nil {
+	if err := extractMihomo(ctx, archivePath, asset.Name, mihomoDest, o.CopyChunkHook); err != nil {
 		return err
 	}
-	if err := writeCoreChannelSidecar(filepath.Join(stage, "data", "bin", "core-channel"), o.Channel, release, asset); err != nil {
+	if err := writeCoreChannelSidecar(filepath.Join(stage, "data", "bin", "core-channel"), inputs.Channel, inputs.Tag, asset); err != nil {
 		return err
 	}
 	if err := os.Remove(archivePath); err != nil {
@@ -170,10 +272,10 @@ func buildPlatform(ctx context.Context, installer core.Installer, release core.R
 	if err := os.MkdirAll(geoipDest, 0o700); err != nil {
 		return err
 	}
-	if err := copyFile(countryPath, filepath.Join(geoipDest, "GeoLite2-Country.mmdb")); err != nil {
+	if err := copyFile(ctx, countryPath, filepath.Join(geoipDest, "GeoLite2-Country.mmdb"), o.CopyChunkHook); err != nil {
 		return err
 	}
-	if err := copyFile(asnPath, filepath.Join(geoipDest, "GeoLite2-ASN.mmdb")); err != nil {
+	if err := copyFile(ctx, asnPath, filepath.Join(geoipDest, "GeoLite2-ASN.mmdb"), o.CopyChunkHook); err != nil {
 		return err
 	}
 
@@ -181,7 +283,7 @@ func buildPlatform(ctx context.Context, installer core.Installer, release core.R
 	if goos == "windows" {
 		mihariName = "mihari.exe"
 	}
-	if err := copyFile(distBinaryName(o.MihariDir, goos, goarch), filepath.Join(stage, mihariName)); err != nil {
+	if err := copyFile(ctx, distBinaryName(o.MihariDir, goos, goarch), filepath.Join(stage, mihariName), o.CopyChunkHook); err != nil {
 		return err
 	}
 
@@ -189,38 +291,27 @@ func buildPlatform(ctx context.Context, installer core.Installer, release core.R
 	if goos == "windows" {
 		script = "install-aio.ps1"
 	}
-	if err := copyFile(filepath.Join(o.ScriptsDir, script), filepath.Join(stage, script)); err != nil {
+	if err := copyFile(ctx, filepath.Join(o.ScriptsDir, script), filepath.Join(stage, script), o.CopyChunkHook); err != nil {
 		return err
 	}
 
-	files, err := relativeFiles(stage)
+	files, err := relativeFiles(ctx, stage)
 	if err != nil {
 		return err
 	}
 	if err := assertStage(goos, files); err != nil {
 		return err
 	}
-	return packStage(stage, o.Out, goos, goarch)
+	return packStage(ctx, stage, o.Out, goos, goarch, o.CopyChunkHook)
 }
 
-// downloadGeoIP fetches Country+ASN MMDB once with the same checksum-verified
-// mechanism as the runtime geoip.Service (geoip.Downloader + .sha256sum).
-func downloadGeoIP(ctx context.Context, client *http.Client, destDir string, o options) (country, asn string, err error) {
-	countryURL, countryChecksum := geoip.DefaultCountryURL, geoip.DefaultCountryChecksumURL
-	asnURL, asnChecksum := geoip.DefaultASNURL, geoip.DefaultASNChecksumURL
-	allowHTTP := false
-	if o.GeoIPBase != "" {
-		allowHTTP = true
-		root := strings.TrimRight(o.GeoIPBase, "/")
-		countryURL = root + "/GeoLite2-Country.mmdb"
-		countryChecksum = countryURL + ".sha256sum"
-		asnURL = root + "/GeoLite2-ASN.mmdb"
-		asnChecksum = asnURL + ".sha256sum"
-	}
-	downloader := geoip.Downloader{Client: client, StagingDir: destDir, AllowHTTP: allowHTTP, Validate: o.GeoIPValidate}
+// downloadGeoIP fetches the two immutable, digest-locked databases without a
+// mutable branch or checksum sidecar request.
+func downloadGeoIP(ctx context.Context, client *http.Client, destDir string, inputs releaseinputs.GeoIPInputs, validate func(string) error) (country, asn string, err error) {
+	downloader := geoip.Downloader{Client: client, StagingDir: destDir, Validate: validate}
 
 	country = filepath.Join(destDir, "GeoLite2-Country.mmdb")
-	countryCandidate, err := downloader.Prepare(ctx, geoip.DownloadSpec{URL: countryURL, ChecksumURL: countryChecksum, Destination: country})
+	countryCandidate, err := downloader.Prepare(ctx, geoip.DownloadSpec{URL: inputs.Country.URL, ExpectedSHA256: inputs.Country.SHA256, Destination: country})
 	if err != nil {
 		return "", "", err
 	}
@@ -228,7 +319,7 @@ func downloadGeoIP(ctx context.Context, client *http.Client, destDir string, o o
 		return "", "", err
 	}
 	asn = filepath.Join(destDir, "GeoLite2-ASN.mmdb")
-	asnCandidate, err := downloader.Prepare(ctx, geoip.DownloadSpec{URL: asnURL, ChecksumURL: asnChecksum, Destination: asn})
+	asnCandidate, err := downloader.Prepare(ctx, geoip.DownloadSpec{URL: inputs.ASN.URL, ExpectedSHA256: inputs.ASN.SHA256, Destination: asn})
 	if err != nil {
 		return "", "", err
 	}
@@ -281,11 +372,8 @@ func assertStage(goos string, files []string) error {
 	return nil
 }
 
-func writeCoreChannelSidecar(path, channel string, release core.Release, asset core.Asset) error {
-	if channel == "" {
-		channel = "stable"
-	}
-	fingerprint := release.TagName
+func writeCoreChannelSidecar(path, channel, tag string, asset core.Asset) error {
+	fingerprint := tag
 	if channel == "alpha" {
 		fingerprint = core.ParseAlphaSHA(asset.Name)
 	}
@@ -296,21 +384,21 @@ func writeCoreChannelSidecar(path, channel string, release core.Release, asset c
 	return os.WriteFile(path, []byte(content), 0o644)
 }
 
-func extractMihomo(archivePath, assetName, dest string) error {
+func extractMihomo(ctx context.Context, archivePath, assetName, dest string, chunkHook func()) error {
 	if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
 		return err
 	}
 	switch lower := strings.ToLower(assetName); {
 	case strings.HasSuffix(lower, ".gz"):
-		return extractGzipSingle(archivePath, dest)
+		return extractGzipSingle(ctx, archivePath, dest, chunkHook)
 	case strings.HasSuffix(lower, ".zip"):
-		return extractZipSingle(archivePath, dest)
+		return extractZipSingle(ctx, archivePath, dest, chunkHook)
 	default:
 		return fmt.Errorf("unsupported mihomo archive %q", assetName)
 	}
 }
 
-func extractGzipSingle(archivePath, dest string) error {
+func extractGzipSingle(ctx context.Context, archivePath, dest string, chunkHook func()) error {
 	archive, err := os.Open(archivePath)
 	if err != nil {
 		return err
@@ -321,16 +409,19 @@ func extractGzipSingle(archivePath, dest string) error {
 		return errors.New("invalid mihomo gzip archive")
 	}
 	defer reader.Close()
-	return writeAll(dest, io.LimitReader(reader, maxMihomoBinary+1), maxMihomoBinary)
+	return writeAll(ctx, dest, io.LimitReader(reader, maxMihomoBinary+1), maxMihomoBinary, chunkHook)
 }
 
-func extractZipSingle(archivePath, dest string) error {
+func extractZipSingle(ctx context.Context, archivePath, dest string, chunkHook func()) error {
 	archive, err := zip.OpenReader(archivePath)
 	if err != nil {
 		return errors.New("invalid mihomo zip archive")
 	}
 	defer archive.Close()
 	for _, file := range archive.File {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		base := strings.ToLower(filepath.Base(file.Name))
 		if file.FileInfo().IsDir() || !strings.Contains(base, "mihomo") || !strings.HasSuffix(base, ".exe") {
 			continue
@@ -339,7 +430,7 @@ func extractZipSingle(archivePath, dest string) error {
 		if err != nil {
 			return err
 		}
-		err = writeAll(dest, io.LimitReader(source, maxMihomoBinary+1), maxMihomoBinary)
+		err = writeAll(ctx, dest, io.LimitReader(source, maxMihomoBinary+1), maxMihomoBinary, chunkHook)
 		source.Close()
 		return err
 	}
@@ -347,12 +438,12 @@ func extractZipSingle(archivePath, dest string) error {
 }
 
 // writeAll copies reader into dest, enforcing a maxBytes ceiling on the result.
-func writeAll(dest string, reader io.Reader, maxBytes int64) error {
+func writeAll(ctx context.Context, dest string, reader io.Reader, maxBytes int64, chunkHook func()) error {
 	file, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o700)
 	if err != nil {
 		return err
 	}
-	written, err := io.Copy(file, reader)
+	written, err := copyWithContext(ctx, file, reader, chunkHook)
 	if closeErr := file.Close(); err == nil {
 		err = closeErr
 	}
@@ -386,11 +477,23 @@ func smokeMihomo(ctx context.Context, goos, goarch, path string, runner core.Com
 		}
 		return nil
 	}
-	data, err := os.ReadFile(path)
+	file, err := os.Open(path)
 	if err != nil {
 		return err
 	}
-	return checkMagic(goos, data)
+	defer file.Close()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	data := make([]byte, 4)
+	read, err := io.ReadFull(file, data)
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return checkMagic(goos, data[:read])
 }
 
 func checkMagic(goos string, data []byte) error {
@@ -419,21 +522,356 @@ func checkMagic(goos string, data []byte) error {
 	return fmt.Errorf("mihomo magic number mismatch for %s", goos)
 }
 
-func packStage(stage, out, goos, goarch string) error {
-	name := "mihari-all-in-one-" + goos + "-" + goarch
+func packStage(ctx context.Context, stage, out, goos, goarch string, chunkHook func()) error {
+	name := bundleName(goos, goarch)
 	if goos == "windows" {
-		return zipStage(stage, filepath.Join(out, name+".zip"))
+		return zipStage(ctx, stage, filepath.Join(out, name), chunkHook)
 	}
-	return tarStage(stage, filepath.Join(out, name+".tar.gz"))
+	return tarStage(ctx, stage, filepath.Join(out, name), chunkHook)
 }
 
-func tarStage(stage, dest string) (err error) {
+func bundleName(goos, goarch string) string {
+	name := "mihari-all-in-one-" + goos + "-" + goarch
+	if goos == "windows" {
+		return name + ".zip"
+	}
+	return name + ".tar.gz"
+}
+
+func publishBundles(ctx context.Context, source, destination string, platforms []string, fault func(operation, path string) error, warningSink func(message string), chunkHook func()) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	sourceInfo, err := os.Lstat(source)
+	if err != nil {
+		return err
+	}
+	if sourceInfo.Mode()&os.ModeSymlink != 0 || !sourceInfo.IsDir() {
+		return errors.New("temporary bundle source must be a real directory")
+	}
+	destination, err = filepath.Abs(destination)
+	if err != nil {
+		return err
+	}
+	parent := filepath.Dir(destination)
+	if parent == destination || filepath.Base(destination) == "." {
+		return errors.New("bundle destination must not be a filesystem root")
+	}
+	createdParents, err := ensureSafePublishParent(ctx, parent)
+	if err != nil {
+		return err
+	}
+	publishCommitted := false
+	defer func() {
+		if !publishCommitted {
+			removeCreatedPublishParents(createdParents)
+		}
+	}()
+
+	stage, err := os.MkdirTemp(parent, ".mihari-aio-publish-")
+	if err != nil {
+		return err
+	}
+	stagePending := true
+	defer func() {
+		if stagePending {
+			_ = os.RemoveAll(stage)
+		}
+	}()
+
+	destinationExists := false
+	destinationMode := os.FileMode(0o755)
+	var originalDestinationInfo os.FileInfo
+	if info, statErr := os.Lstat(destination); statErr == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return errors.New("bundle destination must be a real directory")
+		}
+		destinationExists = true
+		destinationMode = info.Mode().Perm()
+		originalDestinationInfo = info
+		if err := validateManagedOutput(ctx, destination, platforms); err != nil {
+			return err
+		}
+	} else if !os.IsNotExist(statErr) {
+		return statErr
+	}
+
+	for _, platform := range platforms {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		goos, goarch, err := splitPlatform(platform)
+		if err != nil {
+			return err
+		}
+		name := bundleName(goos, goarch)
+		sourcePath := filepath.Join(source, name)
+		info, err := os.Stat(sourcePath)
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("temporary bundle %q is not a regular file", name)
+		}
+		destinationPath := filepath.Join(destination, name)
+		stagePath := filepath.Join(stage, name)
+		if existing, statErr := os.Lstat(stagePath); statErr == nil && !existing.Mode().IsRegular() {
+			return fmt.Errorf("existing output path %q is not a regular file", name)
+		} else if statErr != nil && !os.IsNotExist(statErr) {
+			return statErr
+		}
+		if err := runPublishFault(fault, "copy", destinationPath); err != nil {
+			return err
+		}
+		if err := copyRegularFile(ctx, sourcePath, stagePath, info.Mode().Perm(), chunkHook); err != nil {
+			return err
+		}
+		if err := runPublishFault(fault, "chmod", destinationPath); err != nil {
+			return err
+		}
+		if err := os.Chmod(stagePath, info.Mode().Perm()); err != nil {
+			return err
+		}
+	}
+	if err := os.Chmod(stage, destinationMode); err != nil {
+		return err
+	}
+
+	if !destinationExists {
+		if _, err := os.Lstat(destination); !os.IsNotExist(err) {
+			if err == nil {
+				return errors.New("bundle destination appeared during publish")
+			}
+			return err
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := runPublishFault(fault, "replace", destination); err != nil {
+			return err
+		}
+		if err := os.Rename(stage, destination); err != nil {
+			return err
+		}
+		stagePending = false
+		publishCommitted = true
+		return nil
+	}
+
+	backup, err := reservePublishBackup(parent)
+	if err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	currentDestinationInfo, err := os.Lstat(destination)
+	if err != nil {
+		return err
+	}
+	if currentDestinationInfo.Mode()&os.ModeSymlink != 0 || !currentDestinationInfo.IsDir() || !os.SameFile(originalDestinationInfo, currentDestinationInfo) {
+		return errors.New("bundle destination changed during publish")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := os.Rename(destination, backup); err != nil {
+		return err
+	}
+	rollback := func(commitErr error) error {
+		if err := os.Rename(backup, destination); err != nil {
+			return fmt.Errorf("%w; restore original output: %v", commitErr, err)
+		}
+		return commitErr
+	}
+	if err := runPublishFault(fault, "replace", destination); err != nil {
+		return rollback(err)
+	}
+	if err := os.Rename(stage, destination); err != nil {
+		return rollback(err)
+	}
+	stagePending = false
+	publishCommitted = true
+	// The destination swap is the commit point. Old-output cleanup is
+	// best-effort: returning an error now would falsely report an uncommitted
+	// publish even though the new directory is already visible.
+	cleanupErr := runPublishFault(fault, "cleanup", backup)
+	if cleanupErr == nil {
+		cleanupErr = removePublishBackup(backup)
+	}
+	if cleanupErr != nil && warningSink != nil {
+		warningSink(publishCleanupWarning)
+	}
+	return nil
+}
+
+func ensureSafePublishParent(ctx context.Context, parent string) ([]string, error) {
+	var missing []string
+	for current := parent; ; current = filepath.Dir(current) {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		info, err := os.Lstat(current)
+		switch {
+		case err == nil:
+			if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+				return nil, errors.New("bundle destination path must not cross a link or non-directory")
+			}
+		case os.IsNotExist(err):
+			missing = append(missing, current)
+		default:
+			return nil, err
+		}
+		if filepath.Dir(current) == current {
+			break
+		}
+	}
+	created := make([]string, 0, len(missing))
+	for index := len(missing) - 1; index >= 0; index-- {
+		if err := ctx.Err(); err != nil {
+			removeCreatedPublishParents(created)
+			return nil, err
+		}
+		if err := os.Mkdir(missing[index], 0o755); err == nil {
+			created = append(created, missing[index])
+			continue
+		} else if !os.IsExist(err) {
+			removeCreatedPublishParents(created)
+			return nil, err
+		}
+		info, err := os.Lstat(missing[index])
+		if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			removeCreatedPublishParents(created)
+			return nil, errors.New("bundle destination path changed during creation")
+		}
+	}
+	return created, nil
+}
+
+func removeCreatedPublishParents(created []string) {
+	for index := len(created) - 1; index >= 0; index-- {
+		_ = os.Remove(created[index])
+	}
+}
+
+func validateManagedOutput(ctx context.Context, destination string, platforms []string) error {
+	expected := make(map[string]struct{}, len(platforms))
+	for _, platform := range platforms {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		goos, goarch, err := splitPlatform(platform)
+		if err != nil {
+			return errors.New("managed bundle output has an invalid platform set")
+		}
+		expected[bundleName(goos, goarch)] = struct{}{}
+	}
+	entries, err := os.ReadDir(destination)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if _, ok := expected[entry.Name()]; !ok {
+			return errors.New("managed bundle output contains an unexpected entry")
+		}
+		info, err := os.Lstat(filepath.Join(destination, entry.Name()))
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return errors.New("managed bundle output contains a non-regular entry")
+		}
+	}
+	return nil
+}
+
+func copyRegularFile(ctx context.Context, source, destination string, mode os.FileMode, chunkHook func()) (resultErr error) {
+	info, err := os.Lstat(source)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return errors.New("publish source must be a regular file")
+	}
+	if existing, statErr := os.Lstat(destination); statErr == nil && !existing.Mode().IsRegular() {
+		return errors.New("publish destination must be a regular file")
+	} else if statErr != nil && !os.IsNotExist(statErr) {
+		return statErr
+	}
+	in, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := out.Close(); resultErr == nil {
+			resultErr = closeErr
+		}
+	}()
+	if _, err := copyWithContext(ctx, out, in, chunkHook); err != nil {
+		return err
+	}
+	if err := out.Sync(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func reservePublishBackup(parent string) (string, error) {
+	path, err := os.MkdirTemp(parent, ".mihari-aio-backup-")
+	if err != nil {
+		return "", err
+	}
+	if err := os.Remove(path); err != nil {
+		_ = os.RemoveAll(path)
+		return "", err
+	}
+	return path, nil
+}
+
+func removePublishBackup(path string) error {
+	_ = filepath.WalkDir(path, func(current string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if entry.IsDir() {
+			_ = os.Chmod(current, 0o700)
+		} else {
+			_ = os.Chmod(current, 0o600)
+		}
+		return nil
+	})
+	return os.RemoveAll(path)
+}
+
+func runPublishFault(fault func(operation, path string) error, operation, path string) error {
+	if fault == nil {
+		return nil
+	}
+	return fault(operation, path)
+}
+
+func tarStage(ctx context.Context, stage, dest string, chunkHook func()) (err error) {
 	out, err := os.Create(dest)
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if err != nil {
+			_ = os.Remove(dest)
+		}
+	}()
 	defer out.Close()
 	gzipWriter := gzip.NewWriter(out)
+	gzipWriter.ModTime = time.Unix(0, 0).UTC()
+	gzipWriter.OS = 255
 	defer func() {
 		if cerr := gzipWriter.Close(); err == nil {
 			err = cerr
@@ -446,6 +884,9 @@ func tarStage(stage, dest string) (err error) {
 		}
 	}()
 	return filepath.Walk(stage, func(path string, info os.FileInfo, walkErr error) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if walkErr != nil {
 			return walkErr
 		}
@@ -456,7 +897,15 @@ func tarStage(stage, dest string) (err error) {
 		if err != nil {
 			return err
 		}
-		header := &tar.Header{Name: filepath.ToSlash(rel), Mode: int64(info.Mode().Perm()), Size: info.Size(), Format: tar.FormatGNU}
+		archiveName := filepath.ToSlash(rel)
+		mode, err := canonicalBundleMode(archiveName)
+		if err != nil {
+			return err
+		}
+		header := &tar.Header{
+			Name: archiveName, Mode: int64(mode), Size: info.Size(),
+			Typeflag: tar.TypeReg, ModTime: time.Unix(0, 0).UTC(), Format: tar.FormatGNU,
+		}
 		if err := tarWriter.WriteHeader(header); err != nil {
 			return err
 		}
@@ -464,17 +913,22 @@ func tarStage(stage, dest string) (err error) {
 		if err != nil {
 			return err
 		}
-		_, err = io.Copy(tarWriter, file)
+		_, err = copyWithContext(ctx, tarWriter, file, chunkHook)
 		file.Close()
 		return err
 	})
 }
 
-func zipStage(stage, dest string) (err error) {
+func zipStage(ctx context.Context, stage, dest string, chunkHook func()) (err error) {
 	out, err := os.Create(dest)
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if err != nil {
+			_ = os.Remove(dest)
+		}
+	}()
 	defer out.Close()
 	zipWriter := zip.NewWriter(out)
 	defer func() {
@@ -483,6 +937,9 @@ func zipStage(stage, dest string) (err error) {
 		}
 	}()
 	return filepath.Walk(stage, func(path string, info os.FileInfo, walkErr error) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if walkErr != nil {
 			return walkErr
 		}
@@ -493,7 +950,15 @@ func zipStage(stage, dest string) (err error) {
 		if err != nil {
 			return err
 		}
-		entry, err := zipWriter.Create(filepath.ToSlash(rel))
+		archiveName := filepath.ToSlash(rel)
+		mode, err := canonicalBundleMode(archiveName)
+		if err != nil {
+			return err
+		}
+		header := &zip.FileHeader{Name: archiveName, Method: zip.Deflate}
+		header.SetMode(mode)
+		header.Modified = time.Date(1980, time.January, 1, 0, 0, 0, 0, time.UTC)
+		entry, err := zipWriter.CreateHeader(header)
 		if err != nil {
 			return err
 		}
@@ -501,13 +966,24 @@ func zipStage(stage, dest string) (err error) {
 		if err != nil {
 			return err
 		}
-		_, err = io.Copy(entry, file)
+		_, err = copyWithContext(ctx, entry, file, chunkHook)
 		file.Close()
 		return err
 	})
 }
 
-func copyFile(source, dest string) error {
+func canonicalBundleMode(path string) (os.FileMode, error) {
+	switch path {
+	case "mihari", "mihari.exe", "data/bin/mihomo", "data/bin/mihomo.exe", "install-aio.sh":
+		return 0o755, nil
+	case "install-aio.ps1", "data/bin/core-channel", "data/geoip/GeoLite2-Country.mmdb", "data/geoip/GeoLite2-ASN.mmdb":
+		return 0o644, nil
+	default:
+		return 0, errors.New("bundle stage contains an entry without a canonical archive mode")
+	}
+}
+
+func copyFile(ctx context.Context, source, dest string, chunkHook func()) error {
 	if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
 		return err
 	}
@@ -520,16 +996,55 @@ func copyFile(source, dest string) error {
 	if err != nil {
 		return err
 	}
-	_, err = io.Copy(out, in)
+	_, err = copyWithContext(ctx, out, in, chunkHook)
+	if err == nil {
+		err = out.Sync()
+	}
 	if closeErr := out.Close(); err == nil {
 		err = closeErr
 	}
 	return err
 }
 
-func relativeFiles(root string) ([]string, error) {
+func copyWithContext(ctx context.Context, destination io.Writer, source io.Reader, chunkHook func()) (int64, error) {
+	buffer := make([]byte, 64<<10)
+	var written int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return written, err
+		}
+		read, readErr := source.Read(buffer)
+		if read > 0 {
+			count, writeErr := destination.Write(buffer[:read])
+			written += int64(count)
+			if writeErr != nil {
+				return written, writeErr
+			}
+			if count != read {
+				return written, io.ErrShortWrite
+			}
+			if chunkHook != nil {
+				chunkHook()
+			}
+			if err := ctx.Err(); err != nil {
+				return written, err
+			}
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				return written, nil
+			}
+			return written, readErr
+		}
+	}
+}
+
+func relativeFiles(ctx context.Context, root string) ([]string, error) {
 	var files []string
 	err := filepath.Walk(root, func(path string, info os.FileInfo, walkErr error) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if walkErr != nil {
 			return walkErr
 		}
@@ -572,25 +1087,24 @@ func splitPlatforms(csv string) []string {
 	return platforms
 }
 
-func newClient(token string) *http.Client {
-	if token == "" {
-		return &http.Client{Timeout: 15 * time.Minute}
-	}
-	base, ok := http.DefaultTransport.(*http.Transport)
-	if !ok || base == nil {
-		return &http.Client{Timeout: 15 * time.Minute}
-	}
-	transport := base.Clone()
-	return &http.Client{Timeout: 15 * time.Minute, Transport: &bearerTransport{base: transport, token: token}}
+func newClient() *http.Client {
+	return &http.Client{Timeout: 15 * time.Minute}
 }
 
-type bearerTransport struct {
-	base  http.RoundTripper
-	token string
-}
-
-func (t *bearerTransport) RoundTrip(request *http.Request) (*http.Response, error) {
-	cloned := request.Clone(request.Context())
-	cloned.Header.Set("Authorization", "Bearer "+t.token)
-	return t.base.RoundTrip(cloned)
+func secureRedirectClient(base *http.Client) *http.Client {
+	client := *base
+	previous := client.CheckRedirect
+	client.CheckRedirect = func(request *http.Request, via []*http.Request) error {
+		if request.URL.Scheme != "https" || request.URL.User != nil {
+			return errors.New("release input redirect must use HTTPS without credentials")
+		}
+		if previous != nil {
+			return previous(request, via)
+		}
+		if len(via) >= 10 {
+			return errors.New("release input redirect limit exceeded")
+		}
+		return nil
+	}
+	return &client
 }

--- a/scripts/build-all-in-one/main_test.go
+++ b/scripts/build-all-in-one/main_test.go
@@ -8,18 +8,19 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 
-	"github.com/mihari-proxy/mihari/internal/core"
+	"github.com/mihari-proxy/mihari/scripts/internal/releaseinputs"
 )
 
 // fakeRunner satisfies core.CommandRunner for the host-matching `-v` smoke.
@@ -42,29 +43,9 @@ func (r *recordingRunner) Run(_ context.Context, _ string, _ ...string) ([]byte,
 }
 
 func TestBundlerProducesSixPlatformBundles(t *testing.T) {
-	api := fakeGitHubAPI(t)
-	defer api.Close()
-	geoipSrv := fakeGeoIPServer(t)
-	defer geoipSrv.Close()
-
-	mihariDir := t.TempDir()
-	writeMihariDist(t, mihariDir)
-
-	scriptsDir := t.TempDir()
-	for _, name := range []string{"install-aio.sh", "install-aio.ps1"} {
-		if err := os.WriteFile(filepath.Join(scriptsDir, name), []byte("# aio installer\n"), 0o600); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	out := t.TempDir()
-	err := run(options{
-		MihariDir: mihariDir, Out: out, ScriptsDir: scriptsDir,
-		Platforms:  []string{"linux/amd64", "linux/arm64", "darwin/amd64", "darwin/arm64", "windows/amd64", "windows/arm64"},
-		HTTPClient: api.Client(), APIBase: api.URL, Repository: "MetaCubeX/mihomo",
-		GeoIPBase: geoipSrv.URL, GeoIPValidate: func(string) error { return nil },
-		Runner: fakeRunner{output: []byte("Mihomo Meta v1.19.0")},
-	})
+	fixture := newLockedFixture(t, "stable")
+	out := filepath.Join(t.TempDir(), "bundles")
+	err := run(fixture.options(out))
 	if err != nil {
 		t.Fatalf("run: %v", err)
 	}
@@ -109,35 +90,15 @@ func TestBundlerProducesSixPlatformBundles(t *testing.T) {
 		if mihomo := entries["data/bin/mihomo"+suffix]; len(mihomo) == 0 {
 			t.Fatalf("%s: empty mihomo binary", platform)
 		}
-		assertCoreChannelSidecar(t, entries, "stable", "stable-v1.19.0")
+		assertCoreChannelSidecar(t, entries, "stable", "stable-v1.19.30")
 	}
+	fixture.assertOnlyLockedRequests(t)
 }
 
 func TestBundlerAlphaChannelWritesSidecar(t *testing.T) {
-	api := fakeGitHubAlphaAPI(t)
-	defer api.Close()
-	geoipSrv := fakeGeoIPServer(t)
-	defer geoipSrv.Close()
-
-	mihariDir := t.TempDir()
-	writeMihariDist(t, mihariDir)
-
-	scriptsDir := t.TempDir()
-	for _, name := range []string{"install-aio.sh", "install-aio.ps1"} {
-		if err := os.WriteFile(filepath.Join(scriptsDir, name), []byte("# aio installer\n"), 0o600); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	out := t.TempDir()
-	err := run(options{
-		MihariDir: mihariDir, Out: out, ScriptsDir: scriptsDir,
-		Channel:    "alpha",
-		Platforms:  []string{"linux/amd64", "linux/arm64", "darwin/amd64", "darwin/arm64", "windows/amd64", "windows/arm64"},
-		HTTPClient: api.Client(), APIBase: api.URL, Repository: "MetaCubeX/mihomo",
-		GeoIPBase: geoipSrv.URL, GeoIPValidate: func(string) error { return nil },
-		Runner: fakeRunner{output: []byte("Mihomo Meta alpha-e183c58")},
-	})
+	fixture := newLockedFixture(t, "alpha")
+	out := filepath.Join(t.TempDir(), "bundles")
+	err := run(fixture.options(out))
 	if err != nil {
 		t.Fatalf("run: %v", err)
 	}
@@ -157,6 +118,577 @@ func TestBundlerAlphaChannelWritesSidecar(t *testing.T) {
 			t.Fatalf("%s: missing data/bin/core-channel", platform)
 		}
 	}
+	fixture.assertOnlyLockedRequests(t)
+}
+
+func TestRunRequiresValidLockBeforeNetworkOrOutputMutation(t *testing.T) {
+	tests := []struct {
+		name     string
+		lockPath func(*testing.T) string
+	}{
+		{name: "missing flag", lockPath: func(*testing.T) string { return "" }},
+		{name: "missing file", lockPath: func(t *testing.T) string { return filepath.Join(t.TempDir(), "missing.json") }},
+		{name: "invalid file", lockPath: func(t *testing.T) string {
+			path := filepath.Join(t.TempDir(), "invalid.json")
+			if err := os.WriteFile(path, []byte(`{"schema":"wrong"}`), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			return path
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			transport := &fixtureTransport{payloads: map[string][]byte{}}
+			out := filepath.Join(t.TempDir(), "must-not-exist")
+			err := run(options{LockPath: test.lockPath(t), Out: out, HTTPClient: &http.Client{Transport: transport}})
+			if err == nil {
+				t.Fatal("run accepted a missing or invalid release input lock")
+			}
+			if transport.requestCount() != 0 {
+				t.Fatalf("network requests = %d, want 0", transport.requestCount())
+			}
+			if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+				t.Fatalf("output path was mutated before lock validation: %v", statErr)
+			}
+		})
+	}
+}
+
+func TestRunRejectsPlatformOutsideLockBeforeNetwork(t *testing.T) {
+	fixture := newLockedFixture(t, "stable")
+	out := filepath.Join(t.TempDir(), "must-not-exist")
+	opts := fixture.options(out)
+	opts.Platforms = []string{"linux/riscv64"}
+	if err := run(opts); err == nil {
+		t.Fatal("run accepted a platform outside the exact lock set")
+	}
+	if fixture.transport.requestCount() != 0 {
+		t.Fatalf("network requests = %d, want 0", fixture.transport.requestCount())
+	}
+	if _, err := os.Stat(out); !os.IsNotExist(err) {
+		t.Fatalf("output path was mutated before platform validation: %v", err)
+	}
+}
+
+func TestRunRejectsOutputPathOverlapBeforeNetwork(t *testing.T) {
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name string
+		out  func(*lockedFixture) string
+	}{
+		{name: "working directory", out: func(*lockedFixture) string { return "." }},
+		{name: "working directory ancestor", out: func(*lockedFixture) string { return filepath.Dir(workingDirectory) }},
+		{name: "equals lock", out: func(f *lockedFixture) string { return f.lockPath }},
+		{name: "contains lock", out: func(f *lockedFixture) string { return filepath.Dir(f.lockPath) }},
+		{name: "equals mihari input", out: func(f *lockedFixture) string { return f.mihariDir }},
+		{name: "contains mihari input", out: func(f *lockedFixture) string { return filepath.Dir(f.mihariDir) }},
+		{name: "inside mihari input", out: func(f *lockedFixture) string { return filepath.Join(f.mihariDir, "nested-output") }},
+		{name: "contains scripts input", out: func(f *lockedFixture) string { return filepath.Dir(f.scriptsDir) }},
+		{name: "inside scripts input", out: func(f *lockedFixture) string { return filepath.Join(f.scriptsDir, "nested-output") }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newLockedFixture(t, "stable")
+			out := test.out(fixture)
+			opts := fixture.options(out)
+			err := run(opts)
+			if err == nil || !strings.Contains(err.Error(), "dedicated managed bundle directory") {
+				t.Fatalf("run overlap error = %v, want fixed isolation error", err)
+			}
+			if fixture.transport.requestCount() != 0 {
+				t.Fatalf("network requests = %d, want 0", fixture.transport.requestCount())
+			}
+			for _, sensitive := range []string{out, fixture.lockPath, fixture.mihariDir, fixture.scriptsDir} {
+				if filepath.IsAbs(sensitive) && strings.Contains(err.Error(), sensitive) {
+					t.Fatalf("isolation error %q leaked absolute path %q", err, sensitive)
+				}
+			}
+		})
+	}
+}
+
+func TestRunRejectsLockedPayloadMismatchWithoutBundle(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*lockedFixture)
+	}{
+		{name: "mihomo size", mutate: func(f *lockedFixture) {
+			asset := f.lock.Mihomo.Assets["windows/arm64"]
+			asset.Size++
+			f.lock.Mihomo.Assets["windows/arm64"] = asset
+		}},
+		{name: "mihomo digest", mutate: func(f *lockedFixture) {
+			asset := f.lock.Mihomo.Assets["windows/arm64"]
+			asset.SHA256 = strings.Repeat("0", 64)
+			f.lock.Mihomo.Assets["windows/arm64"] = asset
+		}},
+		{name: "geoip digest", mutate: func(f *lockedFixture) {
+			f.lock.GeoIP.Country.SHA256 = strings.Repeat("0", 64)
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newLockedFixture(t, "stable")
+			test.mutate(fixture)
+			fixture.writeLock(t)
+			out := filepath.Join(t.TempDir(), "bundles")
+			err := run(fixture.options(out))
+			if err == nil {
+				t.Fatal("run accepted payload that disagrees with the lock")
+			}
+			entries, readErr := os.ReadDir(out)
+			if readErr != nil && !os.IsNotExist(readErr) {
+				t.Fatal(readErr)
+			}
+			if len(entries) != 0 {
+				t.Fatalf("failed build left outputs: %v", entries)
+			}
+		})
+	}
+}
+
+func TestRunProducesByteIdenticalBundlesFromSameLock(t *testing.T) {
+	fixture := newLockedFixture(t, "stable")
+	first := filepath.Join(t.TempDir(), "first")
+	second := filepath.Join(t.TempDir(), "second")
+	if err := run(fixture.options(first)); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	if err := run(fixture.options(second)); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	for _, platform := range releaseinputs.RequiredPlatforms() {
+		goos, goarch, err := splitPlatform(platform)
+		if err != nil {
+			t.Fatal(err)
+		}
+		name := bundleName(goos, goarch)
+		firstBytes, err := os.ReadFile(filepath.Join(first, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		secondBytes, err := os.ReadFile(filepath.Join(second, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(firstBytes, secondBytes) {
+			t.Fatalf("%s differs across identical builds", name)
+		}
+	}
+}
+
+func TestPackStageUsesCanonicalModesIndependentOfHostPermissions(t *testing.T) {
+	for _, goos := range []string{"linux", "windows"} {
+		t.Run(goos, func(t *testing.T) {
+			firstStage := t.TempDir()
+			secondStage := t.TempDir()
+			writeCanonicalArchiveStage(t, firstStage, goos, 0o444)
+			writeCanonicalArchiveStage(t, secondStage, goos, 0o777)
+			firstOut := t.TempDir()
+			secondOut := t.TempDir()
+			if err := packStage(context.Background(), firstStage, firstOut, goos, "amd64", nil); err != nil {
+				t.Fatalf("pack first stage: %v", err)
+			}
+			if err := packStage(context.Background(), secondStage, secondOut, goos, "amd64", nil); err != nil {
+				t.Fatalf("pack second stage: %v", err)
+			}
+			name := bundleName(goos, "amd64")
+			firstBytes, err := os.ReadFile(filepath.Join(firstOut, name))
+			if err != nil {
+				t.Fatal(err)
+			}
+			secondBytes, err := os.ReadFile(filepath.Join(secondOut, name))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(firstBytes, secondBytes) {
+				t.Fatalf("%s archive bytes depend on host file permissions", goos)
+			}
+			modes := archiveEntryModes(t, filepath.Join(firstOut, name))
+			want := canonicalArchiveModes(goos)
+			if !reflect.DeepEqual(modes, want) {
+				t.Fatalf("%s archive modes = %v, want %v", goos, modes, want)
+			}
+		})
+	}
+}
+
+func TestPackStageHonorsCancellationBetweenChunks(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		goos string
+	}{
+		{name: "tar gzip", goos: "linux"},
+		{name: "zip", goos: "windows"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			stage := t.TempDir()
+			name := "mihari"
+			if test.goos == "windows" {
+				name = "mihari.exe"
+			}
+			if err := os.WriteFile(filepath.Join(stage, name), bytes.Repeat([]byte("x"), 256<<10), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			chunks := 0
+			hook := func() {
+				chunks++
+				if chunks == 1 {
+					cancel()
+				}
+			}
+			out := t.TempDir()
+			err := packStage(ctx, stage, out, test.goos, "amd64", hook)
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("packStage error = %v, want context cancellation", err)
+			}
+			if chunks == 0 {
+				t.Fatal("copy hook was not reached")
+			}
+			if _, err := os.Lstat(filepath.Join(out, bundleName(test.goos, "amd64"))); !os.IsNotExist(err) {
+				t.Fatalf("partial archive remains after cancellation: %v", err)
+			}
+		})
+	}
+}
+
+func TestRunCancellationDuringLocalCopyPreservesManagedOutput(t *testing.T) {
+	fixture := newLockedFixture(t, "stable")
+	largeMihari := filepath.Join(fixture.mihariDir, "mihari-"+runtime.GOOS+"-"+runtime.GOARCH)
+	if runtime.GOOS == "windows" {
+		largeMihari += ".exe"
+	}
+	if err := os.WriteFile(largeMihari, bytes.Repeat([]byte("m"), 256<<10), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	parent := t.TempDir()
+	destination := filepath.Join(parent, "bundles")
+	writeExistingOutput(t, destination)
+	before := snapshotTree(t, destination)
+	ctx, cancel := context.WithCancel(context.Background())
+	opts := fixture.options(destination)
+	opts.Context = ctx
+	opts.CopyChunkHook = cancel
+	err := run(opts)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("run error = %v, want context cancellation", err)
+	}
+	after := snapshotTree(t, destination)
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("managed output changed after local-copy cancellation\nbefore=%v\nafter=%v", before, after)
+	}
+	assertNoPublishResidue(t, parent)
+}
+
+func TestPublishBundlesCancellationDuringStagingPreservesManagedOutput(t *testing.T) {
+	parent := t.TempDir()
+	source := writePublishSource(t, parent)
+	name := bundleName("linux", "amd64")
+	if err := os.WriteFile(filepath.Join(source, name), bytes.Repeat([]byte("b"), 256<<10), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	destination := filepath.Join(parent, "bundles")
+	writeExistingOutput(t, destination)
+	before := snapshotTree(t, destination)
+	ctx, cancel := context.WithCancel(context.Background())
+	err := publishBundles(ctx, source, destination, releaseinputs.RequiredPlatforms(), nil, nil, cancel)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("publishBundles error = %v, want context cancellation", err)
+	}
+	after := snapshotTree(t, destination)
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("managed output changed after staging cancellation\nbefore=%v\nafter=%v", before, after)
+	}
+	assertNoPublishResidue(t, parent)
+}
+
+func TestPublishBundlesFinishesCommitAfterCancellation(t *testing.T) {
+	parent := t.TempDir()
+	source := writePublishSource(t, parent)
+	destination := filepath.Join(parent, "bundles")
+	writeExistingOutput(t, destination)
+	ctx, cancel := context.WithCancel(context.Background())
+	fault := func(operation, _ string) error {
+		if operation == "replace" {
+			cancel()
+		}
+		return nil
+	}
+	if err := publishBundles(ctx, source, destination, releaseinputs.RequiredPlatforms(), fault, nil, nil); err != nil {
+		t.Fatalf("publishBundles interrupted an active commit: %v", err)
+	}
+	name := bundleName("windows", "arm64")
+	got, err := os.ReadFile(filepath.Join(destination, name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new-"+name {
+		t.Fatalf("active bundle = %q, want committed bundle", got)
+	}
+	assertNoPublishResidue(t, parent)
+}
+
+func TestPublishBundlesFailureIsAllOrNothing(t *testing.T) {
+	tests := []struct {
+		name      string
+		operation string
+	}{
+		{name: "copy failure", operation: "copy"},
+		{name: "chmod failure", operation: "chmod"},
+		{name: "replace failure", operation: "replace"},
+	}
+	for _, test := range tests {
+		t.Run(test.name+" preserves existing output", func(t *testing.T) {
+			parent := t.TempDir()
+			source := writePublishSource(t, parent)
+			destination := filepath.Join(parent, "bundles")
+			writeExistingOutput(t, destination)
+			before := snapshotTree(t, destination)
+			fault := func(operation, path string) error {
+				if operation == test.operation && (operation == "replace" || filepath.Base(path) == bundleName("windows", "arm64")) {
+					return errors.New("injected " + operation + " failure")
+				}
+				return nil
+			}
+			if err := publishBundles(context.Background(), source, destination, releaseinputs.RequiredPlatforms(), fault, nil, nil); err == nil {
+				t.Fatalf("publishBundles accepted injected %s failure", test.operation)
+			}
+			after := snapshotTree(t, destination)
+			if !reflect.DeepEqual(after, before) {
+				t.Fatalf("existing output changed after %s failure\nbefore=%v\nafter=%v", test.operation, before, after)
+			}
+			assertNoPublishResidue(t, parent)
+		})
+
+		t.Run(test.name+" leaves absent output absent", func(t *testing.T) {
+			parent := t.TempDir()
+			source := writePublishSource(t, parent)
+			createdParent := filepath.Join(parent, "new-parent")
+			destination := filepath.Join(createdParent, "bundles")
+			fault := func(operation, path string) error {
+				if operation == test.operation && (operation == "replace" || filepath.Base(path) == bundleName("windows", "arm64")) {
+					return errors.New("injected " + operation + " failure")
+				}
+				return nil
+			}
+			if err := publishBundles(context.Background(), source, destination, releaseinputs.RequiredPlatforms(), fault, nil, nil); err == nil {
+				t.Fatalf("publishBundles accepted injected %s failure", test.operation)
+			}
+			if _, err := os.Lstat(destination); !os.IsNotExist(err) {
+				t.Fatalf("destination exists after %s failure: %v", test.operation, err)
+			}
+			if _, err := os.Lstat(createdParent); !os.IsNotExist(err) {
+				t.Fatalf("new parent exists after %s failure: %v", test.operation, err)
+			}
+			assertNoPublishResidue(t, parent)
+		})
+	}
+}
+
+func TestPublishBundlesRejectsUnmanagedEntriesWithoutMutation(t *testing.T) {
+	parent := t.TempDir()
+	source := writePublishSource(t, parent)
+	destination := filepath.Join(parent, "bundles")
+	writeExistingOutput(t, destination)
+	if err := os.Mkdir(filepath.Join(destination, "notes"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(destination, "notes", "keep.txt"), []byte("unmanaged"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before := snapshotTree(t, destination)
+	if err := publishBundles(context.Background(), source, destination, releaseinputs.RequiredPlatforms(), nil, nil, nil); err == nil {
+		t.Fatal("publishBundles accepted an unmanaged output entry")
+	}
+	after := snapshotTree(t, destination)
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("managed output changed after rejecting unrelated entry\nbefore=%v\nafter=%v", before, after)
+	}
+	assertNoPublishResidue(t, parent)
+}
+
+func TestPublishBundlesRejectsUnsafeExistingOutput(t *testing.T) {
+	parent := t.TempDir()
+	source := writePublishSource(t, parent)
+	destination := filepath.Join(parent, "bundles")
+	if err := os.MkdirAll(destination, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(parent, "outside.txt")
+	if err := os.WriteFile(target, []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(destination, "unsafe-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+	before := snapshotTreeLstat(t, destination)
+	if err := publishBundles(context.Background(), source, destination, releaseinputs.RequiredPlatforms(), nil, nil, nil); err == nil {
+		t.Fatal("publishBundles accepted an existing symlink")
+	}
+	after := snapshotTreeLstat(t, destination)
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("unsafe output changed\nbefore=%v\nafter=%v", before, after)
+	}
+	assertNoPublishResidue(t, parent)
+}
+
+func TestPublishBundlesRejectsNonDirectoryDestination(t *testing.T) {
+	parent := t.TempDir()
+	source := writePublishSource(t, parent)
+	destination := filepath.Join(parent, "bundles")
+	if err := os.WriteFile(destination, []byte("do not replace"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := publishBundles(context.Background(), source, destination, releaseinputs.RequiredPlatforms(), nil, nil, nil); err == nil {
+		t.Fatal("publishBundles accepted a non-directory destination")
+	}
+	after, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatalf("non-directory destination changed: got %q want %q", after, before)
+	}
+	assertNoPublishResidue(t, parent)
+}
+
+func TestPublishBundlesRejectsSymlinkedParent(t *testing.T) {
+	parent := t.TempDir()
+	source := writePublishSource(t, parent)
+	realParent := filepath.Join(parent, "real-parent")
+	if err := os.Mkdir(realParent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	linkedParent := filepath.Join(parent, "linked-parent")
+	if err := os.Symlink(realParent, linkedParent); err != nil {
+		t.Skipf("directory symlink creation is unavailable: %v", err)
+	}
+	if err := publishBundles(context.Background(), source, filepath.Join(linkedParent, "bundles"), releaseinputs.RequiredPlatforms(), nil, nil, nil); err == nil {
+		t.Fatal("publishBundles crossed a symlinked destination parent")
+	}
+	if _, err := os.Lstat(filepath.Join(realParent, "bundles")); !os.IsNotExist(err) {
+		t.Fatalf("publish crossed parent link and created output: %v", err)
+	}
+	assertNoPublishResidue(t, parent)
+}
+
+func TestRunCleanupFailureWarnsAfterSuccessfulCommit(t *testing.T) {
+	fixture := newLockedFixture(t, "stable")
+	parent := t.TempDir()
+	destination := filepath.Join(parent, "bundles")
+	writeExistingOutput(t, destination)
+	var warnings bytes.Buffer
+	opts := fixture.options(destination)
+	opts.PublishFault = func(operation, _ string) error {
+		if operation == "cleanup" {
+			return errors.New("injected cleanup failure at " + destination)
+		}
+		return nil
+	}
+	opts.WarningSink = func(message string) {
+		warnings.WriteString(message)
+		warnings.WriteByte('\n')
+	}
+	if err := run(opts); err != nil {
+		t.Fatalf("run returned an error after commit: %v", err)
+	}
+	entries := extractBundle(t, filepath.Join(destination, bundleName("linux", "amd64")))
+	if len(entries) == 0 {
+		t.Fatal("new bundle directory is not active after cleanup failure")
+	}
+	warningLines := strings.Split(strings.TrimSpace(warnings.String()), "\n")
+	if len(warningLines) != 1 {
+		t.Fatalf("warnings = %q, want exactly one cleanup warning", warnings.String())
+	}
+	const wantWarning = "old bundle backup cleanup failed; manual cleanup may be required"
+	if warningLines[0] != wantWarning {
+		t.Fatalf("warning = %q, want fixed %q", warningLines[0], wantWarning)
+	}
+	for _, sensitive := range []string{destination, parent, filepath.Base(destination), "injected cleanup failure"} {
+		if strings.Contains(warningLines[0], sensitive) {
+			t.Fatalf("warning %q leaked path component %q", warningLines[0], sensitive)
+		}
+	}
+	backupCount := 0
+	parentEntries, err := os.ReadDir(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range parentEntries {
+		if strings.HasPrefix(entry.Name(), ".mihari-aio-backup-") {
+			backupCount++
+		}
+	}
+	if backupCount != 1 {
+		t.Fatalf("backup count = %d, want one retained backup after injected cleanup failure", backupCount)
+	}
+}
+
+func TestPublishBundlesCleanupFailureAllowsNoOpWarningSink(t *testing.T) {
+	parent := t.TempDir()
+	source := writePublishSource(t, parent)
+	destination := filepath.Join(parent, "bundles")
+	writeExistingOutput(t, destination)
+	fault := func(operation, _ string) error {
+		if operation == "cleanup" {
+			return errors.New("injected cleanup failure")
+		}
+		return nil
+	}
+	if err := publishBundles(context.Background(), source, destination, releaseinputs.RequiredPlatforms(), fault, nil, nil); err != nil {
+		t.Fatalf("publishBundles with no-op warning sink: %v", err)
+	}
+	name := bundleName("windows", "arm64")
+	got, err := os.ReadFile(filepath.Join(destination, name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new-"+name {
+		t.Fatalf("active bundle = %q, want committed bundle", got)
+	}
+}
+
+func TestRunHonorsContextAndRejectsInsecureRedirects(t *testing.T) {
+	t.Run("canceled context", func(t *testing.T) {
+		fixture := newLockedFixture(t, "stable")
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		opts := fixture.options(filepath.Join(t.TempDir(), "out"))
+		opts.Context = ctx
+		if err := run(opts); err == nil {
+			t.Fatal("run accepted a canceled context")
+		}
+	})
+
+	t.Run("non-200 status", func(t *testing.T) {
+		fixture := newLockedFixture(t, "stable")
+		asset := fixture.lock.Mihomo.Assets["linux/amd64"]
+		fixture.transport.statuses[asset.URL] = http.StatusServiceUnavailable
+		if err := run(fixture.options(filepath.Join(t.TempDir(), "out"))); err == nil {
+			t.Fatal("run accepted a non-200 locked download")
+		}
+	})
+
+	t.Run("HTTPS downgrade redirect", func(t *testing.T) {
+		fixture := newLockedFixture(t, "stable")
+		asset := fixture.lock.Mihomo.Assets["linux/amd64"]
+		fixture.transport.redirects[asset.URL] = "http://example.invalid/core.gz"
+		if err := run(fixture.options(filepath.Join(t.TempDir(), "out"))); err == nil {
+			t.Fatal("run followed an HTTPS downgrade redirect")
+		}
+		if fixture.transport.requestsByURL()["http://example.invalid/core.gz"] != 0 {
+			t.Fatal("insecure redirect target was requested")
+		}
+	})
 }
 
 func TestSidecarScriptInstallersCopyCoreChannel(t *testing.T) {
@@ -265,106 +797,371 @@ func TestAssertStageEnforcesWhitelist(t *testing.T) {
 	}
 }
 
-func fakeGitHubAlphaAPI(t *testing.T) *httptest.Server {
-	t.Helper()
-	// Standard names first; variants must exist so a stable-style scorer
-	// that prefers -compatible / would accept -v3 is observable as a miss.
-	names := []string{
-		"mihomo-linux-amd64-compatible-alpha-e183c58.gz",
-		"mihomo-linux-amd64-v3-alpha-e183c58.gz",
-		"mihomo-linux-amd64-alpha-e183c58.gz",
-		"mihomo-linux-arm64-alpha-e183c58.gz",
-		"mihomo-darwin-amd64-compatible-alpha-e183c58.gz",
-		"mihomo-darwin-amd64-v3-alpha-e183c58.gz",
-		"mihomo-darwin-amd64-alpha-e183c58.gz",
-		"mihomo-darwin-arm64-alpha-e183c58.gz",
-		"mihomo-windows-amd64-compatible-alpha-e183c58.zip",
-		"mihomo-windows-amd64-v3-alpha-e183c58.zip",
-		"mihomo-windows-amd64-alpha-e183c58.zip",
-		"mihomo-windows-arm64-alpha-e183c58.zip",
-	}
-	archives := make(map[string][]byte, len(names))
-	for _, name := range names {
-		archives[name] = fakeMihomoArchive(t, name)
-	}
-	var server *httptest.Server
-	server = httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
-		switch {
-		case request.URL.Path == "/repos/MetaCubeX/mihomo/releases/tags/Prerelease-Alpha":
-			assets := make([]core.Asset, 0, len(names))
-			for _, name := range names {
-				data := archives[name]
-				sum := sha256.Sum256(data)
-				assets = append(assets, core.Asset{
-					Name: name, URL: server.URL + "/asset/" + name,
-					Size: int64(len(data)), Digest: "sha256:" + hex.EncodeToString(sum[:]),
-				})
-			}
-			response.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(response).Encode(core.Release{TagName: "Prerelease-Alpha", Assets: assets})
-		case strings.HasPrefix(request.URL.Path, "/asset/"):
-			_, _ = response.Write(archives[strings.TrimPrefix(request.URL.Path, "/asset/")])
-		default:
-			http.NotFound(response, request)
-		}
-	}))
-	return server
+type treeSnapshotEntry struct {
+	Mode os.FileMode
+	Data string
 }
 
-func fakeGitHubAPI(t *testing.T) *httptest.Server {
-	t.Helper()
-	names := []string{
-		"mihomo-linux-amd64-compatible-v1.19.0.gz",
-		"mihomo-linux-arm64-v1.19.0.gz",
-		"mihomo-darwin-amd64-compatible-v1.19.0.gz",
-		"mihomo-darwin-arm64-v1.19.0.gz",
-		"mihomo-windows-amd64-compatible-v1.19.0.zip",
-		"mihomo-windows-arm64-v1.19.0.zip",
+func canonicalArchiveModes(goos string) map[string]os.FileMode {
+	suffix, script := "", "install-aio.sh"
+	if goos == "windows" {
+		suffix, script = ".exe", "install-aio.ps1"
 	}
-	archives := make(map[string][]byte, len(names))
-	for _, name := range names {
-		archives[name] = fakeMihomoArchive(t, name)
+	modes := map[string]os.FileMode{
+		"mihari" + suffix:                  0o755,
+		script:                             0o644,
+		"data/bin/mihomo" + suffix:         0o755,
+		"data/bin/core-channel":            0o644,
+		"data/geoip/GeoLite2-Country.mmdb": 0o644,
+		"data/geoip/GeoLite2-ASN.mmdb":     0o644,
 	}
-	var server *httptest.Server
-	server = httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
-		switch {
-		case request.URL.Path == "/repos/MetaCubeX/mihomo/releases/latest":
-			assets := make([]core.Asset, 0, len(names))
-			for _, name := range names {
-				data := archives[name]
-				sum := sha256.Sum256(data)
-				assets = append(assets, core.Asset{
-					Name: name, URL: server.URL + "/asset/" + name,
-					Size: int64(len(data)), Digest: "sha256:" + hex.EncodeToString(sum[:]),
-				})
-			}
-			response.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(response).Encode(core.Release{TagName: "v1.19.0", Assets: assets})
-		case strings.HasPrefix(request.URL.Path, "/asset/"):
-			_, _ = response.Write(archives[strings.TrimPrefix(request.URL.Path, "/asset/")])
-		default:
-			http.NotFound(response, request)
-		}
-	}))
-	return server
+	if goos != "windows" {
+		modes[script] = 0o755
+	}
+	return modes
 }
 
-func fakeGeoIPServer(t *testing.T) *httptest.Server {
+func writeCanonicalArchiveStage(t *testing.T, root, goos string, hostMode os.FileMode) {
 	t.Helper()
-	files := make(map[string][]byte)
-	for _, name := range []string{"GeoLite2-Country.mmdb", "GeoLite2-ASN.mmdb"} {
-		payload := []byte("fake-" + name)
-		files[name] = payload
+	for name := range canonicalArchiveModes(goos) {
+		path := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("fixture-"+name), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(path, hostMode); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func archiveEntryModes(t *testing.T, path string) map[string]os.FileMode {
+	t.Helper()
+	result := make(map[string]os.FileMode)
+	if strings.HasSuffix(path, ".tar.gz") {
+		file, err := os.Open(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer file.Close()
+		compressed, err := gzip.NewReader(file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer compressed.Close()
+		reader := tar.NewReader(compressed)
+		for {
+			header, err := reader.Next()
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			result[header.Name] = os.FileMode(header.Mode).Perm()
+		}
+		return result
+	}
+	reader, err := zip.OpenReader(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+	for _, file := range reader.File {
+		result[file.Name] = file.Mode().Perm()
+	}
+	return result
+}
+
+func writePublishSource(t *testing.T, parent string) string {
+	t.Helper()
+	source := filepath.Join(parent, "source")
+	if err := os.Mkdir(source, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, platform := range releaseinputs.RequiredPlatforms() {
+		goos, goarch, err := splitPlatform(platform)
+		if err != nil {
+			t.Fatal(err)
+		}
+		name := bundleName(goos, goarch)
+		if err := os.WriteFile(filepath.Join(source, name), []byte("new-"+name), 0o640); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return source
+}
+
+func writeExistingOutput(t *testing.T, destination string) {
+	t.Helper()
+	if err := os.MkdirAll(destination, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, platform := range releaseinputs.RequiredPlatforms() {
+		goos, goarch, err := splitPlatform(platform)
+		if err != nil {
+			t.Fatal(err)
+		}
+		name := bundleName(goos, goarch)
+		if err := os.WriteFile(filepath.Join(destination, name), []byte("old-"+name), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func snapshotTree(t *testing.T, root string) map[string]treeSnapshotEntry {
+	t.Helper()
+	return snapshotTreeWithLinks(t, root, false)
+}
+
+func snapshotTreeLstat(t *testing.T, root string) map[string]treeSnapshotEntry {
+	t.Helper()
+	return snapshotTreeWithLinks(t, root, true)
+}
+
+func snapshotTreeWithLinks(t *testing.T, root string, allowLinks bool) map[string]treeSnapshotEntry {
+	t.Helper()
+	result := make(map[string]treeSnapshotEntry)
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		info, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+		item := treeSnapshotEntry{Mode: info.Mode()}
+		switch {
+		case info.Mode()&os.ModeSymlink != 0:
+			if !allowLinks {
+				return errors.New("unexpected link in snapshot")
+			}
+			item.Data, err = os.Readlink(path)
+		case info.Mode().IsRegular():
+			var data []byte
+			data, err = os.ReadFile(path)
+			item.Data = string(data)
+		}
+		if err != nil {
+			return err
+		}
+		result[filepath.ToSlash(relative)] = item
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("snapshot %s: %v", root, err)
+	}
+	return result
+}
+
+func assertNoPublishResidue(t *testing.T, parent string) {
+	t.Helper()
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".mihari-aio-publish-") || strings.HasPrefix(entry.Name(), ".mihari-aio-backup-") {
+			t.Fatalf("publish transaction residue remains: %s", entry.Name())
+		}
+	}
+}
+
+type lockedFixture struct {
+	lock       releaseinputs.Lock
+	lockPath   string
+	mihariDir  string
+	scriptsDir string
+	transport  *fixtureTransport
+}
+
+func newLockedFixture(t *testing.T, channel string) *lockedFixture {
+	t.Helper()
+	const (
+		tag    = "v1.19.30"
+		commit = "69986b5d098c8d723a2c4d56317bc10cd5669c02"
+	)
+	lock := releaseinputs.Lock{
+		Schema: releaseinputs.SchemaV1,
+		Mihomo: releaseinputs.MihomoInputs{
+			Repository: "MetaCubeX/mihomo",
+			Channel:    channel,
+			ReleaseID:  1,
+			Tag:        tag,
+			Assets:     make(map[string]releaseinputs.MihomoAsset),
+		},
+		GeoIP: releaseinputs.GeoIPInputs{
+			Repository: "Loyalsoldier/geoip",
+			Commit:     commit,
+		},
+	}
+	if channel == "alpha" {
+		lock.Mihomo.Tag = "Prerelease-Alpha"
+	}
+	payloads := make(map[string][]byte)
+	for index, platform := range releaseinputs.RequiredPlatforms() {
+		extension := ".gz"
+		if strings.HasPrefix(platform, "windows/") {
+			extension = ".zip"
+		}
+		name := "mihomo-" + strings.ReplaceAll(platform, "/", "-") + "-" + lock.Mihomo.Tag + extension
+		if channel == "alpha" {
+			name = "mihomo-" + strings.ReplaceAll(platform, "/", "-") + "-alpha-e183c58" + extension
+		}
+		payload := fakeMihomoArchive(t, name)
 		sum := sha256.Sum256(payload)
-		files[name+".sha256sum"] = []byte(hex.EncodeToString(sum[:]) + "  " + name + "\n")
-	}
-	return httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
-		if data, ok := files[strings.TrimPrefix(request.URL.Path, "/")]; ok {
-			_, _ = response.Write(data)
-			return
+		url := "https://github.com/MetaCubeX/mihomo/releases/download/" + lock.Mihomo.Tag + "/" + name
+		lock.Mihomo.Assets[platform] = releaseinputs.MihomoAsset{
+			AssetID: int64(index + 1), Name: name, URL: url,
+			Size: int64(len(payload)), SHA256: hex.EncodeToString(sum[:]),
 		}
-		http.NotFound(response, request)
-	}))
+		payloads[url] = payload
+	}
+	country := []byte("fake-GeoLite2-Country.mmdb")
+	asn := []byte("fake-GeoLite2-ASN.mmdb")
+	countrySum := sha256.Sum256(country)
+	asnSum := sha256.Sum256(asn)
+	lock.GeoIP.Country = releaseinputs.GeoIPFile{
+		Name:   "GeoLite2-Country.mmdb",
+		URL:    "https://raw.githubusercontent.com/Loyalsoldier/geoip/" + commit + "/GeoLite2-Country.mmdb",
+		SHA256: hex.EncodeToString(countrySum[:]),
+	}
+	lock.GeoIP.ASN = releaseinputs.GeoIPFile{
+		Name:   "GeoLite2-ASN.mmdb",
+		URL:    "https://raw.githubusercontent.com/Loyalsoldier/geoip/" + commit + "/GeoLite2-ASN.mmdb",
+		SHA256: hex.EncodeToString(asnSum[:]),
+	}
+	payloads[lock.GeoIP.Country.URL] = country
+	payloads[lock.GeoIP.ASN.URL] = asn
+
+	mihariDir := t.TempDir()
+	writeMihariDist(t, mihariDir)
+	scriptsDir := t.TempDir()
+	for _, name := range []string{"install-aio.sh", "install-aio.ps1"} {
+		if err := os.WriteFile(filepath.Join(scriptsDir, name), []byte("# aio installer\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	fixture := &lockedFixture{
+		lock:       lock,
+		lockPath:   filepath.Join(t.TempDir(), "release-inputs.lock.json"),
+		mihariDir:  mihariDir,
+		scriptsDir: scriptsDir,
+		transport: &fixtureTransport{
+			payloads:  payloads,
+			statuses:  make(map[string]int),
+			redirects: make(map[string]string),
+		},
+	}
+	fixture.writeLock(t)
+	return fixture
+}
+
+func (f *lockedFixture) writeLock(t *testing.T) {
+	t.Helper()
+	data, err := releaseinputs.Encode(f.lock)
+	if err != nil {
+		t.Fatalf("encode fixture lock: %v", err)
+	}
+	if err := os.WriteFile(f.lockPath, data, 0o600); err != nil {
+		t.Fatalf("write fixture lock: %v", err)
+	}
+}
+
+func (f *lockedFixture) options(out string) options {
+	return options{
+		LockPath: f.lockPath, MihariDir: f.mihariDir, Out: out, ScriptsDir: f.scriptsDir,
+		Platforms:     releaseinputs.RequiredPlatforms(),
+		HTTPClient:    &http.Client{Transport: f.transport},
+		GeoIPValidate: func(string) error { return nil },
+		Runner:        fakeRunner{output: []byte("Mihomo Meta v1.19.30")},
+	}
+}
+
+func (f *lockedFixture) assertOnlyLockedRequests(t *testing.T) {
+	t.Helper()
+	want := make(map[string]int, 8)
+	for _, asset := range f.lock.Mihomo.Assets {
+		want[asset.URL]++
+	}
+	want[f.lock.GeoIP.Country.URL]++
+	want[f.lock.GeoIP.ASN.URL]++
+	got := f.transport.requestsByURL()
+	if len(got) != len(want) {
+		t.Fatalf("requested URLs = %v, want exactly locked URLs %v", got, want)
+	}
+	for url, count := range want {
+		if got[url] != count {
+			t.Fatalf("request count for %s = %d, want %d (all requests: %v)", url, got[url], count, got)
+		}
+	}
+	for url := range got {
+		if strings.Contains(url, "/latest") || strings.Contains(url, "/release/") || strings.HasSuffix(url, ".sha256sum") {
+			t.Fatalf("mutable discovery request observed: %s", url)
+		}
+	}
+}
+
+type fixtureTransport struct {
+	mu        sync.Mutex
+	payloads  map[string][]byte
+	statuses  map[string]int
+	redirects map[string]string
+	requests  []string
+}
+
+func (f *fixtureTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	if err := request.Context().Err(); err != nil {
+		return nil, err
+	}
+	f.mu.Lock()
+	f.requests = append(f.requests, request.URL.String())
+	payload, ok := f.payloads[request.URL.String()]
+	status := f.statuses[request.URL.String()]
+	redirect := f.redirects[request.URL.String()]
+	f.mu.Unlock()
+	if redirect != "" {
+		return &http.Response{
+			StatusCode: http.StatusFound,
+			Header:     http.Header{"Location": []string{redirect}},
+			Body:       io.NopCloser(strings.NewReader("redirect")),
+			Request:    request,
+		}, nil
+	}
+	if status == 0 {
+		status = http.StatusOK
+	}
+	if !ok && status == http.StatusOK {
+		status = http.StatusNotFound
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(bytes.NewReader(payload)),
+		Request:    request,
+	}, nil
+}
+
+func (f *fixtureTransport) requestCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.requests)
+}
+
+func (f *fixtureTransport) requestsByURL() map[string]int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	result := make(map[string]int, len(f.requests))
+	for _, rawURL := range f.requests {
+		result[rawURL]++
+	}
+	return result
 }
 
 func fakeMihomoArchive(t *testing.T, name string) []byte {

--- a/scripts/build-all-in-one/main_test.go
+++ b/scripts/build-all-in-one/main_test.go
@@ -210,6 +210,112 @@ func TestRunRejectsOutputPathOverlapBeforeNetwork(t *testing.T) {
 	}
 }
 
+func TestRunPublishesToResolvedOutputBelowSymlinkedAncestor(t *testing.T) {
+	fixture := newLockedFixture(t, "stable")
+	root := t.TempDir()
+	realParent := filepath.Join(root, "private", "var")
+	if err := os.MkdirAll(realParent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	linkedParent := filepath.Join(root, "var")
+	if err := os.Symlink(realParent, linkedParent); err != nil {
+		t.Skipf("directory symlink creation is unavailable: %v", err)
+	}
+
+	logicalOutput := filepath.Join(linkedParent, "bundles")
+	canonicalOutput := filepath.Join(realParent, "bundles")
+	redirectedParent := filepath.Join(root, "redirected")
+	if err := os.Mkdir(redirectedParent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	retargeted := false
+	opts := fixture.options(logicalOutput)
+	opts.PublishFault = func(operation, path string) error {
+		if !pathContains(canonicalOutput, path) {
+			t.Fatalf("publish path %q is outside canonical output", path)
+		}
+		if operation == "copy" && !retargeted {
+			retargeted = true
+			if err := os.Remove(linkedParent); err != nil {
+				t.Fatalf("remove output ancestor symlink: %v", err)
+			}
+			if err := os.Symlink(redirectedParent, linkedParent); err != nil {
+				t.Fatalf("retarget output ancestor symlink: %v", err)
+			}
+		}
+		return nil
+	}
+	if err := run(opts); err != nil {
+		t.Fatalf("run below symlinked ancestor: %v", err)
+	}
+	if !retargeted {
+		t.Fatal("publish did not reach the identity-change seam")
+	}
+	for _, platform := range releaseinputs.RequiredPlatforms() {
+		goos, goarch, err := splitPlatform(platform)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat(filepath.Join(canonicalOutput, bundleName(goos, goarch))); err != nil {
+			t.Fatalf("canonical output is missing %s: %v", platform, err)
+		}
+	}
+	if entries, err := os.ReadDir(filepath.Join(redirectedParent, "bundles")); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("retargeted ancestor received output entries %v: %v", entries, err)
+	}
+}
+
+func TestRunRejectsDestinationSymlinkBeforeNetwork(t *testing.T) {
+	fixture := newLockedFixture(t, "stable")
+	root := t.TempDir()
+	target := filepath.Join(root, "real-bundles")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	destination := filepath.Join(root, "bundles")
+	if err := os.Symlink(target, destination); err != nil {
+		t.Skipf("directory symlink creation is unavailable: %v", err)
+	}
+
+	err := run(fixture.options(destination))
+	if !errors.Is(err, errUnsafeBundleOutput) {
+		t.Fatalf("run destination symlink error = %v, want fixed isolation error", err)
+	}
+	if fixture.transport.requestCount() != 0 {
+		t.Fatalf("network requests = %d, want 0", fixture.transport.requestCount())
+	}
+	entries, readErr := os.ReadDir(target)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("destination symlink target was mutated: %v", entries)
+	}
+}
+
+func TestRunRejectsNonDirectoryDestinationBeforeNetwork(t *testing.T) {
+	fixture := newLockedFixture(t, "stable")
+	destination := filepath.Join(t.TempDir(), "bundles")
+	if err := os.WriteFile(destination, []byte("do not replace"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := run(fixture.options(destination))
+	if !errors.Is(err, errUnsafeBundleOutput) {
+		t.Fatalf("run non-directory destination error = %v, want fixed isolation error", err)
+	}
+	if fixture.transport.requestCount() != 0 {
+		t.Fatalf("network requests = %d, want 0", fixture.transport.requestCount())
+	}
+	got, readErr := os.ReadFile(destination)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != "do not replace" {
+		t.Fatalf("non-directory destination was mutated: %q", got)
+	}
+}
+
 func TestRunRejectsLockedPayloadMismatchWithoutBundle(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/scripts/build-all-in-one/main_test.go
+++ b/scripts/build-all-in-one/main_test.go
@@ -223,9 +223,16 @@ func TestRunPublishesToResolvedOutputBelowSymlinkedAncestor(t *testing.T) {
 	}
 
 	logicalOutput := filepath.Join(linkedParent, "bundles")
-	canonicalOutput := filepath.Join(realParent, "bundles")
+	canonicalOutput, err := canonicalOverlapPath(filepath.Join(realParent, "bundles"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	redirectedParent := filepath.Join(root, "redirected")
 	if err := os.Mkdir(redirectedParent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	resolvedRedirected, err := canonicalOverlapPath(redirectedParent)
+	if err != nil {
 		t.Fatal(err)
 	}
 	retargeted := false
@@ -260,7 +267,7 @@ func TestRunPublishesToResolvedOutputBelowSymlinkedAncestor(t *testing.T) {
 			t.Fatalf("canonical output is missing %s: %v", platform, err)
 		}
 	}
-	if entries, err := os.ReadDir(filepath.Join(redirectedParent, "bundles")); err == nil || !os.IsNotExist(err) {
+	if entries, err := os.ReadDir(filepath.Join(resolvedRedirected, "bundles")); err == nil || !os.IsNotExist(err) {
 		t.Fatalf("retargeted ancestor received output entries %v: %v", entries, err)
 	}
 }
@@ -685,6 +692,48 @@ func TestPublishBundlesRejectsSymlinkedParent(t *testing.T) {
 		t.Fatalf("publish crossed parent link and created output: %v", err)
 	}
 	assertNoPublishResidue(t, parent)
+}
+
+func TestPublishBundlesRejectsFileAncestorOfMissingParent(t *testing.T) {
+	parent := t.TempDir()
+	source := writePublishSource(t, parent)
+	fileAncestor := filepath.Join(parent, "not-a-dir")
+	if err := os.WriteFile(fileAncestor, []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	destination := filepath.Join(fileAncestor, "nested", "bundles")
+	if err := publishBundles(context.Background(), source, destination, releaseinputs.RequiredPlatforms(), nil, nil, nil); err == nil {
+		t.Fatal("publishBundles accepted a file as the first existing ancestor")
+	}
+	if _, err := os.Lstat(filepath.Join(fileAncestor, "nested")); !os.IsNotExist(err) {
+		t.Fatalf("missing parent was created under a file ancestor: %v", err)
+	}
+	assertNoPublishResidue(t, parent)
+}
+
+func TestPublishBundlesAllowsExistingParentBelowSymlinkedAncestor(t *testing.T) {
+	root := t.TempDir()
+	realAncestor := filepath.Join(root, "private", "real")
+	if err := os.MkdirAll(realAncestor, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	linkedAncestor := filepath.Join(root, "link")
+	if err := os.Symlink(realAncestor, linkedAncestor); err != nil {
+		t.Skipf("directory symlink creation is unavailable: %v", err)
+	}
+	existingParent := filepath.Join(linkedAncestor, "existing")
+	if err := os.Mkdir(existingParent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	source := writePublishSource(t, root)
+	destination := filepath.Join(existingParent, "bundles")
+	if err := publishBundles(context.Background(), source, destination, releaseinputs.RequiredPlatforms(), nil, nil, nil); err != nil {
+		t.Fatalf("publishBundles rejected a real parent below a symlinked ancestor: %v", err)
+	}
+	name := bundleName("linux", "amd64")
+	if _, err := os.Stat(filepath.Join(realAncestor, "existing", "bundles", name)); err != nil {
+		t.Fatalf("canonical output is missing %s: %v", name, err)
+	}
 }
 
 func TestRunCleanupFailureWarnsAfterSuccessfulCommit(t *testing.T) {

--- a/scripts/build-all-in-one/main_test.go
+++ b/scripts/build-all-in-one/main_test.go
@@ -705,8 +705,22 @@ func TestPublishBundlesRejectsFileAncestorOfMissingParent(t *testing.T) {
 	if err := publishBundles(context.Background(), source, destination, releaseinputs.RequiredPlatforms(), nil, nil, nil); err == nil {
 		t.Fatal("publishBundles accepted a file as the first existing ancestor")
 	}
-	if _, err := os.Lstat(filepath.Join(fileAncestor, "nested")); !os.IsNotExist(err) {
-		t.Fatalf("missing parent was created under a file ancestor: %v", err)
+	info, err := os.Lstat(fileAncestor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.Mode().IsRegular() {
+		t.Fatalf("file ancestor mode = %v, want a regular file", info.Mode())
+	}
+	got, err := os.ReadFile(fileAncestor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "not a directory" {
+		t.Fatalf("file ancestor contents = %q, want unchanged", got)
+	}
+	if _, err := os.Lstat(filepath.Join(fileAncestor, "nested")); err == nil {
+		t.Fatal("nested parent exists under a file ancestor")
 	}
 	assertNoPublishResidue(t, parent)
 }

--- a/scripts/internal/releaseinputs/lock.go
+++ b/scripts/internal/releaseinputs/lock.go
@@ -1,0 +1,432 @@
+// Package releaseinputs defines the reviewed, immutable inputs used to build
+// Mihari all-in-one release bundles.
+package releaseinputs
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	// SchemaV1 identifies the first Mihari all-in-one release input lock schema.
+	SchemaV1 = "mihari-aio-input-lock/v1"
+	// MaxLockSize bounds a release input lock before JSON decoding.
+	MaxLockSize = 1 << 20
+
+	mihomoRepository = "MetaCubeX/mihomo"
+	geoIPRepository  = "Loyalsoldier/geoip"
+	// Keep this in sync with internal/core maxCoreArchiveSize. The lock must
+	// never approve an archive that the consuming downloader will reject.
+	maxMihomoAsset = 128 << 20
+)
+
+var requiredPlatforms = [...]string{
+	"linux/amd64",
+	"linux/arm64",
+	"darwin/amd64",
+	"darwin/arm64",
+	"windows/amd64",
+	"windows/arm64",
+}
+
+// Lock contains every immutable external input used by the all-in-one build.
+type Lock struct {
+	Schema string       `json:"schema"`
+	Mihomo MihomoInputs `json:"mihomo"`
+	GeoIP  GeoIPInputs  `json:"geoip"`
+}
+
+// MihomoInputs identifies one release and its exact supported assets.
+type MihomoInputs struct {
+	Repository string                 `json:"repository"`
+	Channel    string                 `json:"channel"`
+	ReleaseID  int64                  `json:"release_id"`
+	Tag        string                 `json:"tag"`
+	Assets     map[string]MihomoAsset `json:"assets"`
+}
+
+// MihomoAsset identifies and verifies one platform-specific mihomo archive.
+type MihomoAsset struct {
+	AssetID int64  `json:"asset_id"`
+	Name    string `json:"name"`
+	URL     string `json:"url"`
+	Size    int64  `json:"size"`
+	SHA256  string `json:"sha256"`
+}
+
+// GeoIPInputs pins the GeoIP repository and both required databases.
+type GeoIPInputs struct {
+	Repository string    `json:"repository"`
+	Commit     string    `json:"commit"`
+	Country    GeoIPFile `json:"country"`
+	ASN        GeoIPFile `json:"asn"`
+}
+
+// GeoIPFile identifies and verifies one GeoIP database.
+type GeoIPFile struct {
+	Name   string `json:"name"`
+	URL    string `json:"url"`
+	SHA256 string `json:"sha256"`
+}
+
+// RequiredPlatforms returns the exact platform keys required by the lock.
+func RequiredPlatforms() []string {
+	platforms := make([]string, len(requiredPlatforms))
+	copy(platforms, requiredPlatforms[:])
+	return platforms
+}
+
+// Load opens, strictly decodes, and validates a release input lock file.
+func Load(path string) (Lock, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return Lock{}, fmt.Errorf("open release input lock: %w", err)
+	}
+	defer func() {
+		// A close error cannot affect a completed read-only decode.
+		_ = file.Close()
+	}()
+	return Decode(file)
+}
+
+// Decode reads, strictly decodes, and validates a release input lock.
+func Decode(reader io.Reader) (Lock, error) {
+	limited := io.LimitReader(reader, MaxLockSize+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return Lock{}, fmt.Errorf("read release input lock: %w", err)
+	}
+	if len(data) > MaxLockSize {
+		return Lock{}, fmt.Errorf("release input lock exceeds %d bytes", MaxLockSize)
+	}
+	if !utf8.Valid(data) {
+		return Lock{}, errors.New("release input lock is not valid UTF-8")
+	}
+	if err := rejectDuplicateKeys(data); err != nil {
+		return Lock{}, err
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var lock Lock
+	if err := decoder.Decode(&lock); err != nil {
+		return Lock{}, fmt.Errorf("decode release input lock: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return Lock{}, errors.New("decode release input lock: trailing JSON value")
+		}
+		return Lock{}, fmt.Errorf("decode release input lock: trailing JSON: %w", err)
+	}
+	if err := lock.Validate(); err != nil {
+		return Lock{}, err
+	}
+	return lock, nil
+}
+
+// Encode validates a lock and returns deterministic indented JSON ending in
+// exactly one newline.
+func Encode(lock Lock) ([]byte, error) {
+	if err := lock.Validate(); err != nil {
+		return nil, err
+	}
+	data, err := json.MarshalIndent(lock, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode release input lock: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+// Validate checks the complete semantic and URL contract of a lock.
+func (lock Lock) Validate() error {
+	if lock.Schema != SchemaV1 {
+		return fmt.Errorf("release input lock schema %q is unsupported", lock.Schema)
+	}
+	if lock.Mihomo.Repository != mihomoRepository {
+		return fmt.Errorf("mihomo repository must be %q", mihomoRepository)
+	}
+	if lock.Mihomo.Channel != "stable" && lock.Mihomo.Channel != "alpha" {
+		return fmt.Errorf("mihomo channel %q is unsupported", lock.Mihomo.Channel)
+	}
+	if lock.Mihomo.ReleaseID <= 0 {
+		return errors.New("mihomo release ID must be positive")
+	}
+	if err := validateTag(lock.Mihomo.Channel, lock.Mihomo.Tag); err != nil {
+		return err
+	}
+	if err := validateMihomoAssets(lock.Mihomo); err != nil {
+		return err
+	}
+	if lock.GeoIP.Repository != geoIPRepository {
+		return fmt.Errorf("GeoIP repository must be %q", geoIPRepository)
+	}
+	if !isLowerHex(lock.GeoIP.Commit, 40) {
+		return errors.New("GeoIP commit must be exactly 40 lowercase hexadecimal characters")
+	}
+	if err := validateGeoIPFile("country", "GeoLite2-Country.mmdb", lock.GeoIP, lock.GeoIP.Country); err != nil {
+		return err
+	}
+	if err := validateGeoIPFile("ASN", "GeoLite2-ASN.mmdb", lock.GeoIP, lock.GeoIP.ASN); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateTag(channel, tag string) error {
+	if tag == "" || strings.ContainsAny(tag, "/\\?#") || strings.TrimSpace(tag) != tag {
+		return fmt.Errorf("mihomo tag %q is invalid", tag)
+	}
+	for _, char := range tag {
+		if char < 0x21 || char > 0x7e {
+			return fmt.Errorf("mihomo tag %q is invalid", tag)
+		}
+	}
+	if channel == "stable" && !strings.HasPrefix(tag, "v") {
+		return fmt.Errorf("mihomo tag %q is invalid for stable channel", tag)
+	}
+	if channel == "alpha" && tag != "Prerelease-Alpha" {
+		return fmt.Errorf("mihomo tag %q is invalid for alpha channel", tag)
+	}
+	return nil
+}
+
+func validateMihomoAssets(inputs MihomoInputs) error {
+	if len(inputs.Assets) != len(requiredPlatforms) {
+		return fmt.Errorf("mihomo assets must contain exactly six platforms, got %d", len(inputs.Assets))
+	}
+	seenIDs := make(map[int64]string, len(inputs.Assets))
+	seenNames := make(map[string]string, len(inputs.Assets))
+	seenURLs := make(map[string]string, len(inputs.Assets))
+	for _, platform := range requiredPlatforms {
+		asset, ok := inputs.Assets[platform]
+		if !ok {
+			return fmt.Errorf("mihomo assets missing required platform %q", platform)
+		}
+		if asset.AssetID <= 0 {
+			return fmt.Errorf("mihomo %s asset ID must be positive", platform)
+		}
+		if previous, duplicate := seenIDs[asset.AssetID]; duplicate {
+			return fmt.Errorf("mihomo %s asset ID duplicates %s", platform, previous)
+		}
+		seenIDs[asset.AssetID] = platform
+		if asset.Size <= 0 || asset.Size > maxMihomoAsset {
+			return fmt.Errorf("mihomo %s asset size must be between 1 and %d bytes", platform, maxMihomoAsset)
+		}
+		if !isLowerHex(asset.SHA256, 64) {
+			return fmt.Errorf("mihomo %s SHA-256 must be exactly 64 lowercase hexadecimal characters", platform)
+		}
+		if err := validateMihomoAssetName(platform, inputs.Channel, inputs.Tag, asset.Name); err != nil {
+			return err
+		}
+		if previous, duplicate := seenNames[asset.Name]; duplicate {
+			return fmt.Errorf("mihomo %s asset name duplicates %s", platform, previous)
+		}
+		seenNames[asset.Name] = platform
+		if err := validateExactHTTPSURL(asset.URL, "github.com", "/"+inputs.Repository+"/releases/download/"+inputs.Tag+"/"+asset.Name); err != nil {
+			return fmt.Errorf("mihomo %s asset URL: %w", platform, err)
+		}
+		if previous, duplicate := seenURLs[asset.URL]; duplicate {
+			return fmt.Errorf("mihomo %s asset URL duplicates %s", platform, previous)
+		}
+		seenURLs[asset.URL] = platform
+	}
+	for platform := range inputs.Assets {
+		if !isRequiredPlatform(platform) {
+			return fmt.Errorf("mihomo assets contain unexpected platform %q", platform)
+		}
+	}
+	return nil
+}
+
+func validateMihomoAssetName(platform, channel, tag, name string) error {
+	prefix := "mihomo-" + strings.ReplaceAll(platform, "/", "-") + "-"
+	if !strings.HasPrefix(name, prefix) || strings.ContainsAny(name, "/\\") {
+		return fmt.Errorf("mihomo %s asset name %q is invalid", platform, name)
+	}
+	extension := ".gz"
+	if strings.HasPrefix(platform, "windows/") {
+		extension = ".zip"
+	}
+	if !strings.HasSuffix(name, extension) {
+		return fmt.Errorf("mihomo %s asset name %q must end in %s", platform, name, extension)
+	}
+	if channel == "stable" && !strings.HasSuffix(name, "-"+tag+extension) {
+		return fmt.Errorf("mihomo %s asset name %q must end in -%s%s", platform, name, tag, extension)
+	}
+	if channel == "alpha" {
+		alphaPart := strings.TrimSuffix(strings.TrimPrefix(name, prefix), extension)
+		sha, found := strings.CutPrefix(alphaPart, "alpha-")
+		if !found || len(sha) < 7 || len(sha) > 40 || !isLowerHex(sha, len(sha)) {
+			return fmt.Errorf("mihomo %s asset name %q must use the standard alpha SHA form", platform, name)
+		}
+	}
+	return nil
+}
+
+func validateGeoIPFile(label, expectedName string, inputs GeoIPInputs, file GeoIPFile) error {
+	if file.Name != expectedName {
+		return fmt.Errorf("GeoIP %s name must be %q", label, expectedName)
+	}
+	if !isLowerHex(file.SHA256, 64) {
+		return fmt.Errorf("GeoIP %s SHA-256 must be exactly 64 lowercase hexadecimal characters", label)
+	}
+	expectedPath := "/" + inputs.Repository + "/" + inputs.Commit + "/" + file.Name
+	if err := validateExactHTTPSURL(file.URL, "raw.githubusercontent.com", expectedPath); err != nil {
+		return fmt.Errorf("GeoIP %s URL: %w", label, err)
+	}
+	return nil
+}
+
+func validateExactHTTPSURL(rawURL, host, path string) error {
+	if strings.Contains(rawURL, "#") {
+		return errors.New("must not contain a fragment delimiter")
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return errors.New("invalid URL syntax")
+	}
+	if parsed.Scheme != "https" || parsed.Host != host || parsed.User != nil || parsed.Opaque != "" {
+		return errors.New("must use the approved HTTPS host without credentials")
+	}
+	if parsed.RawPath != "" || parsed.Path != path {
+		return fmt.Errorf("path must be %q", path)
+	}
+	if parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
+		return errors.New("must not contain a query or fragment")
+	}
+	return nil
+}
+
+func rejectDuplicateKeys(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	if err := walkJSONValue(decoder); err != nil {
+		return fmt.Errorf("decode release input lock: %w", err)
+	}
+	return nil
+}
+
+func walkJSONValue(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delim, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+	switch delim {
+	case '{':
+		seen := make(map[string]struct{})
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return errors.New("object key is not a string")
+			}
+			canonicalKey := foldJSONKey(key)
+			if _, duplicate := seen[canonicalKey]; duplicate {
+				return errors.New("duplicate JSON object key")
+			}
+			seen[canonicalKey] = struct{}{}
+			if !isLowerASCIIKey(key) {
+				return errors.New("JSON object keys must use lowercase ASCII schema spelling")
+			}
+			if err := walkJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		closing, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		if closing != json.Delim('}') {
+			return errors.New("object is not properly closed")
+		}
+	case '[':
+		for decoder.More() {
+			if err := walkJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		closing, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		if closing != json.Delim(']') {
+			return errors.New("array is not properly closed")
+		}
+	default:
+		return fmt.Errorf("unexpected JSON delimiter %q", delim)
+	}
+	return nil
+}
+
+func foldJSONKey(key string) string {
+	var folded strings.Builder
+	folded.Grow(len(key))
+	for _, character := range key {
+		folded.WriteRune(foldKeyRune(character))
+	}
+	return folded.String()
+}
+
+func foldKeyRune(character rune) rune {
+	if character < utf8.RuneSelf {
+		if character >= 'A' && character <= 'Z' {
+			return character + ('a' - 'A')
+		}
+		return character
+	}
+	for candidate := unicode.SimpleFold(character); candidate != character; candidate = unicode.SimpleFold(candidate) {
+		if candidate < utf8.RuneSelf {
+			if candidate >= 'A' && candidate <= 'Z' {
+				candidate += 'a' - 'A'
+			}
+			return candidate
+		}
+	}
+	return unicode.ToLower(character)
+}
+
+func isLowerASCIIKey(key string) bool {
+	for index := 0; index < len(key); index++ {
+		character := key[index]
+		if character >= utf8.RuneSelf || (character >= 'A' && character <= 'Z') {
+			return false
+		}
+	}
+	return true
+}
+
+func isRequiredPlatform(candidate string) bool {
+	for _, platform := range requiredPlatforms {
+		if candidate == platform {
+			return true
+		}
+	}
+	return false
+}
+
+func isLowerHex(value string, length int) bool {
+	if len(value) != length {
+		return false
+	}
+	for _, char := range value {
+		if (char < '0' || char > '9') && (char < 'a' || char > 'f') {
+			return false
+		}
+	}
+	return true
+}

--- a/scripts/internal/releaseinputs/lock_test.go
+++ b/scripts/internal/releaseinputs/lock_test.go
@@ -1,0 +1,572 @@
+package releaseinputs
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDecodeAcceptsValidLock(t *testing.T) {
+	lock, err := Decode(strings.NewReader(validLockJSON))
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if lock.Schema != SchemaV1 {
+		t.Fatalf("schema = %q, want %q", lock.Schema, SchemaV1)
+	}
+	if got := lock.Mihomo.Assets["windows/arm64"].AssetID; got != 516687082 {
+		t.Fatalf("windows/arm64 asset ID = %d, want 516687082", got)
+	}
+	if got := lock.GeoIP.Commit; got != "69986b5d098c8d723a2c4d56317bc10cd5669c02" {
+		t.Fatalf("GeoIP commit = %q", got)
+	}
+}
+
+func TestLoadReadsAndValidatesFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "release-inputs.lock.json")
+	if err := os.WriteFile(path, []byte(validLockJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	lock, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if lock.Mihomo.Tag != "v1.19.30" {
+		t.Fatalf("mihomo tag = %q, want v1.19.30", lock.Mihomo.Tag)
+	}
+
+	if _, err := Load(filepath.Join(t.TempDir(), "missing.json")); err == nil || !strings.Contains(err.Error(), "open") {
+		t.Fatalf("Load missing file error = %v, want open context", err)
+	}
+}
+
+func TestCheckedInLockIsValidCanonicalJSON(t *testing.T) {
+	path := filepath.Join("..", "..", "release-inputs.lock.json")
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read checked-in lock: %v", err)
+	}
+	lock, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load checked-in lock: %v", err)
+	}
+	got, err := Encode(lock)
+	if err != nil {
+		t.Fatalf("Encode checked-in lock: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatal("checked-in release input lock is not canonical JSON")
+	}
+}
+
+func TestDecodeRejectsOversizedLock(t *testing.T) {
+	_, err := Decode(strings.NewReader(strings.Repeat(" ", MaxLockSize+1)))
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("Decode oversized lock error = %v, want size-limit error", err)
+	}
+}
+
+func TestDecodeRejectsInvalidUTF8(t *testing.T) {
+	_, err := Decode(bytes.NewReader([]byte{0xff, 0xfe}))
+	if err == nil || !strings.Contains(err.Error(), "UTF-8") {
+		t.Fatalf("Decode invalid UTF-8 error = %v, want UTF-8 error", err)
+	}
+}
+
+func TestDecodeRejectsUnknownAndTrailingJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want string
+	}{
+		{name: "unknown field", data: strings.Replace(validLockJSON, `"schema":`, `"unexpected": true, "schema":`, 1), want: "unknown field"},
+		{name: "trailing object", data: validLockJSON + `{}`, want: "trailing JSON"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := Decode(strings.NewReader(test.data))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Decode error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestDecodeRejectsDuplicateJSONKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want string
+	}{
+		{
+			name: "top-level field",
+			data: strings.Replace(validLockJSON, `"schema": "mihari-aio-input-lock/v1",`, `"schema": "mihari-aio-input-lock/v1", "schema": "mihari-aio-input-lock/v1",`, 1),
+			want: "duplicate JSON object key",
+		},
+		{
+			name: "nested field",
+			data: strings.Replace(validLockJSON, `"repository": "MetaCubeX/mihomo",`, `"repository": "MetaCubeX/mihomo", "repository": "MetaCubeX/mihomo",`, 1),
+			want: "duplicate JSON object key",
+		},
+		{
+			name: "asset platform key",
+			data: strings.Replace(validLockJSON, `"windows/arm64": {`, `"linux/amd64": {`, 1),
+			want: "duplicate JSON object key",
+		},
+		{
+			name: "escaped-equivalent key",
+			data: strings.Replace(validLockJSON, `"schema": "mihari-aio-input-lock/v1",`, `"schema": "mihari-aio-input-lock/v1", "\u0073chema": "mihari-aio-input-lock/v1",`, 1),
+			want: "duplicate JSON object key",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := Decode(strings.NewReader(test.data))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Decode error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestDecodeRejectsCaseInsensitiveFieldAliases(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want string
+	}{
+		{
+			name: "top-level alias",
+			data: strings.Replace(validLockJSON, `"schema":`, `"Schema":`, 1),
+			want: "lowercase",
+		},
+		{
+			name: "top-level semantic duplicate",
+			data: strings.Replace(validLockJSON, `"schema": "mihari-aio-input-lock/v1",`, `"schema": "mihari-aio-input-lock/v1", "Schema": "mihari-aio-input-lock/v1",`, 1),
+			want: "duplicate JSON object key",
+		},
+		{
+			name: "nested alias",
+			data: strings.Replace(validLockJSON, `"repository": "MetaCubeX/mihomo",`, `"Repository": "MetaCubeX/mihomo",`, 1),
+			want: "lowercase",
+		},
+		{
+			name: "nested semantic duplicate",
+			data: strings.Replace(validLockJSON, `"asset_id": 516687180,`, `"asset_id": 516687180, "Asset_ID": 516687180,`, 1),
+			want: "duplicate JSON object key",
+		},
+		{
+			name: "non-ASCII case-fold alias",
+			data: strings.Replace(validLockJSON, `"schema":`, `"ſchema":`, 1),
+			want: "lowercase ASCII",
+		},
+		{
+			name: "non-ASCII semantic duplicate",
+			data: strings.Replace(validLockJSON, `"schema": "mihari-aio-input-lock/v1",`, `"schema": "mihari-aio-input-lock/v1", "ſchema": "mihari-aio-input-lock/v1",`, 1),
+			want: "duplicate JSON object key",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := Decode(strings.NewReader(test.data))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Decode error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestDecodeAcceptsEscapedLowercaseASCIIKey(t *testing.T) {
+	data := strings.Replace(validLockJSON, `"schema":`, `"\u0073chema":`, 1)
+	lock, err := Decode(strings.NewReader(data))
+	if err != nil {
+		t.Fatalf("Decode escaped lowercase ASCII key: %v", err)
+	}
+	if lock.Schema != SchemaV1 {
+		t.Fatalf("schema = %q, want %q", lock.Schema, SchemaV1)
+	}
+}
+
+func TestNonASCIIKeyErrorDoesNotEchoRejectedAlias(t *testing.T) {
+	data := strings.Replace(validLockJSON, `"schema":`, `"ſchema":`, 1)
+	_, err := Decode(strings.NewReader(data))
+	if err == nil {
+		t.Fatal("Decode accepted non-ASCII field alias")
+	}
+	const want = "decode release input lock: JSON object keys must use lowercase ASCII schema spelling"
+	if err.Error() != want {
+		t.Fatalf("non-ASCII key error = %q, want fixed safe text %q", err, want)
+	}
+	if strings.Contains(err.Error(), "ſchema") {
+		t.Fatalf("non-ASCII key error leaked rejected alias: %q", err)
+	}
+}
+
+func TestDuplicateKeyErrorDoesNotEchoUntrustedKey(t *testing.T) {
+	key := strings.Repeat("secret-token-", 200)
+	data := []byte(`{"` + key + `": 1, "` + key + `": 2}`)
+	err := rejectDuplicateKeys(data)
+	if err == nil {
+		t.Fatal("rejectDuplicateKeys accepted a duplicate long key")
+	}
+	message := err.Error()
+	if message != "decode release input lock: duplicate JSON object key" {
+		t.Fatalf("duplicate-key error = %q, want fixed safe text", message)
+	}
+	if strings.Contains(message, "secret-token") || strings.Contains(message, key) {
+		t.Fatalf("duplicate-key error leaked untrusted key: %q", message)
+	}
+}
+
+func TestDuplicateKeyCheckIgnoresObjectSyntaxInsideString(t *testing.T) {
+	data := []byte(`{"message":"embedded {\"message\":true} is data"}`)
+	if err := rejectDuplicateKeys(data); err != nil {
+		t.Fatalf("rejectDuplicateKeys: %v", err)
+	}
+}
+
+func TestDecodeValidatesTopLevelMetadata(t *testing.T) {
+	tests := []struct {
+		name string
+		old  string
+		new  string
+		want string
+	}{
+		{name: "schema", old: SchemaV1, new: "mihari-aio-input-lock/v2", want: "schema"},
+		{name: "mihomo repository", old: "MetaCubeX/mihomo", new: "attacker/mihomo", want: "mihomo repository"},
+		{name: "mihomo channel", old: `"channel": "stable"`, new: `"channel": "nightly"`, want: "mihomo channel"},
+		{name: "mihomo release ID", old: `"release_id": 371291937`, new: `"release_id": 0`, want: "release ID"},
+		{name: "mihomo tag", old: `"tag": "v1.19.30"`, new: `"tag": "../v1.19.30"`, want: "mihomo tag"},
+		{name: "GeoIP repository", old: "Loyalsoldier/geoip", new: "attacker/geoip", want: "GeoIP repository"},
+		{name: "GeoIP commit length", old: "69986b5d098c8d723a2c4d56317bc10cd5669c02", new: "69986b5d", want: "GeoIP commit"},
+		{name: "GeoIP commit uppercase", old: "69986b5d098c8d723a2c4d56317bc10cd5669c02", new: "69986B5D098C8D723A2C4D56317BC10CD5669C02", want: "GeoIP commit"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data := strings.Replace(validLockJSON, test.old, test.new, 1)
+			_, err := Decode(strings.NewReader(data))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Decode error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestDecodeRequiresExactPlatformSet(t *testing.T) {
+	tests := []struct {
+		name string
+		edit func(*Lock)
+		want string
+	}{
+		{
+			name: "missing platform",
+			edit: func(lock *Lock) {
+				delete(lock.Mihomo.Assets, "windows/arm64")
+			},
+			want: "exactly six",
+		},
+		{
+			name: "unexpected platform",
+			edit: func(lock *Lock) {
+				asset := lock.Mihomo.Assets["windows/arm64"]
+				delete(lock.Mihomo.Assets, "windows/arm64")
+				lock.Mihomo.Assets["freebsd/arm64"] = asset
+			},
+			want: "platform",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			lock, err := Decode(strings.NewReader(validLockJSON))
+			if err != nil {
+				t.Fatalf("Decode fixture: %v", err)
+			}
+			test.edit(&lock)
+			err = lock.Validate()
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Validate error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestDecodeValidatesMihomoAssets(t *testing.T) {
+	tests := []struct {
+		name string
+		old  string
+		new  string
+		want string
+	}{
+		{name: "asset ID", old: `"asset_id": 516687180`, new: `"asset_id": 0`, want: "asset ID"},
+		{name: "size zero", old: `"size": 18899951`, new: `"size": 0`, want: "size"},
+		{name: "size over bound", old: `"size": 18899951`, new: `"size": 268435457`, want: "size"},
+		{name: "digest length", old: "db214c7a2517e63c150d123178d16d102e03a241ccdae4e5e07ffbe9cf56c6f9", new: "deadbeef", want: "SHA-256"},
+		{name: "digest uppercase", old: "db214c7a2517e63c150d123178d16d102e03a241ccdae4e5e07ffbe9cf56c6f9", new: "DB214C7A2517E63C150D123178D16D102E03A241CCDAE4E5E07FFBE9CF56C6F9", want: "SHA-256"},
+		{name: "wrong platform name", old: "mihomo-linux-amd64-compatible-v1.19.30.gz", new: "mihomo-linux-arm64-compatible-v1.19.30.gz", want: "asset name"},
+		{name: "tag absent from name", old: "mihomo-linux-amd64-compatible-v1.19.30.gz", new: "mihomo-linux-amd64-compatible-v1.19.29.gz", want: "asset name"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data := strings.Replace(validLockJSON, test.old, test.new, 1)
+			_, err := Decode(strings.NewReader(data))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Decode error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestValidateMihomoAssetSizeMatchesCoreDownloadBound(t *testing.T) {
+	lock, err := Decode(strings.NewReader(validLockJSON))
+	if err != nil {
+		t.Fatalf("Decode fixture: %v", err)
+	}
+	asset := lock.Mihomo.Assets["linux/amd64"]
+	asset.Size = 134217728 // 128 MiB: internal/core maxCoreArchiveSize.
+	lock.Mihomo.Assets["linux/amd64"] = asset
+	if err := lock.Validate(); err != nil {
+		t.Fatalf("Validate 128 MiB asset: %v", err)
+	}
+
+	asset.Size = 134217729
+	lock.Mihomo.Assets["linux/amd64"] = asset
+	if err := lock.Validate(); err == nil || !strings.Contains(err.Error(), "size") {
+		t.Fatalf("Validate 128 MiB + 1 asset error = %v, want size error", err)
+	}
+}
+
+func TestValidateRequiresStableTagAsExactAssetNameSuffix(t *testing.T) {
+	lock, err := Decode(strings.NewReader(validLockJSON))
+	if err != nil {
+		t.Fatalf("Decode fixture: %v", err)
+	}
+	lock.Mihomo.Tag = "v1.19.3"
+	for platform, asset := range lock.Mihomo.Assets {
+		asset.URL = strings.Replace(asset.URL, "/v1.19.30/", "/v1.19.3/", 1)
+		lock.Mihomo.Assets[platform] = asset
+	}
+	if err := lock.Validate(); err == nil || !strings.Contains(err.Error(), "asset name") {
+		t.Fatalf("Validate short tag error = %v, want exact asset-name suffix error", err)
+	}
+}
+
+func TestValidateAlphaReleaseTagAndAssetNames(t *testing.T) {
+	t.Run("valid Prerelease-Alpha", func(t *testing.T) {
+		lock := alphaLock(t)
+		if err := lock.Validate(); err != nil {
+			t.Fatalf("Validate alpha lock: %v", err)
+		}
+	})
+
+	t.Run("wrong release tag", func(t *testing.T) {
+		lock := alphaLock(t)
+		lock.Mihomo.Tag = "alpha-e183c58"
+		if err := lock.Validate(); err == nil || !strings.Contains(err.Error(), "tag") {
+			t.Fatalf("Validate alpha tag error = %v, want tag error", err)
+		}
+	})
+
+	t.Run("non-standard asset name", func(t *testing.T) {
+		lock := alphaLock(t)
+		asset := lock.Mihomo.Assets["linux/amd64"]
+		asset.Name = "mihomo-linux-amd64-compatible-alpha-e183c58.gz"
+		asset.URL = "https://github.com/MetaCubeX/mihomo/releases/download/Prerelease-Alpha/" + asset.Name
+		lock.Mihomo.Assets["linux/amd64"] = asset
+		if err := lock.Validate(); err == nil || !strings.Contains(err.Error(), "asset name") {
+			t.Fatalf("Validate alpha asset name error = %v, want asset-name error", err)
+		}
+	})
+}
+
+func alphaLock(t *testing.T) Lock {
+	t.Helper()
+	lock, err := Decode(strings.NewReader(validLockJSON))
+	if err != nil {
+		t.Fatalf("Decode fixture: %v", err)
+	}
+	lock.Mihomo.Channel = "alpha"
+	lock.Mihomo.Tag = "Prerelease-Alpha"
+	for platform, asset := range lock.Mihomo.Assets {
+		extension := ".gz"
+		if strings.HasPrefix(platform, "windows/") {
+			extension = ".zip"
+		}
+		asset.Name = "mihomo-" + strings.ReplaceAll(platform, "/", "-") + "-alpha-e183c58" + extension
+		asset.URL = "https://github.com/MetaCubeX/mihomo/releases/download/Prerelease-Alpha/" + asset.Name
+		lock.Mihomo.Assets[platform] = asset
+	}
+	return lock
+}
+
+func TestDecodeConstrainsMihomoURLs(t *testing.T) {
+	base := "https://github.com/MetaCubeX/mihomo/releases/download/v1.19.30/mihomo-linux-amd64-compatible-v1.19.30.gz"
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{name: "HTTP", url: strings.Replace(base, "https://", "http://", 1)},
+		{name: "credentials", url: strings.Replace(base, "github.com", "token@github.com", 1)},
+		{name: "wrong host", url: strings.Replace(base, "github.com", "example.com", 1)},
+		{name: "wrong repository", url: strings.Replace(base, "MetaCubeX/mihomo", "attacker/mihomo", 1)},
+		{name: "wrong tag", url: strings.Replace(base, "v1.19.30/", "v1.19.29/", 1)},
+		{name: "wrong name", url: strings.Replace(base, "compatible-v1.19.30.gz", "v1.19.30.gz", 1)},
+		{name: "query", url: base + "?download=1"},
+		{name: "fragment", url: base + "#asset"},
+		{name: "empty fragment delimiter", url: base + "#"},
+		{name: "encoded path", url: strings.Replace(base, "/MetaCubeX/", "/%4detaCubeX/", 1)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data := strings.Replace(validLockJSON, base, test.url, 1)
+			_, err := Decode(strings.NewReader(data))
+			if err == nil || !strings.Contains(err.Error(), "URL") {
+				t.Fatalf("Decode error = %v, want URL validation error", err)
+			}
+		})
+	}
+}
+
+func TestURLParseErrorsDoNotLeakCredentialsOrRawURL(t *testing.T) {
+	rawURL := "https://secret-token@github.com/MetaCubeX/mihomo/%zz"
+	err := validateExactHTTPSURL(rawURL, "github.com", "/MetaCubeX/mihomo/asset")
+	if err == nil {
+		t.Fatal("validateExactHTTPSURL accepted an invalid escaped URL")
+	}
+	message := err.Error()
+	for _, secret := range []string{"secret-token", rawURL, "%zz"} {
+		if strings.Contains(message, secret) {
+			t.Fatalf("URL parse error %q leaked %q", message, secret)
+		}
+	}
+}
+
+func TestDecodeValidatesGeoIPFilesAndURLs(t *testing.T) {
+	base := "https://raw.githubusercontent.com/Loyalsoldier/geoip/69986b5d098c8d723a2c4d56317bc10cd5669c02/GeoLite2-Country.mmdb"
+	tests := []struct {
+		name string
+		old  string
+		new  string
+		want string
+	}{
+		{name: "file name", old: `"name": "GeoLite2-Country.mmdb"`, new: `"name": "country.mmdb"`, want: "GeoIP country name"},
+		{name: "digest", old: "26a2c3c3791b36303a1c70bac18320c4e6bd40950286224a38f2756c0f7d0ca2", new: "deadbeef", want: "SHA-256"},
+		{name: "HTTP", old: base, new: strings.Replace(base, "https://", "http://", 1), want: "URL"},
+		{name: "credentials", old: base, new: strings.Replace(base, "raw.githubusercontent.com", "token@raw.githubusercontent.com", 1), want: "URL"},
+		{name: "wrong host", old: base, new: strings.Replace(base, "raw.githubusercontent.com", "github.com", 1), want: "URL"},
+		{name: "mutable ref", old: base, new: strings.Replace(base, "69986b5d098c8d723a2c4d56317bc10cd5669c02", "release", 1), want: "URL"},
+		{name: "wrong file path", old: base, new: strings.Replace(base, "GeoLite2-Country.mmdb", "GeoLite2-ASN.mmdb", 1), want: "URL"},
+		{name: "query", old: base, new: base + "?raw=1", want: "URL"},
+		{name: "empty fragment delimiter", old: base, new: base + "#", want: "URL"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data := strings.Replace(validLockJSON, test.old, test.new, 1)
+			_, err := Decode(strings.NewReader(data))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Decode error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestEncodeProducesCanonicalValidatedJSON(t *testing.T) {
+	lock, err := Decode(strings.NewReader(validLockJSON))
+	if err != nil {
+		t.Fatalf("Decode fixture: %v", err)
+	}
+	first, err := Encode(lock)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	second, err := Encode(lock)
+	if err != nil {
+		t.Fatalf("Encode second: %v", err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatal("Encode returned non-deterministic bytes")
+	}
+	if len(first) == 0 || first[len(first)-1] != '\n' || (len(first) > 1 && first[len(first)-2] == '\n') {
+		t.Fatalf("Encode must end in exactly one newline, got suffix %q", first[max(0, len(first)-4):])
+	}
+	if !bytes.Contains(first, []byte("\n  \"mihomo\":")) {
+		t.Fatalf("Encode output is not canonical indented JSON: %s", first)
+	}
+	if bytes.Index(first, []byte(`"darwin/amd64"`)) > bytes.Index(first, []byte(`"windows/arm64"`)) {
+		t.Fatal("platform map keys are not in canonical lexical order")
+	}
+
+	lock.Mihomo.ReleaseID = 0
+	if _, err := Encode(lock); err == nil {
+		t.Fatal("Encode accepted invalid lock")
+	}
+}
+
+const validLockJSON = `{
+  "schema": "mihari-aio-input-lock/v1",
+  "mihomo": {
+    "repository": "MetaCubeX/mihomo",
+    "channel": "stable",
+    "release_id": 371291937,
+    "tag": "v1.19.30",
+    "assets": {
+      "linux/amd64": {
+        "asset_id": 516687180,
+        "name": "mihomo-linux-amd64-compatible-v1.19.30.gz",
+        "url": "https://github.com/MetaCubeX/mihomo/releases/download/v1.19.30/mihomo-linux-amd64-compatible-v1.19.30.gz",
+        "size": 18899951,
+        "sha256": "db214c7a2517e63c150d123178d16d102e03a241ccdae4e5e07ffbe9cf56c6f9"
+      },
+      "linux/arm64": {
+        "asset_id": 516687149,
+        "name": "mihomo-linux-arm64-v1.19.30.gz",
+        "url": "https://github.com/MetaCubeX/mihomo/releases/download/v1.19.30/mihomo-linux-arm64-v1.19.30.gz",
+        "size": 16965828,
+        "sha256": "58896873736d28628f66de3677c8654fa0f180662523148e136cff4f6e890069"
+      },
+      "darwin/amd64": {
+        "asset_id": 516687197,
+        "name": "mihomo-darwin-amd64-compatible-v1.19.30.gz",
+        "url": "https://github.com/MetaCubeX/mihomo/releases/download/v1.19.30/mihomo-darwin-amd64-compatible-v1.19.30.gz",
+        "size": 18300486,
+        "sha256": "6e75de0732e8afabe413ff7c235e8f16226ce136672371c60787cbf9607402c5"
+      },
+      "darwin/arm64": {
+        "asset_id": 516687188,
+        "name": "mihomo-darwin-arm64-v1.19.30.gz",
+        "url": "https://github.com/MetaCubeX/mihomo/releases/download/v1.19.30/mihomo-darwin-arm64-v1.19.30.gz",
+        "size": 16805556,
+        "sha256": "2c7f3a7904fa1cee291e124123e630e7b1ebd13765dd9bf26c0a28432004d9f4"
+      },
+      "windows/amd64": {
+        "asset_id": 516687134,
+        "name": "mihomo-windows-amd64-compatible-v1.19.30.zip",
+        "url": "https://github.com/MetaCubeX/mihomo/releases/download/v1.19.30/mihomo-windows-amd64-compatible-v1.19.30.zip",
+        "size": 18529108,
+        "sha256": "289fde5e29d37a5b3326480590d8b3551c5bf7f8737290355c19bce74d57a563"
+      },
+      "windows/arm64": {
+        "asset_id": 516687082,
+        "name": "mihomo-windows-arm64-v1.19.30.zip",
+        "url": "https://github.com/MetaCubeX/mihomo/releases/download/v1.19.30/mihomo-windows-arm64-v1.19.30.zip",
+        "size": 16344535,
+        "sha256": "b37c4b0259e85b020edc4215aa4c86052e21071cf520d4800364b21b4e2fc162"
+      }
+    }
+  },
+  "geoip": {
+    "repository": "Loyalsoldier/geoip",
+    "commit": "69986b5d098c8d723a2c4d56317bc10cd5669c02",
+    "country": {
+      "name": "GeoLite2-Country.mmdb",
+      "url": "https://raw.githubusercontent.com/Loyalsoldier/geoip/69986b5d098c8d723a2c4d56317bc10cd5669c02/GeoLite2-Country.mmdb",
+      "sha256": "26a2c3c3791b36303a1c70bac18320c4e6bd40950286224a38f2756c0f7d0ca2"
+    },
+    "asn": {
+      "name": "GeoLite2-ASN.mmdb",
+      "url": "https://raw.githubusercontent.com/Loyalsoldier/geoip/69986b5d098c8d723a2c4d56317bc10cd5669c02/GeoLite2-ASN.mmdb",
+      "sha256": "82abcabdf4d0ecb34da45e4f0f9bc30bf933cfbfec446b89a2215fae5b1fdbdc"
+    }
+  }
+}`

--- a/scripts/release-inputs.lock.json
+++ b/scripts/release-inputs.lock.json
@@ -1,0 +1,67 @@
+{
+  "schema": "mihari-aio-input-lock/v1",
+  "mihomo": {
+    "repository": "MetaCubeX/mihomo",
+    "channel": "stable",
+    "release_id": 371291937,
+    "tag": "v1.19.30",
+    "assets": {
+      "darwin/amd64": {
+        "asset_id": 516687197,
+        "name": "mihomo-darwin-amd64-compatible-v1.19.30.gz",
+        "url": "https://github.com/MetaCubeX/mihomo/releases/download/v1.19.30/mihomo-darwin-amd64-compatible-v1.19.30.gz",
+        "size": 18300486,
+        "sha256": "6e75de0732e8afabe413ff7c235e8f16226ce136672371c60787cbf9607402c5"
+      },
+      "darwin/arm64": {
+        "asset_id": 516687188,
+        "name": "mihomo-darwin-arm64-v1.19.30.gz",
+        "url": "https://github.com/MetaCubeX/mihomo/releases/download/v1.19.30/mihomo-darwin-arm64-v1.19.30.gz",
+        "size": 16805556,
+        "sha256": "2c7f3a7904fa1cee291e124123e630e7b1ebd13765dd9bf26c0a28432004d9f4"
+      },
+      "linux/amd64": {
+        "asset_id": 516687180,
+        "name": "mihomo-linux-amd64-compatible-v1.19.30.gz",
+        "url": "https://github.com/MetaCubeX/mihomo/releases/download/v1.19.30/mihomo-linux-amd64-compatible-v1.19.30.gz",
+        "size": 18899951,
+        "sha256": "db214c7a2517e63c150d123178d16d102e03a241ccdae4e5e07ffbe9cf56c6f9"
+      },
+      "linux/arm64": {
+        "asset_id": 516687149,
+        "name": "mihomo-linux-arm64-v1.19.30.gz",
+        "url": "https://github.com/MetaCubeX/mihomo/releases/download/v1.19.30/mihomo-linux-arm64-v1.19.30.gz",
+        "size": 16965828,
+        "sha256": "58896873736d28628f66de3677c8654fa0f180662523148e136cff4f6e890069"
+      },
+      "windows/amd64": {
+        "asset_id": 516687134,
+        "name": "mihomo-windows-amd64-compatible-v1.19.30.zip",
+        "url": "https://github.com/MetaCubeX/mihomo/releases/download/v1.19.30/mihomo-windows-amd64-compatible-v1.19.30.zip",
+        "size": 18529108,
+        "sha256": "289fde5e29d37a5b3326480590d8b3551c5bf7f8737290355c19bce74d57a563"
+      },
+      "windows/arm64": {
+        "asset_id": 516687082,
+        "name": "mihomo-windows-arm64-v1.19.30.zip",
+        "url": "https://github.com/MetaCubeX/mihomo/releases/download/v1.19.30/mihomo-windows-arm64-v1.19.30.zip",
+        "size": 16344535,
+        "sha256": "b37c4b0259e85b020edc4215aa4c86052e21071cf520d4800364b21b4e2fc162"
+      }
+    }
+  },
+  "geoip": {
+    "repository": "Loyalsoldier/geoip",
+    "commit": "69986b5d098c8d723a2c4d56317bc10cd5669c02",
+    "country": {
+      "name": "GeoLite2-Country.mmdb",
+      "url": "https://raw.githubusercontent.com/Loyalsoldier/geoip/69986b5d098c8d723a2c4d56317bc10cd5669c02/GeoLite2-Country.mmdb",
+      "sha256": "26a2c3c3791b36303a1c70bac18320c4e6bd40950286224a38f2756c0f7d0ca2"
+    },
+    "asn": {
+      "name": "GeoLite2-ASN.mmdb",
+      "url": "https://raw.githubusercontent.com/Loyalsoldier/geoip/69986b5d098c8d723a2c4d56317bc10cd5669c02/GeoLite2-ASN.mmdb",
+      "sha256": "82abcabdf4d0ecb34da45e4f0f9bc30bf933cfbfec446b89a2215fae5b1fdbdc"
+    }
+  }
+}

--- a/scripts/resolve-release-inputs/atomic.go
+++ b/scripts/resolve-release-inputs/atomic.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type atomicFileOps struct {
+	replace       func(string, string) error
+	syncDirectory func(string) error
+}
+
+func writeAtomic(destination string, data []byte) error {
+	return writeAtomicWithOps(destination, data, atomicFileOps{
+		replace:       replaceFile,
+		syncDirectory: syncParentDirectory,
+	})
+}
+
+func writeAtomicWithOps(destination string, data []byte, operations atomicFileOps) error {
+	if operations.replace == nil || operations.syncDirectory == nil {
+		return errors.New("atomic release input lock operations are required")
+	}
+	directory := filepath.Dir(destination)
+	if err := os.MkdirAll(directory, 0o755); err != nil {
+		return fmt.Errorf("create release input lock directory: %w", err)
+	}
+	temporary, err := os.CreateTemp(directory, "."+filepath.Base(destination)+"-*")
+	if err != nil {
+		return fmt.Errorf("create release input lock temporary file: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer func() {
+		_ = temporary.Close()
+		_ = os.Remove(temporaryPath)
+	}()
+	if err := temporary.Chmod(0o644); err != nil {
+		return fmt.Errorf("protect release input lock temporary file: %w", err)
+	}
+	if _, err := temporary.Write(data); err != nil {
+		return fmt.Errorf("write release input lock temporary file: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		return fmt.Errorf("sync release input lock temporary file: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close release input lock temporary file: %w", err)
+	}
+	if err := operations.replace(temporaryPath, destination); err != nil {
+		return fmt.Errorf("replace release input lock: %w", err)
+	}
+	// Replacement is the commit point: returning an error after it would falsely
+	// promise callers that the old reviewed lock is still active. Unix directory
+	// sync is therefore best effort; Windows durability is handled by
+	// MOVEFILE_WRITE_THROUGH in replaceFile.
+	_ = operations.syncDirectory(directory)
+	return nil
+}

--- a/scripts/resolve-release-inputs/atomic.go
+++ b/scripts/resolve-release-inputs/atomic.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -12,14 +13,23 @@ type atomicFileOps struct {
 	syncDirectory func(string) error
 }
 
-func writeAtomic(destination string, data []byte) error {
-	return writeAtomicWithOps(destination, data, atomicFileOps{
+type syncCloser interface {
+	Sync() error
+	Close() error
+}
+
+func syncAndClose(resource syncCloser) error {
+	return errors.Join(resource.Sync(), resource.Close())
+}
+
+func writeAtomic(ctx context.Context, destination string, data []byte) error {
+	return writeAtomicWithOps(ctx, destination, data, atomicFileOps{
 		replace:       replaceFile,
 		syncDirectory: syncParentDirectory,
 	})
 }
 
-func writeAtomicWithOps(destination string, data []byte, operations atomicFileOps) error {
+func writeAtomicWithOps(ctx context.Context, destination string, data []byte, operations atomicFileOps) error {
 	if operations.replace == nil || operations.syncDirectory == nil {
 		return errors.New("atomic release input lock operations are required")
 	}
@@ -47,6 +57,9 @@ func writeAtomicWithOps(destination string, data []byte, operations atomicFileOp
 	}
 	if err := temporary.Close(); err != nil {
 		return fmt.Errorf("close release input lock temporary file: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("cancel release input lock replacement: %w", err)
 	}
 	if err := operations.replace(temporaryPath, destination); err != nil {
 		return fmt.Errorf("replace release input lock: %w", err)

--- a/scripts/resolve-release-inputs/atomic_unix.go
+++ b/scripts/resolve-release-inputs/atomic_unix.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package main
+
+import "os"
+
+func replaceFile(source, destination string) error {
+	return os.Rename(source, destination)
+}
+
+func syncParentDirectory(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer directory.Close()
+	return directory.Sync()
+}

--- a/scripts/resolve-release-inputs/atomic_unix.go
+++ b/scripts/resolve-release-inputs/atomic_unix.go
@@ -13,6 +13,5 @@ func syncParentDirectory(path string) error {
 	if err != nil {
 		return err
 	}
-	defer directory.Close()
-	return directory.Sync()
+	return syncAndClose(directory)
 }

--- a/scripts/resolve-release-inputs/atomic_windows.go
+++ b/scripts/resolve-release-inputs/atomic_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package main
+
+import "golang.org/x/sys/windows"
+
+func replaceFile(source, destination string) error {
+	sourcePath, err := windows.UTF16PtrFromString(source)
+	if err != nil {
+		return err
+	}
+	destinationPath, err := windows.UTF16PtrFromString(destination)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(sourcePath, destinationPath, windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH)
+}
+
+func syncParentDirectory(string) error { return nil }

--- a/scripts/resolve-release-inputs/main.go
+++ b/scripts/resolve-release-inputs/main.go
@@ -1,0 +1,473 @@
+// Command resolve-release-inputs resolves and verifies immutable upstream inputs
+// for Mihari all-in-one release bundles. Release workflows never invoke it.
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/mihari-proxy/mihari/internal/core"
+	"github.com/mihari-proxy/mihari/scripts/internal/releaseinputs"
+)
+
+const (
+	defaultAPIBase      = "https://api.github.com"
+	defaultMihomoRepo   = "MetaCubeX/mihomo"
+	defaultGeoIPRepo    = "Loyalsoldier/geoip"
+	defaultGeoIPRef     = "release"
+	defaultOutput       = "scripts/release-inputs.lock.json"
+	maxRefResponse      = 64 << 10
+	defaultMaxDownload  = int64(128 << 20)
+	resolverHTTPTimeout = 15 * time.Minute
+	githubAPIVersion    = "2026-03-10"
+	resolverUserAgent   = "mihari-release-input-resolver"
+)
+
+type options struct {
+	Channel string
+	Out     string
+
+	GitHubToken      string
+	HTTPClient       *http.Client
+	APIBase          string
+	DownloadBase     string
+	MihomoRepository string
+	GeoIPRepository  string
+	GeoIPRef         string
+	MaxDownloadBytes int64
+}
+
+func main() {
+	os.Exit(runCLI(context.Background(), os.Args[1:], os.Stdout, os.Stderr, os.Getenv))
+}
+
+func parseOptions(args []string) (options, error) {
+	return parseOptionsTo(args, io.Discard)
+}
+
+func parseOptionsTo(args []string, output io.Writer) (options, error) {
+	flags := flag.NewFlagSet("resolve-release-inputs", flag.ContinueOnError)
+	flags.SetOutput(output)
+	var result options
+	flags.StringVar(&result.Channel, "channel", "stable", "mihomo channel: stable or alpha")
+	flags.StringVar(&result.Out, "out", defaultOutput, "release input lock output path")
+	if err := flags.Parse(args); err != nil {
+		return options{}, err
+	}
+	if flags.NArg() != 0 {
+		return options{}, errors.New("unexpected positional arguments")
+	}
+	if result.Channel != "stable" && result.Channel != "alpha" {
+		return options{}, fmt.Errorf("unsupported mihomo channel %q", result.Channel)
+	}
+	if result.Out == "" {
+		return options{}, errors.New("--out is required")
+	}
+	return result, nil
+}
+
+func runCLI(ctx context.Context, args []string, stdout, stderr io.Writer, getenv func(string) string) int {
+	return runCLIWithResolver(ctx, args, stdout, stderr, getenv, resolve)
+}
+
+func runCLIWithResolver(ctx context.Context, args []string, stdout, stderr io.Writer, getenv func(string) string, execute func(context.Context, options) error) int {
+	options, err := parseOptionsTo(args, stdout)
+	if errors.Is(err, flag.ErrHelp) {
+		return 0
+	}
+	if err != nil {
+		if _, writeErr := fmt.Fprintln(stderr, "resolve-release-inputs:", err); writeErr != nil {
+			return 1
+		}
+		return 2
+	}
+	if getenv != nil {
+		options.GitHubToken = getenv("GITHUB_TOKEN")
+	}
+	if err := execute(ctx, options); err != nil {
+		if _, writeErr := fmt.Fprintln(stderr, "resolve-release-inputs:", err); writeErr != nil {
+			return 1
+		}
+		return 1
+	}
+	return 0
+}
+
+func resolve(ctx context.Context, options options) error {
+	options = withDefaults(options)
+	if options.Channel != "stable" && options.Channel != "alpha" {
+		return fmt.Errorf("unsupported mihomo channel %q", options.Channel)
+	}
+	if options.Out == "" {
+		return errors.New("--out is required")
+	}
+
+	client := options.HTTPClient
+	if client == nil {
+		client = newHTTPClient(options.GitHubToken, options.APIBase)
+	}
+	installer := core.Installer{
+		HTTPClient: client,
+		APIBase:    options.APIBase,
+		Repository: options.MihomoRepository,
+	}
+	release, err := installer.LatestRelease(ctx, options.Channel)
+	if err != nil {
+		return fmt.Errorf("resolve mihomo release: %w", err)
+	}
+	commit, err := resolveCommit(ctx, client, options)
+	if err != nil {
+		return err
+	}
+
+	lock, selected, err := assembleLock(release, commit, options)
+	if err != nil {
+		return err
+	}
+	// Validate all identifiers and immutable public URLs before any payload I/O.
+	if err := lock.Validate(); err != nil {
+		return fmt.Errorf("validate resolved release inputs: %w", err)
+	}
+
+	for platform, asset := range selected {
+		digest, err := downloadDigest(ctx, client, mappedDownloadURL(asset.URL, options.DownloadBase), asset.Size, options.MaxDownloadBytes, asset.Digest, options.DownloadBase)
+		if err != nil {
+			return fmt.Errorf("verify mihomo %s payload: %w", platform, err)
+		}
+		entry := lock.Mihomo.Assets[platform]
+		entry.SHA256 = digest
+		lock.Mihomo.Assets[platform] = entry
+	}
+
+	countryDigest, err := downloadDigest(ctx, client, mappedDownloadURL(lock.GeoIP.Country.URL, options.DownloadBase), 0, options.MaxDownloadBytes, "", options.DownloadBase)
+	if err != nil {
+		return fmt.Errorf("verify GeoIP country payload: %w", err)
+	}
+	lock.GeoIP.Country.SHA256 = countryDigest
+	asnDigest, err := downloadDigest(ctx, client, mappedDownloadURL(lock.GeoIP.ASN.URL, options.DownloadBase), 0, options.MaxDownloadBytes, "", options.DownloadBase)
+	if err != nil {
+		return fmt.Errorf("verify GeoIP ASN payload: %w", err)
+	}
+	lock.GeoIP.ASN.SHA256 = asnDigest
+
+	data, err := releaseinputs.Encode(lock)
+	if err != nil {
+		return fmt.Errorf("encode resolved release inputs: %w", err)
+	}
+	if err := writeAtomic(options.Out, data); err != nil {
+		return err
+	}
+	return nil
+}
+
+func withDefaults(options options) options {
+	if options.Channel == "" {
+		options.Channel = "stable"
+	}
+	if options.APIBase == "" {
+		options.APIBase = defaultAPIBase
+	}
+	if options.MihomoRepository == "" {
+		options.MihomoRepository = defaultMihomoRepo
+	}
+	if options.GeoIPRepository == "" {
+		options.GeoIPRepository = defaultGeoIPRepo
+	}
+	if options.GeoIPRef == "" {
+		options.GeoIPRef = defaultGeoIPRef
+	}
+	if options.MaxDownloadBytes <= 0 {
+		options.MaxDownloadBytes = defaultMaxDownload
+	}
+	return options
+}
+
+func resolveCommit(ctx context.Context, client *http.Client, options options) (string, error) {
+	rawURL := strings.TrimRight(options.APIBase, "/") + "/repos/" + options.GeoIPRepository + "/git/ref/heads/" + url.PathEscape(options.GeoIPRef)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return "", errors.New("create GeoIP commit request")
+	}
+	setGitHubHeaders(request, options.GitHubToken)
+	response, err := client.Do(request)
+	if err != nil {
+		return "", safeNetworkError{operation: "resolve GeoIP commit", cause: err}
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("resolve GeoIP commit: unexpected HTTP status %d", response.StatusCode)
+	}
+	raw, err := io.ReadAll(io.LimitReader(response.Body, maxRefResponse+1))
+	if err != nil {
+		return "", fmt.Errorf("read GeoIP commit response: %w", err)
+	}
+	if len(raw) > maxRefResponse {
+		return "", errors.New("GeoIP ref response exceeds size limit")
+	}
+	var result struct {
+		Object struct {
+			Type string `json:"type"`
+			SHA  string `json:"sha"`
+		} `json:"object"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return "", errors.New("decode GeoIP ref response")
+	}
+	if result.Object.Type != "commit" {
+		return "", errors.New("GeoIP release branch must point directly to a commit object")
+	}
+	if !isLowerHex(result.Object.SHA, 40) {
+		return "", errors.New("GeoIP commit must be exactly 40 lowercase hexadecimal characters")
+	}
+	return result.Object.SHA, nil
+}
+
+func assembleLock(release core.Release, commit string, options options) (releaseinputs.Lock, map[string]core.Asset, error) {
+	lock := releaseinputs.Lock{
+		Schema: releaseinputs.SchemaV1,
+		Mihomo: releaseinputs.MihomoInputs{
+			Repository: options.MihomoRepository,
+			Channel:    options.Channel,
+			ReleaseID:  release.ID,
+			Tag:        release.TagName,
+			Assets:     make(map[string]releaseinputs.MihomoAsset, 6),
+		},
+		GeoIP: releaseinputs.GeoIPInputs{
+			Repository: options.GeoIPRepository,
+			Commit:     commit,
+			Country: releaseinputs.GeoIPFile{
+				Name:   "GeoLite2-Country.mmdb",
+				URL:    "https://raw.githubusercontent.com/" + options.GeoIPRepository + "/" + commit + "/GeoLite2-Country.mmdb",
+				SHA256: strings.Repeat("0", sha256.Size*2),
+			},
+			ASN: releaseinputs.GeoIPFile{
+				Name:   "GeoLite2-ASN.mmdb",
+				URL:    "https://raw.githubusercontent.com/" + options.GeoIPRepository + "/" + commit + "/GeoLite2-ASN.mmdb",
+				SHA256: strings.Repeat("0", sha256.Size*2),
+			},
+		},
+	}
+	selected := make(map[string]core.Asset, 6)
+	for _, platform := range releaseinputs.RequiredPlatforms() {
+		goos, goarch, found := strings.Cut(platform, "/")
+		if !found {
+			return releaseinputs.Lock{}, nil, errors.New("invalid required platform")
+		}
+		asset, err := selectResolverAsset(release, goos, goarch, options.Channel)
+		if err != nil {
+			return releaseinputs.Lock{}, nil, fmt.Errorf("select mihomo %s asset: %w", platform, err)
+		}
+		selected[platform] = asset
+		lock.Mihomo.Assets[platform] = releaseinputs.MihomoAsset{
+			AssetID: asset.ID,
+			Name:    asset.Name,
+			URL:     asset.URL,
+			Size:    asset.Size,
+			SHA256:  strings.Repeat("0", sha256.Size*2),
+		}
+	}
+	return lock, selected, nil
+}
+
+func selectResolverAsset(release core.Release, goos, goarch, channel string) (core.Asset, error) {
+	candidates := make([]core.Asset, 0, len(release.Assets))
+	for _, asset := range release.Assets {
+		if _, err := core.SelectAsset(core.Release{TagName: release.TagName, Assets: []core.Asset{asset}}, goos, goarch, channel); err == nil {
+			candidates = append(candidates, asset)
+		}
+	}
+	if len(candidates) == 0 {
+		return core.Asset{}, fmt.Errorf("mihomo release has no compatible %s/%s asset", goos, goarch)
+	}
+	preferred := preferredStableAssetName(goos, goarch, release.TagName)
+	sort.Slice(candidates, func(leftIndex, rightIndex int) bool {
+		left := candidates[leftIndex]
+		right := candidates[rightIndex]
+		leftPreferred := channel != "alpha" && strings.EqualFold(left.Name, preferred)
+		rightPreferred := channel != "alpha" && strings.EqualFold(right.Name, preferred)
+		if leftPreferred != rightPreferred {
+			return leftPreferred
+		}
+		leftName := strings.ToLower(left.Name)
+		rightName := strings.ToLower(right.Name)
+		if leftName != rightName {
+			return leftName < rightName
+		}
+		if left.ID != right.ID {
+			return left.ID < right.ID
+		}
+		if left.URL != right.URL {
+			return left.URL < right.URL
+		}
+		if left.Size != right.Size {
+			return left.Size < right.Size
+		}
+		return left.Digest < right.Digest
+	})
+	return candidates[0], nil
+}
+
+func preferredStableAssetName(goos, goarch, tag string) string {
+	extension := ".gz"
+	if goos == "windows" {
+		extension = ".zip"
+	}
+	variant := ""
+	if goarch == "amd64" {
+		variant = "-compatible"
+	}
+	return "mihomo-" + strings.ToLower(goos) + "-" + strings.ToLower(goarch) + variant + "-" + tag + extension
+}
+
+func downloadDigest(ctx context.Context, client *http.Client, rawURL string, expectedSize, maxBytes int64, upstreamDigest, testBase string) (string, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return "", errors.New("create payload request")
+	}
+	request.Header.Set("User-Agent", resolverUserAgent)
+	response, err := client.Do(request)
+	if err != nil {
+		return "", safeNetworkError{operation: "download payload", cause: err}
+	}
+	defer response.Body.Close()
+	if err := validateFinalDownloadURL(response.Request.URL, testBase); err != nil {
+		return "", err
+	}
+	if response.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download payload: unexpected HTTP status %d", response.StatusCode)
+	}
+	if response.ContentLength > maxBytes {
+		return "", errors.New("payload exceeds size limit")
+	}
+	hash := sha256.New()
+	written, err := io.Copy(hash, io.LimitReader(response.Body, maxBytes+1))
+	if err != nil {
+		return "", fmt.Errorf("download payload: %w", err)
+	}
+	if written > maxBytes {
+		return "", errors.New("payload exceeds size limit")
+	}
+	if expectedSize > 0 && written != expectedSize {
+		return "", errors.New("payload size mismatch")
+	}
+	digest := hex.EncodeToString(hash.Sum(nil))
+	if upstreamDigest != "" {
+		algorithm, expected, found := strings.Cut(upstreamDigest, ":")
+		if !found || algorithm != "sha256" || !isLowerHex(expected, sha256.Size*2) {
+			return "", errors.New("unsupported upstream payload digest")
+		}
+		if digest != expected {
+			return "", errors.New("payload digest mismatch")
+		}
+	}
+	return digest, nil
+}
+
+type safeNetworkError struct {
+	operation string
+	cause     error
+}
+
+func (failure safeNetworkError) Error() string {
+	return failure.operation + " failed"
+}
+
+func (failure safeNetworkError) Unwrap() error {
+	return failure.cause
+}
+
+func validateFinalDownloadURL(final *url.URL, testBase string) error {
+	if final == nil || final.User != nil {
+		return errors.New("payload redirect target is not approved")
+	}
+	if testBase == "" {
+		if final.Scheme != "https" {
+			return errors.New("payload redirect must preserve HTTPS")
+		}
+		return nil
+	}
+	base, err := url.Parse(testBase)
+	if err != nil || final.Scheme != base.Scheme || final.Host != base.Host {
+		return errors.New("payload redirect escaped the injected download origin")
+	}
+	return nil
+}
+
+func mappedDownloadURL(rawURL, downloadBase string) string {
+	if downloadBase == "" {
+		return rawURL
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	return strings.TrimRight(downloadBase, "/") + parsed.EscapedPath()
+}
+
+func newHTTPClient(token, apiBase string) *http.Client {
+	transport := http.DefaultTransport
+	if token != "" {
+		parsed, _ := url.Parse(apiBase)
+		transport = bearerTransport{base: transport, token: token, allowedHost: parsed.Host}
+	}
+	return &http.Client{Timeout: resolverHTTPTimeout, Transport: transport, CheckRedirect: redirectPolicy}
+}
+
+type bearerTransport struct {
+	base        http.RoundTripper
+	token       string
+	allowedHost string
+}
+
+func (transport bearerTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	cloned := request.Clone(request.Context())
+	if cloned.URL.Host == transport.allowedHost {
+		cloned.Header.Set("Authorization", "Bearer "+transport.token)
+	} else {
+		cloned.Header.Del("Authorization")
+	}
+	return transport.base.RoundTrip(cloned)
+}
+
+func redirectPolicy(request *http.Request, previous []*http.Request) error {
+	if len(previous) >= 10 {
+		return errors.New("stopped after 10 redirects")
+	}
+	if len(previous) > 0 && previous[len(previous)-1].URL.Scheme == "https" && request.URL.Scheme != "https" {
+		return errors.New("payload redirect must preserve HTTPS")
+	}
+	return nil
+}
+
+func setGitHubHeaders(request *http.Request, token string) {
+	request.Header.Set("Accept", "application/vnd.github+json")
+	request.Header.Set("X-GitHub-Api-Version", githubAPIVersion)
+	request.Header.Set("User-Agent", resolverUserAgent)
+	if token != "" {
+		request.Header.Set("Authorization", "Bearer "+token)
+	}
+}
+
+func isLowerHex(value string, length int) bool {
+	if len(value) != length {
+		return false
+	}
+	for _, character := range value {
+		if (character < '0' || character > '9') && (character < 'a' || character > 'f') {
+			return false
+		}
+	}
+	return true
+}

--- a/scripts/resolve-release-inputs/main.go
+++ b/scripts/resolve-release-inputs/main.go
@@ -116,7 +116,11 @@ func resolve(ctx context.Context, options options) error {
 
 	client := options.HTTPClient
 	if client == nil {
-		client = newHTTPClient(options.GitHubToken, options.APIBase)
+		var err error
+		client, err = newHTTPClient(options.GitHubToken, options.APIBase)
+		if err != nil {
+			return err
+		}
 	}
 	installer := core.Installer{
 		HTTPClient: client,
@@ -142,7 +146,7 @@ func resolve(ctx context.Context, options options) error {
 	}
 
 	for platform, asset := range selected {
-		digest, err := downloadDigest(ctx, client, mappedDownloadURL(asset.URL, options.DownloadBase), asset.Size, options.MaxDownloadBytes, asset.Digest, options.DownloadBase)
+		digest, err := downloadDigest(ctx, client, mappedDownloadURL(asset.URL, options.DownloadBase), asset.Size, options.MaxDownloadBytes, asset.Digest, mihomoPayload, options.DownloadBase)
 		if err != nil {
 			return fmt.Errorf("verify mihomo %s payload: %w", platform, err)
 		}
@@ -151,12 +155,12 @@ func resolve(ctx context.Context, options options) error {
 		lock.Mihomo.Assets[platform] = entry
 	}
 
-	countryDigest, err := downloadDigest(ctx, client, mappedDownloadURL(lock.GeoIP.Country.URL, options.DownloadBase), 0, options.MaxDownloadBytes, "", options.DownloadBase)
+	countryDigest, err := downloadDigest(ctx, client, mappedDownloadURL(lock.GeoIP.Country.URL, options.DownloadBase), 0, options.MaxDownloadBytes, "", geoIPPayload, options.DownloadBase)
 	if err != nil {
 		return fmt.Errorf("verify GeoIP country payload: %w", err)
 	}
 	lock.GeoIP.Country.SHA256 = countryDigest
-	asnDigest, err := downloadDigest(ctx, client, mappedDownloadURL(lock.GeoIP.ASN.URL, options.DownloadBase), 0, options.MaxDownloadBytes, "", options.DownloadBase)
+	asnDigest, err := downloadDigest(ctx, client, mappedDownloadURL(lock.GeoIP.ASN.URL, options.DownloadBase), 0, options.MaxDownloadBytes, "", geoIPPayload, options.DownloadBase)
 	if err != nil {
 		return fmt.Errorf("verify GeoIP ASN payload: %w", err)
 	}
@@ -166,7 +170,7 @@ func resolve(ctx context.Context, options options) error {
 	if err != nil {
 		return fmt.Errorf("encode resolved release inputs: %w", err)
 	}
-	if err := writeAtomic(options.Out, data); err != nil {
+	if err := writeAtomic(ctx, options.Out, data); err != nil {
 		return err
 	}
 	return nil
@@ -331,18 +335,49 @@ func preferredStableAssetName(goos, goarch, tag string) string {
 	return "mihomo-" + strings.ToLower(goos) + "-" + strings.ToLower(goarch) + variant + "-" + tag + extension
 }
 
-func downloadDigest(ctx context.Context, client *http.Client, rawURL string, expectedSize, maxBytes int64, upstreamDigest, testBase string) (string, error) {
+type payloadSource uint8
+
+const (
+	mihomoPayload payloadSource = iota + 1
+	geoIPPayload
+)
+
+func downloadDigest(ctx context.Context, client *http.Client, rawURL string, expectedSize, maxBytes int64, upstreamDigest string, source payloadSource, testBase string) (string, error) {
+	policy, err := newPayloadURLPolicy(source, testBase)
+	if err != nil {
+		return "", err
+	}
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
 		return "", errors.New("create payload request")
 	}
+	if err := policy.validate(request.URL); err != nil {
+		return "", err
+	}
 	request.Header.Set("User-Agent", resolverUserAgent)
-	response, err := client.Do(request)
+	downloadClient := *client
+	baseRedirect := client.CheckRedirect
+	downloadClient.CheckRedirect = func(next *http.Request, previous []*http.Request) error {
+		if len(previous) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		if err := policy.validate(next.URL); err != nil {
+			return err
+		}
+		if baseRedirect != nil {
+			return baseRedirect(next, previous)
+		}
+		return nil
+	}
+	response, err := downloadClient.Do(request)
 	if err != nil {
 		return "", safeNetworkError{operation: "download payload", cause: err}
 	}
 	defer response.Body.Close()
-	if err := validateFinalDownloadURL(response.Request.URL, testBase); err != nil {
+	if response.Request == nil {
+		return "", errors.New("payload response URL is unavailable")
+	}
+	if err := policy.validate(response.Request.URL); err != nil {
 		return "", err
 	}
 	if response.StatusCode != http.StatusOK {
@@ -388,19 +423,52 @@ func (failure safeNetworkError) Unwrap() error {
 	return failure.cause
 }
 
-func validateFinalDownloadURL(final *url.URL, testBase string) error {
-	if final == nil || final.User != nil {
-		return errors.New("payload redirect target is not approved")
+type payloadURLPolicy struct {
+	source     payloadSource
+	testOrigin *url.URL
+}
+
+func newPayloadURLPolicy(source payloadSource, testBase string) (payloadURLPolicy, error) {
+	if source != mihomoPayload && source != geoIPPayload {
+		return payloadURLPolicy{}, errors.New("payload source is unsupported")
 	}
+	policy := payloadURLPolicy{source: source}
 	if testBase == "" {
-		if final.Scheme != "https" {
-			return errors.New("payload redirect must preserve HTTPS")
+		return policy, nil
+	}
+	base, err := url.Parse(testBase)
+	if err != nil || strings.Contains(testBase, "#") || !base.IsAbs() || (base.Scheme != "http" && base.Scheme != "https") || base.Host == "" || base.User != nil || base.Opaque != "" || base.RawQuery != "" || base.ForceQuery || base.Fragment != "" {
+		return payloadURLPolicy{}, errors.New("injected payload origin is invalid")
+	}
+	policy.testOrigin = base
+	return policy, nil
+}
+
+func (policy payloadURLPolicy) validate(candidate *url.URL) error {
+	if candidate == nil || candidate.User != nil || candidate.Opaque != "" {
+		return errors.New("payload URL is not approved")
+	}
+	if policy.testOrigin != nil {
+		if candidate.Scheme != policy.testOrigin.Scheme || candidate.Host != policy.testOrigin.Host {
+			return errors.New("payload redirect escaped the injected download origin")
 		}
 		return nil
 	}
-	base, err := url.Parse(testBase)
-	if err != nil || final.Scheme != base.Scheme || final.Host != base.Host {
-		return errors.New("payload redirect escaped the injected download origin")
+	if candidate.Scheme != "https" || candidate.Port() != "" {
+		return errors.New("payload URL must use an approved HTTPS host")
+	}
+	host := strings.ToLower(candidate.Hostname())
+	switch policy.source {
+	case geoIPPayload:
+		if host != "raw.githubusercontent.com" {
+			return errors.New("GeoIP payload URL host is not approved")
+		}
+	case mihomoPayload:
+		if host != "github.com" && host != "release-assets.githubusercontent.com" && host != "objects.githubusercontent.com" {
+			return errors.New("mihomo payload URL host is not approved")
+		}
+	default:
+		return errors.New("payload source is unsupported")
 	}
 	return nil
 }
@@ -416,13 +484,16 @@ func mappedDownloadURL(rawURL, downloadBase string) string {
 	return strings.TrimRight(downloadBase, "/") + parsed.EscapedPath()
 }
 
-func newHTTPClient(token, apiBase string) *http.Client {
+func newHTTPClient(token, apiBase string) (*http.Client, error) {
+	parsed, err := url.Parse(apiBase)
+	if err != nil || strings.Contains(apiBase, "#") || !parsed.IsAbs() || parsed.Scheme != "https" || parsed.Host == "" || parsed.User != nil || parsed.Opaque != "" || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
+		return nil, errors.New("GitHub API base must be an absolute HTTPS URL without credentials, query, or fragment")
+	}
 	transport := http.DefaultTransport
 	if token != "" {
-		parsed, _ := url.Parse(apiBase)
 		transport = bearerTransport{base: transport, token: token, allowedHost: parsed.Host}
 	}
-	return &http.Client{Timeout: resolverHTTPTimeout, Transport: transport, CheckRedirect: redirectPolicy}
+	return &http.Client{Timeout: resolverHTTPTimeout, Transport: transport, CheckRedirect: redirectPolicy}, nil
 }
 
 type bearerTransport struct {

--- a/scripts/resolve-release-inputs/main_test.go
+++ b/scripts/resolve-release-inputs/main_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/mihari-proxy/mihari/internal/core"
@@ -363,7 +364,7 @@ func TestWriteAtomicReplaceFailurePreservesExistingFileAndCleansTemporary(t *tes
 		t.Fatal(err)
 	}
 	var source, target string
-	err := writeAtomicWithOps(destination, []byte("new\n"), atomicFileOps{
+	err := writeAtomicWithOps(context.Background(), destination, []byte("new\n"), atomicFileOps{
 		replace: func(candidate, output string) error {
 			source, target = candidate, output
 			return errors.New("replace denied")
@@ -393,7 +394,7 @@ func TestWriteAtomicSyncFailureIsBestEffortAfterSuccessfulReplacement(t *testing
 		t.Fatal(err)
 	}
 	syncCalled := false
-	err := writeAtomicWithOps(destination, []byte("new\n"), atomicFileOps{
+	err := writeAtomicWithOps(context.Background(), destination, []byte("new\n"), atomicFileOps{
 		replace: replaceFile,
 		syncDirectory: func(path string) error {
 			syncCalled = true
@@ -414,6 +415,68 @@ func TestWriteAtomicSyncFailureIsBestEffortAfterSuccessfulReplacement(t *testing
 		t.Fatalf("destination after sync failure = %q, %v", got, readErr)
 	}
 	assertNoLockTemporaries(t, directory)
+}
+
+func TestWriteAtomicCancellationBeforeCommitPreservesExistingFile(t *testing.T) {
+	directory := t.TempDir()
+	destination := filepath.Join(directory, "release-inputs.lock.json")
+	if err := os.WriteFile(destination, []byte("old\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	replaceCalled := false
+	err := writeAtomicWithOps(ctx, destination, []byte("new\n"), atomicFileOps{
+		replace: func(string, string) error {
+			replaceCalled = true
+			return nil
+		},
+		syncDirectory: func(string) error {
+			t.Fatal("syncDirectory called without a committed replacement")
+			return nil
+		},
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("writeAtomicWithOps error = %v, want context cancellation", err)
+	}
+	if replaceCalled {
+		t.Fatal("writeAtomicWithOps called replace after cancellation")
+	}
+	got, readErr := os.ReadFile(destination)
+	if readErr != nil || string(got) != "old\n" {
+		t.Fatalf("destination after cancellation = %q, %v", got, readErr)
+	}
+	assertNoLockTemporaries(t, directory)
+}
+
+func TestSyncAndCloseJoinsBothErrors(t *testing.T) {
+	syncErr := errors.New("sync failed")
+	closeErr := errors.New("close failed")
+	resource := &syncCloseFixture{syncErr: syncErr, closeErr: closeErr}
+	err := syncAndClose(resource)
+	if !errors.Is(err, syncErr) || !errors.Is(err, closeErr) {
+		t.Fatalf("syncAndClose error = %v, want both sync and close causes", err)
+	}
+	if resource.syncCalls != 1 || resource.closeCalls != 1 {
+		t.Fatalf("calls = sync %d, close %d; want one each", resource.syncCalls, resource.closeCalls)
+	}
+}
+
+type syncCloseFixture struct {
+	syncErr    error
+	closeErr   error
+	syncCalls  int
+	closeCalls int
+}
+
+func (fixture *syncCloseFixture) Sync() error {
+	fixture.syncCalls++
+	return fixture.syncErr
+}
+
+func (fixture *syncCloseFixture) Close() error {
+	fixture.closeCalls++
+	return fixture.closeErr
 }
 
 func assertNoLockTemporaries(t *testing.T, directory string) {
@@ -442,7 +505,7 @@ func TestNetworkErrorsRedactURLsAndPreserveContextCause(t *testing.T) {
 		{
 			name: "download payload",
 			run: func(client *http.Client) error {
-				_, err := downloadDigest(context.Background(), client, "https://github.com/MetaCubeX/mihomo/releases/download/v1.19.30/asset.gz", 0, 1024, "", "")
+				_, err := downloadDigest(context.Background(), client, "https://github.com/MetaCubeX/mihomo/releases/download/v1.19.30/asset.gz", 0, 1024, "", mihomoPayload, "")
 				return err
 			},
 		},
@@ -497,6 +560,159 @@ func TestResolveRejectsUnapprovedAssetURLBeforeDownload(t *testing.T) {
 		}
 	}
 }
+
+func TestResolveRejectsCrossOriginHTTPSRedirectBeforePayloadRequest(t *testing.T) {
+	var evilHits atomic.Int32
+	evil := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		evilHits.Add(1)
+		_, _ = response.Write([]byte("evil-payload"))
+	}))
+	defer evil.Close()
+	fixture := newResolverFixture(t)
+	fixture.override = func(response http.ResponseWriter, request *http.Request) bool {
+		if strings.Contains(request.URL.Path, "mihomo-darwin-amd64-compatible") {
+			http.Redirect(response, request, evil.URL+"/signed?token=secret-value", http.StatusFound)
+			return true
+		}
+		return false
+	}
+	directory := t.TempDir()
+	out := filepath.Join(directory, "release-inputs.lock.json")
+	if err := os.WriteFile(out, []byte("old\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	resolverOptions := fixture.options(out)
+	resolverOptions.HTTPClient = evil.Client()
+	err := resolve(context.Background(), resolverOptions)
+	if err == nil {
+		t.Fatal("resolve accepted cross-origin HTTPS payload redirect")
+	}
+	for _, secret := range []string{"secret-value", evil.URL, "token="} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("redirect error leaked %q: %v", secret, err)
+		}
+	}
+	if evilHits.Load() != 0 {
+		t.Fatalf("cross-origin redirect target received %d requests, want 0", evilHits.Load())
+	}
+	got, readErr := os.ReadFile(out)
+	if readErr != nil || string(got) != "old\n" {
+		t.Fatalf("lock after rejected redirect = %q, %v", got, readErr)
+	}
+	assertNoLockTemporaries(t, directory)
+}
+
+func TestDownloadDigestRejectsUnapprovedFinalURLBeforeReadingBody(t *testing.T) {
+	body := &readTrackingBody{reader: strings.NewReader("evil-payload")}
+	finalURL, err := url.Parse("https://evil.example/signed?token=secret-value")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       body,
+			Request:    &http.Request{URL: finalURL},
+		}, nil
+	})}
+	_, err = downloadDigest(
+		context.Background(),
+		client,
+		"https://raw.githubusercontent.com/Loyalsoldier/geoip/0123456789abcdef0123456789abcdef01234567/GeoLite2-Country.mmdb",
+		0,
+		1024,
+		"",
+		geoIPPayload,
+		"",
+	)
+	if err == nil {
+		t.Fatal("downloadDigest accepted unapproved final URL")
+	}
+	if body.readCalls != 0 {
+		t.Fatalf("unapproved response body read %d times, want 0", body.readCalls)
+	}
+	for _, secret := range []string{"evil.example", "secret-value", "token="} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("final URL error leaked %q: %v", secret, err)
+		}
+	}
+}
+
+func TestPayloadURLPolicyProductionHostContract(t *testing.T) {
+	valid := []struct {
+		name   string
+		source payloadSource
+		rawURL string
+	}{
+		{name: "mihomo release page", source: mihomoPayload, rawURL: "https://github.com/MetaCubeX/mihomo/releases/download/v1.19.30/core.gz"},
+		{name: "mihomo release assets", source: mihomoPayload, rawURL: "https://release-assets.githubusercontent.com/github-production-release-asset/123/core.gz?sig=signed"},
+		{name: "mihomo objects", source: mihomoPayload, rawURL: "https://objects.githubusercontent.com/github-production-release-asset/core.gz?sig=signed"},
+		{name: "GeoIP raw content", source: geoIPPayload, rawURL: "https://raw.githubusercontent.com/Loyalsoldier/geoip/0123456789abcdef0123456789abcdef01234567/GeoLite2-Country.mmdb"},
+	}
+	for _, test := range valid {
+		t.Run("accept/"+test.name, func(t *testing.T) {
+			policy, err := newPayloadURLPolicy(test.source, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			candidate, err := url.Parse(test.rawURL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := policy.validate(candidate); err != nil {
+				t.Fatalf("validate(%q): %v", test.rawURL, err)
+			}
+		})
+	}
+
+	invalid := []struct {
+		name   string
+		source payloadSource
+		rawURL string
+	}{
+		{name: "mihomo cannot use GeoIP host", source: mihomoPayload, rawURL: "https://raw.githubusercontent.com/MetaCubeX/mihomo/core.gz"},
+		{name: "GeoIP cannot use GitHub release host", source: geoIPPayload, rawURL: "https://github.com/Loyalsoldier/geoip/file.mmdb"},
+		{name: "evil host", source: mihomoPayload, rawURL: "https://evil.example/payload?token=secret-value"},
+		{name: "subdomain spoof", source: mihomoPayload, rawURL: "https://github.com.evil.example/payload"},
+		{name: "port", source: mihomoPayload, rawURL: "https://github.com:443/payload"},
+		{name: "HTTP", source: mihomoPayload, rawURL: "http://github.com/payload"},
+		{name: "userinfo", source: mihomoPayload, rawURL: "https://secret-user@github.com/payload"},
+		{name: "GeoIP subdomain spoof", source: geoIPPayload, rawURL: "https://raw.githubusercontent.com.evil.example/file.mmdb"},
+	}
+	for _, test := range invalid {
+		t.Run("reject/"+test.name, func(t *testing.T) {
+			policy, err := newPayloadURLPolicy(test.source, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			candidate, err := url.Parse(test.rawURL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = policy.validate(candidate)
+			if err == nil {
+				t.Fatalf("validate accepted %q", test.rawURL)
+			}
+			for _, sensitive := range []string{test.rawURL, "secret-value", "secret-user", "evil.example"} {
+				if strings.Contains(err.Error(), sensitive) {
+					t.Fatalf("policy error leaked %q: %v", sensitive, err)
+				}
+			}
+		})
+	}
+}
+
+type readTrackingBody struct {
+	reader    *strings.Reader
+	readCalls int
+}
+
+func (body *readTrackingBody) Read(destination []byte) (int, error) {
+	body.readCalls++
+	return body.reader.Read(destination)
+}
+
+func (*readTrackingBody) Close() error { return nil }
 
 func TestResolvePropagatesCanceledDownloadContextAndPreservesOutput(t *testing.T) {
 	fixture := newResolverFixture(t)
@@ -676,6 +892,57 @@ func TestBearerTransportDoesNotSendTokenToPayloadHosts(t *testing.T) {
 	}
 	if len(headers) != 2 || headers[0] != "Bearer secret-token" || headers[1] != "" {
 		t.Fatalf("authorization headers = %q, want token only for API host", headers)
+	}
+}
+
+func TestNewHTTPClientRejectsUnsafeAPIBase(t *testing.T) {
+	tests := []string{
+		"://malformed-token",
+		"/relative/api",
+		"http://api.github.com",
+		"https:///missing-host",
+		"https://user-secret@api.github.com",
+		"https://api.github.com?token=secret-value",
+		"https://api.github.com#secret-fragment",
+		"https://api.github.com#",
+	}
+	for _, rawBase := range tests {
+		t.Run(strings.ReplaceAll(rawBase, "/", "_"), func(t *testing.T) {
+			client, err := newHTTPClient("environment-secret", rawBase)
+			if err == nil || client != nil {
+				t.Fatalf("newHTTPClient(%q) = %#v, %v; want rejection", rawBase, client, err)
+			}
+			for _, secret := range []string{rawBase, "malformed-token", "user-secret", "secret-value", "secret-fragment", "environment-secret"} {
+				if strings.Contains(err.Error(), secret) {
+					t.Fatalf("API base error leaked %q: %v", secret, err)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveRejectsUnsafeAPIBaseWithoutMutatingLock(t *testing.T) {
+	for _, rawBase := range []string{"://malformed-token", "/relative/api", "http://api.github.com", "https://user-secret@api.github.com", "https://api.github.com?token=secret-value"} {
+		t.Run(strings.ReplaceAll(rawBase, "/", "_"), func(t *testing.T) {
+			destination := filepath.Join(t.TempDir(), "release-inputs.lock.json")
+			if err := os.WriteFile(destination, []byte("old\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			err := resolve(context.Background(), options{Out: destination, APIBase: rawBase, GitHubToken: "environment-secret"})
+			if err == nil {
+				t.Fatalf("resolve accepted unsafe API base %q", rawBase)
+			}
+			for _, secret := range []string{rawBase, "malformed-token", "user-secret", "secret-value", "environment-secret"} {
+				if strings.Contains(err.Error(), secret) {
+					t.Fatalf("resolve API base error leaked %q: %v", secret, err)
+				}
+			}
+			got, readErr := os.ReadFile(destination)
+			if readErr != nil || string(got) != "old\n" {
+				t.Fatalf("lock after unsafe API base = %q, %v", got, readErr)
+			}
+			assertNoLockTemporaries(t, filepath.Dir(destination))
+		})
 	}
 }
 

--- a/scripts/resolve-release-inputs/main_test.go
+++ b/scripts/resolve-release-inputs/main_test.go
@@ -1,0 +1,686 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/mihari-proxy/mihari/internal/core"
+	"github.com/mihari-proxy/mihari/scripts/internal/releaseinputs"
+)
+
+const fixtureCommit = "0123456789abcdef0123456789abcdef01234567"
+
+type resolverFixture struct {
+	server       *httptest.Server
+	assets       []fixtureAsset
+	requestsMu   sync.Mutex
+	requests     []string
+	override     func(http.ResponseWriter, *http.Request) bool
+	releaseEdit  func(*core.Release)
+	commitSHA    string
+	commitType   string
+	blockPayload string
+	payloadStart chan struct{}
+}
+
+type fixtureAsset struct {
+	platform string
+	id       int64
+	name     string
+	payload  string
+	digest   string
+}
+
+func newResolverFixture(t *testing.T) *resolverFixture {
+	t.Helper()
+	fixture := &resolverFixture{
+		commitSHA:    fixtureCommit,
+		commitType:   "commit",
+		payloadStart: make(chan struct{}),
+		assets: []fixtureAsset{
+			{platform: "darwin/amd64", id: 101, name: "mihomo-darwin-amd64-compatible-v1.19.30.gz", payload: "darwin-amd64", digest: "5fc18e80e71334e0ced23b751a1b626ad0a806e097ba20202032db5e05923e3f"},
+			{platform: "darwin/arm64", id: 102, name: "mihomo-darwin-arm64-v1.19.30.gz", payload: "darwin-arm64", digest: "1a349b12b50ad5b43740e0952adc33c7805ce06f091074be977624d09ed9d432"},
+			{platform: "linux/amd64", id: 103, name: "mihomo-linux-amd64-compatible-v1.19.30.gz", payload: "linux-amd64", digest: "abb35c616421af72198ad7c2aeeef38516f08f6a7afb2a728cf0068a8a712ddc"},
+			{platform: "linux/arm64", id: 104, name: "mihomo-linux-arm64-v1.19.30.gz", payload: "linux-arm64", digest: "17d46d4991b2edd5e445342a72ba0cb7cf09e4849b5e98c16408ce11e05c7388"},
+			{platform: "windows/amd64", id: 105, name: "mihomo-windows-amd64-compatible-v1.19.30.zip", payload: "windows-amd64", digest: "b5c168db719e3a66397ce14e1907340ebdb78b910c98df897c665a1a74804190"},
+			{platform: "windows/arm64", id: 106, name: "mihomo-windows-arm64-v1.19.30.zip", payload: "windows-arm64", digest: "604d41bacaf2d2d45aa875439af0ee31dc84692ae22365e6111e38a3310c1c01"},
+		},
+	}
+	fixture.server = httptest.NewServer(http.HandlerFunc(fixture.serveHTTP))
+	t.Cleanup(fixture.server.Close)
+	return fixture
+}
+
+func (f *resolverFixture) serveHTTP(response http.ResponseWriter, request *http.Request) {
+	f.requestsMu.Lock()
+	f.requests = append(f.requests, request.URL.Path)
+	f.requestsMu.Unlock()
+	if f.override != nil && f.override(response, request) {
+		return
+	}
+	switch request.URL.Path {
+	case "/repos/MetaCubeX/mihomo/releases/latest":
+		release := core.Release{ID: 77, TagName: "v1.19.30"}
+		for _, asset := range f.assets {
+			release.Assets = append(release.Assets, core.Asset{
+				ID: asset.id, Name: asset.name,
+				URL:  "https://github.com/MetaCubeX/mihomo/releases/download/v1.19.30/" + asset.name,
+				Size: int64(len(asset.payload)), Digest: "sha256:" + asset.digest,
+			})
+		}
+		if f.releaseEdit != nil {
+			f.releaseEdit(&release)
+		}
+		_ = json.NewEncoder(response).Encode(release)
+	case "/repos/Loyalsoldier/geoip/git/ref/heads/release":
+		_ = json.NewEncoder(response).Encode(map[string]any{"object": map[string]string{"type": f.commitType, "sha": f.commitSHA}})
+	case "/Loyalsoldier/geoip/" + fixtureCommit + "/GeoLite2-Country.mmdb":
+		_, _ = response.Write([]byte("country-mmdb"))
+	case "/Loyalsoldier/geoip/" + fixtureCommit + "/GeoLite2-ASN.mmdb":
+		_, _ = response.Write([]byte("asn-mmdb"))
+	default:
+		for _, asset := range f.assets {
+			if request.URL.Path == "/MetaCubeX/mihomo/releases/download/v1.19.30/"+asset.name {
+				if f.blockPayload == asset.platform {
+					close(f.payloadStart)
+					<-request.Context().Done()
+					return
+				}
+				_, _ = response.Write([]byte(asset.payload))
+				return
+			}
+		}
+		http.NotFound(response, request)
+	}
+}
+
+func (f *resolverFixture) options(out string) options {
+	return options{
+		Channel: "stable", Out: out, HTTPClient: f.server.Client(), APIBase: f.server.URL,
+		DownloadBase: f.server.URL,
+	}
+}
+
+func (f *resolverFixture) requestCount(path string) int {
+	f.requestsMu.Lock()
+	defer f.requestsMu.Unlock()
+	count := 0
+	for _, request := range f.requests {
+		if request == path {
+			count++
+		}
+	}
+	return count
+}
+
+func TestResolveWritesCanonicalLockForExactlySixPlatforms(t *testing.T) {
+	fixture := newResolverFixture(t)
+	out := filepath.Join(t.TempDir(), "release-inputs.lock.json")
+
+	options := fixture.options(out)
+	if err := resolve(context.Background(), options); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	lock, err := releaseinputs.Load(out)
+	if err != nil {
+		t.Fatalf("load resolved lock: %v", err)
+	}
+	if lock.Mihomo.ReleaseID != 77 || lock.Mihomo.Tag != "v1.19.30" {
+		t.Fatalf("mihomo release = ID %d tag %q, want 77 v1.19.30", lock.Mihomo.ReleaseID, lock.Mihomo.Tag)
+	}
+	if len(lock.Mihomo.Assets) != 6 {
+		t.Fatalf("asset count = %d, want 6", len(lock.Mihomo.Assets))
+	}
+	for _, asset := range fixture.assets {
+		got, ok := lock.Mihomo.Assets[asset.platform]
+		if !ok {
+			t.Fatalf("missing platform %q", asset.platform)
+		}
+		if got.AssetID != asset.id || got.Name != asset.name || got.SHA256 != asset.digest {
+			t.Fatalf("asset %s = %#v, want ID %d name %q digest %q", asset.platform, got, asset.id, asset.name, asset.digest)
+		}
+	}
+	if lock.GeoIP.Commit != fixtureCommit {
+		t.Fatalf("GeoIP commit = %q, want %q", lock.GeoIP.Commit, fixtureCommit)
+	}
+	if lock.GeoIP.Country.SHA256 != "c28f761f7671a73f31faf731060c838eba4b0ce12c5fe75242148503ee011518" {
+		t.Fatalf("country digest = %q", lock.GeoIP.Country.SHA256)
+	}
+	if lock.GeoIP.ASN.SHA256 != "c7bd6ecba06b61885f05e59fd15b6c19fed9aad8666c9fa074bd6c222ae592a0" {
+		t.Fatalf("ASN digest = %q", lock.GeoIP.ASN.SHA256)
+	}
+	raw, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := releaseinputs.Encode(lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != string(want) {
+		t.Fatal("resolved lock is not canonical releaseinputs JSON")
+	}
+	if fixture.requestCount("/repos/MetaCubeX/mihomo/releases/latest") != 1 || fixture.requestCount("/repos/Loyalsoldier/geoip/git/ref/heads/release") != 1 {
+		t.Fatal("resolver did not resolve each upstream revision exactly once")
+	}
+}
+
+func TestSelectResolverAssetIsOrderIndependentAndPrefersReviewedVariants(t *testing.T) {
+	tests := []struct {
+		name   string
+		goos   string
+		goarch string
+		assets []core.Asset
+		want   string
+	}{
+		{
+			name: "arm64 standard over specialized Go toolchains", goos: "darwin", goarch: "arm64",
+			assets: []core.Asset{
+				{ID: 1, Name: "mihomo-darwin-arm64-go120-v1.19.30.gz"},
+				{ID: 2, Name: "mihomo-darwin-arm64-v1.19.30.gz"},
+				{ID: 3, Name: "mihomo-darwin-arm64-go122-v1.19.30.gz"},
+			},
+			want: "mihomo-darwin-arm64-v1.19.30.gz",
+		},
+		{
+			name: "amd64 compatible over other variants", goos: "linux", goarch: "amd64",
+			assets: []core.Asset{
+				{ID: 4, Name: "mihomo-linux-amd64-v3-v1.19.30.gz"},
+				{ID: 5, Name: "mihomo-linux-amd64-compatible-v1.19.30.gz"},
+				{ID: 6, Name: "mihomo-linux-amd64-go120-v1.19.30.gz"},
+			},
+			want: "mihomo-linux-amd64-compatible-v1.19.30.gz",
+		},
+		{
+			name: "fallback is lexical instead of API order", goos: "linux", goarch: "arm64",
+			assets: []core.Asset{
+				{ID: 7, Name: "mihomo-linux-arm64-go124-v1.19.30.gz"},
+				{ID: 8, Name: "mihomo-linux-arm64-go120-v1.19.30.gz"},
+			},
+			want: "mihomo-linux-arm64-go120-v1.19.30.gz",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for _, assets := range [][]core.Asset{test.assets, reversedAssets(test.assets)} {
+				release := core.Release{TagName: "v1.19.30", Assets: assets}
+				got, err := selectResolverAsset(release, test.goos, test.goarch, "stable")
+				if err != nil {
+					t.Fatalf("selectResolverAsset: %v", err)
+				}
+				if got.Name != test.want {
+					t.Fatalf("selected %q, want %q", got.Name, test.want)
+				}
+			}
+		})
+	}
+}
+
+func reversedAssets(input []core.Asset) []core.Asset {
+	result := make([]core.Asset, len(input))
+	for index := range input {
+		result[len(input)-1-index] = input[index]
+	}
+	return result
+}
+
+func TestResolveRejectsInvalidGeoIPCommitBeforePayloadDownloads(t *testing.T) {
+	fixture := newResolverFixture(t)
+	fixture.commitSHA = "release"
+	out := filepath.Join(t.TempDir(), "release-inputs.lock.json")
+	if err := resolve(context.Background(), fixture.options(out)); err == nil || !strings.Contains(err.Error(), "40 lowercase") {
+		t.Fatalf("resolve error = %v, want exact-commit error", err)
+	}
+	if fixture.requestCount("/Loyalsoldier/geoip/release/GeoLite2-Country.mmdb") != 0 {
+		t.Fatal("resolver downloaded GeoIP before validating the immutable commit")
+	}
+	if _, err := os.Stat(out); !os.IsNotExist(err) {
+		t.Fatalf("output exists after invalid commit: %v", err)
+	}
+}
+
+func TestResolveRejectsGeoIPRefThatDoesNotPointDirectlyToCommit(t *testing.T) {
+	fixture := newResolverFixture(t)
+	fixture.commitType = "tag"
+	out := filepath.Join(t.TempDir(), "release-inputs.lock.json")
+	err := resolve(context.Background(), fixture.options(out))
+	if err == nil || !strings.Contains(err.Error(), "commit object") {
+		t.Fatalf("resolve error = %v, want direct commit object error", err)
+	}
+	if _, err := os.Stat(out); !os.IsNotExist(err) {
+		t.Fatalf("output exists after tag ref rejection: %v", err)
+	}
+}
+
+func TestResolvePreservesExistingLockOnDownloadFailure(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*resolverFixture, *options)
+	}{
+		{
+			name: "HTTP status",
+			setup: func(fixture *resolverFixture, _ *options) {
+				fixture.override = func(response http.ResponseWriter, request *http.Request) bool {
+					if strings.Contains(request.URL.Path, "mihomo-linux-amd64-compatible") {
+						http.Error(response, "unavailable", http.StatusServiceUnavailable)
+						return true
+					}
+					return false
+				}
+			},
+		},
+		{
+			name: "declared size mismatch",
+			setup: func(fixture *resolverFixture, _ *options) {
+				fixture.releaseEdit = func(release *core.Release) { release.Assets[2].Size++ }
+			},
+		},
+		{
+			name: "GitHub digest mismatch",
+			setup: func(fixture *resolverFixture, _ *options) {
+				fixture.releaseEdit = func(release *core.Release) { release.Assets[2].Digest = "sha256:" + strings.Repeat("0", 64) }
+			},
+		},
+		{
+			name:  "payload exceeds resolver bound",
+			setup: func(_ *resolverFixture, options *options) { options.MaxDownloadBytes = 4 },
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newResolverFixture(t)
+			dir := t.TempDir()
+			out := filepath.Join(dir, "release-inputs.lock.json")
+			const old = "reviewed old lock\n"
+			if err := os.WriteFile(out, []byte(old), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			options := fixture.options(out)
+			test.setup(fixture, &options)
+			if err := resolve(context.Background(), options); err == nil {
+				t.Fatal("resolve unexpectedly succeeded")
+			}
+			got, err := os.ReadFile(out)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != old {
+				t.Fatalf("old lock changed after failure: %q", got)
+			}
+			matches, err := filepath.Glob(filepath.Join(dir, ".release-inputs.lock.json-*"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(matches) != 0 {
+				t.Fatalf("temporary lock files remain after failure: %v", matches)
+			}
+		})
+	}
+}
+
+func TestResolveAtomicallyReplacesExistingLockWithoutTemporaryFiles(t *testing.T) {
+	fixture := newResolverFixture(t)
+	directory := t.TempDir()
+	out := filepath.Join(directory, "release-inputs.lock.json")
+	if err := os.WriteFile(out, []byte("old reviewed lock\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := resolve(context.Background(), fixture.options(out)); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	lock, err := releaseinputs.Load(out)
+	if err != nil {
+		t.Fatalf("load replaced lock: %v", err)
+	}
+	if lock.Mihomo.ReleaseID != 77 || lock.GeoIP.Commit != fixtureCommit {
+		t.Fatalf("replaced lock = release %d, commit %q", lock.Mihomo.ReleaseID, lock.GeoIP.Commit)
+	}
+	matches, err := filepath.Glob(filepath.Join(directory, ".release-inputs.lock.json-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary lock files remain after successful replacement: %v", matches)
+	}
+}
+
+func TestWriteAtomicReplaceFailurePreservesExistingFileAndCleansTemporary(t *testing.T) {
+	directory := t.TempDir()
+	destination := filepath.Join(directory, "release-inputs.lock.json")
+	if err := os.WriteFile(destination, []byte("old\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var source, target string
+	err := writeAtomicWithOps(destination, []byte("new\n"), atomicFileOps{
+		replace: func(candidate, output string) error {
+			source, target = candidate, output
+			return errors.New("replace denied")
+		},
+		syncDirectory: func(string) error {
+			t.Fatal("syncDirectory called after failed replacement")
+			return nil
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "replace release input lock") {
+		t.Fatalf("writeAtomicWithOps error = %v, want replacement error", err)
+	}
+	if filepath.Dir(source) != directory || target != destination {
+		t.Fatalf("replace = %q -> %q, want same-directory candidate -> destination", source, target)
+	}
+	got, readErr := os.ReadFile(destination)
+	if readErr != nil || string(got) != "old\n" {
+		t.Fatalf("destination after replacement failure = %q, %v", got, readErr)
+	}
+	assertNoLockTemporaries(t, directory)
+}
+
+func TestWriteAtomicSyncFailureIsBestEffortAfterSuccessfulReplacement(t *testing.T) {
+	directory := t.TempDir()
+	destination := filepath.Join(directory, "release-inputs.lock.json")
+	if err := os.WriteFile(destination, []byte("old\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	syncCalled := false
+	err := writeAtomicWithOps(destination, []byte("new\n"), atomicFileOps{
+		replace: replaceFile,
+		syncDirectory: func(path string) error {
+			syncCalled = true
+			if path != directory {
+				t.Fatalf("sync directory = %q, want %q", path, directory)
+			}
+			return errors.New("sync denied")
+		},
+	})
+	if err != nil {
+		t.Fatalf("writeAtomicWithOps after committed replacement: %v", err)
+	}
+	if !syncCalled {
+		t.Fatal("writeAtomicWithOps did not attempt best-effort parent-directory sync")
+	}
+	got, readErr := os.ReadFile(destination)
+	if readErr != nil || string(got) != "new\n" {
+		t.Fatalf("destination after sync failure = %q, %v", got, readErr)
+	}
+	assertNoLockTemporaries(t, directory)
+}
+
+func assertNoLockTemporaries(t *testing.T, directory string) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(directory, ".release-inputs.lock.json-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary lock files remain: %v", matches)
+	}
+}
+
+func TestNetworkErrorsRedactURLsAndPreserveContextCause(t *testing.T) {
+	operations := []struct {
+		name string
+		run  func(*http.Client) error
+	}{
+		{
+			name: "resolve GeoIP commit",
+			run: func(client *http.Client) error {
+				_, err := resolveCommit(context.Background(), client, withDefaults(options{}))
+				return err
+			},
+		},
+		{
+			name: "download payload",
+			run: func(client *http.Client) error {
+				_, err := downloadDigest(context.Background(), client, "https://github.com/MetaCubeX/mihomo/releases/download/v1.19.30/asset.gz", 0, 1024, "", "")
+				return err
+			},
+		},
+	}
+	causes := []struct {
+		name string
+		err  error
+	}{
+		{name: "canceled", err: context.Canceled},
+		{name: "deadline", err: context.DeadlineExceeded},
+	}
+	for _, operation := range operations {
+		for _, cause := range causes {
+			t.Run(operation.name+"/"+cause.name, func(t *testing.T) {
+				const secretURL = "https://signed.example/download?token=secret-value"
+				client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+					return nil, &url.Error{Op: "Get", URL: secretURL, Err: cause.err}
+				})}
+				err := operation.run(client)
+				if err == nil {
+					t.Fatal("operation unexpectedly succeeded")
+				}
+				if !errors.Is(err, cause.err) {
+					t.Fatalf("errors.Is(%v, %v) = false", err, cause.err)
+				}
+				for _, secret := range []string{"secret-value", secretURL, "signed.example", "token="} {
+					if strings.Contains(err.Error(), secret) {
+						t.Fatalf("network error leaked %q: %v", secret, err)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestResolveRejectsUnapprovedAssetURLBeforeDownload(t *testing.T) {
+	fixture := newResolverFixture(t)
+	fixture.releaseEdit = func(release *core.Release) {
+		release.Assets[0].URL = "https://evil.example/secret?token=do-not-log"
+	}
+	out := filepath.Join(t.TempDir(), "release-inputs.lock.json")
+	err := resolve(context.Background(), fixture.options(out))
+	if err == nil || !strings.Contains(err.Error(), "URL") {
+		t.Fatalf("resolve error = %v, want safe URL error", err)
+	}
+	if strings.Contains(err.Error(), "do-not-log") || strings.Contains(err.Error(), "evil.example") {
+		t.Fatalf("resolver leaked rejected URL: %v", err)
+	}
+	for _, asset := range fixture.assets {
+		if fixture.requestCount("/MetaCubeX/mihomo/releases/download/v1.19.30/"+asset.name) != 0 {
+			t.Fatal("resolver downloaded payload before validating locked URL metadata")
+		}
+	}
+}
+
+func TestResolvePropagatesCanceledDownloadContextAndPreservesOutput(t *testing.T) {
+	fixture := newResolverFixture(t)
+	fixture.blockPayload = "darwin/amd64"
+	dir := t.TempDir()
+	out := filepath.Join(dir, "release-inputs.lock.json")
+	if err := os.WriteFile(out, []byte("old\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		result <- resolve(ctx, fixture.options(out))
+	}()
+	<-fixture.payloadStart
+	cancel()
+	err := <-result
+	if err == nil {
+		t.Fatal("resolve with canceled context unexpectedly succeeded")
+	}
+	got, readErr := os.ReadFile(out)
+	if readErr != nil || string(got) != "old\n" {
+		t.Fatalf("old lock after cancellation = %q, %v", got, readErr)
+	}
+}
+
+func TestParseOptionsImplementsDocumentedCLIContract(t *testing.T) {
+	got, err := parseOptions([]string{"--channel", "stable", "--out", "scripts/release-inputs.lock.json"})
+	if err != nil {
+		t.Fatalf("parseOptions: %v", err)
+	}
+	if got.Channel != "stable" || got.Out != "scripts/release-inputs.lock.json" {
+		t.Fatalf("options = %#v", got)
+	}
+	if _, err := parseOptions([]string{"--channel", "nightly", "--out", "lock.json"}); err == nil {
+		t.Fatal("parseOptions accepted unsupported channel")
+	}
+}
+
+func TestParseOptionsRejectsGitHubTokenFlag(t *testing.T) {
+	_, err := parseOptions([]string{"--github-token", "secret-value"})
+	if err == nil {
+		t.Fatal("parseOptions accepted command-line GitHub token")
+	}
+	if strings.Contains(err.Error(), "secret-value") {
+		t.Fatalf("parseOptions error leaked token: %v", err)
+	}
+}
+
+func TestRunCLIHelpPrintsUsageAndExitsSuccessfully(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runCLI(context.Background(), []string{"--help"}, &stdout, &stderr, func(string) string {
+		return "secret-from-environment"
+	})
+	if exitCode != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr=%q", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Usage of resolve-release-inputs") || !strings.Contains(stdout.String(), "-channel") {
+		t.Fatalf("help output missing usage: %q", stdout.String())
+	}
+	for _, forbidden := range []string{"github-token", "GITHUB_TOKEN", "secret-from-environment"} {
+		if strings.Contains(stdout.String(), forbidden) || strings.Contains(stderr.String(), forbidden) {
+			t.Fatalf("help output exposed %q: stdout=%q stderr=%q", forbidden, stdout.String(), stderr.String())
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunCLIWiresEnvironmentTokenOnlyToAPIRequests(t *testing.T) {
+	fixture := newResolverFixture(t)
+	serverURL, err := url.Parse(fixture.server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var headersMu sync.Mutex
+	headers := make(map[string][]string)
+	mapper := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		headersMu.Lock()
+		headers[request.URL.Path] = append(headers[request.URL.Path], request.Header.Get("Authorization"))
+		headersMu.Unlock()
+		forwarded := request.Clone(request.Context())
+		forwarded.URL.Scheme = serverURL.Scheme
+		forwarded.URL.Host = serverURL.Host
+		response, err := fixture.server.Client().Transport.RoundTrip(forwarded)
+		if response != nil {
+			// Preserve the original HTTPS URL for resolver redirect validation.
+			response.Request = request
+		}
+		return response, err
+	})
+	execute := func(ctx context.Context, options options) error {
+		options.HTTPClient = &http.Client{
+			Transport:     bearerTransport{base: mapper, token: options.GitHubToken, allowedHost: "api.github.com"},
+			CheckRedirect: redirectPolicy,
+		}
+		options.APIBase = defaultAPIBase
+		return resolve(ctx, options)
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	out := filepath.Join(t.TempDir(), "release-inputs.lock.json")
+	exitCode := runCLIWithResolver(
+		context.Background(),
+		[]string{"--channel", "stable", "--out", out},
+		&stdout,
+		&stderr,
+		func(name string) string {
+			if name == "GITHUB_TOKEN" {
+				return "environment-secret"
+			}
+			return ""
+		},
+		execute,
+	)
+	if exitCode != 0 {
+		t.Fatalf("exit code = %d, stdout=%q stderr=%q", exitCode, stdout.String(), stderr.String())
+	}
+
+	headersMu.Lock()
+	defer headersMu.Unlock()
+	apiRequests := 0
+	payloadRequests := 0
+	for path, values := range headers {
+		for _, authorization := range values {
+			if strings.HasPrefix(path, "/repos/") {
+				apiRequests++
+				if authorization != "Bearer environment-secret" {
+					t.Fatalf("API %s authorization = %q", path, authorization)
+				}
+			} else {
+				payloadRequests++
+				if authorization != "" {
+					t.Fatalf("payload %s received authorization %q", path, authorization)
+				}
+			}
+		}
+	}
+	if apiRequests != 2 || payloadRequests != 8 {
+		t.Fatalf("request counts = %d API, %d payload; want 2 and 8", apiRequests, payloadRequests)
+	}
+	if strings.Contains(stdout.String(), "environment-secret") || strings.Contains(stderr.String(), "environment-secret") {
+		t.Fatal("CLI output leaked environment token")
+	}
+}
+
+func TestRedirectPolicyRejectsHTTPSDowngrade(t *testing.T) {
+	previous := &http.Request{URL: &url.URL{Scheme: "https", Host: "github.com"}}
+	if err := redirectPolicy(&http.Request{URL: &url.URL{Scheme: "http", Host: "example.com"}}, []*http.Request{previous}); err == nil {
+		t.Fatal("redirect policy accepted HTTPS-to-HTTP downgrade")
+	}
+	if err := redirectPolicy(&http.Request{URL: &url.URL{Scheme: "https", Host: "release-assets.githubusercontent.com"}}, []*http.Request{previous}); err != nil {
+		t.Fatalf("redirect policy rejected HTTPS redirect: %v", err)
+	}
+}
+
+func TestBearerTransportDoesNotSendTokenToPayloadHosts(t *testing.T) {
+	var headers []string
+	base := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		headers = append(headers, request.Header.Get("Authorization"))
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: request}, nil
+	})
+	transport := bearerTransport{base: base, token: "secret-token", allowedHost: "api.github.com"}
+	for _, rawURL := range []string{
+		"https://api.github.com/repos/MetaCubeX/mihomo/releases/latest",
+		"https://raw.githubusercontent.com/Loyalsoldier/geoip/commit/GeoLite2-Country.mmdb",
+	} {
+		request, err := http.NewRequest(http.MethodGet, rawURL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := transport.RoundTrip(request); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(headers) != 2 || headers[0] != "Bearer secret-token" || headers[1] != "" {
+		t.Fatalf("authorization headers = %q, want token only for API host", headers)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}

--- a/scripts/test_release_workflow.py
+++ b/scripts/test_release_workflow.py
@@ -1,9 +1,12 @@
-"""Static regression checks for GitHub dev-release recovery wiring."""
+"""Behavioral regression checks for stable and dev release workflow invariants."""
 
+import copy
 import os
 from pathlib import Path
+import shlex
 import subprocess
 
+import pytest
 import yaml
 
 
@@ -26,6 +29,313 @@ RELEASE_SAFETY_TESTS = (
     "scripts/test_retract_alist.py "
     "scripts/test_regenerate_index.py -q"
 )
+
+
+def _workflow_step(document, job_name, *, name=None, uses=None):
+    matches = [
+        step
+        for step in document["jobs"][job_name]["steps"]
+        if (name is None or step.get("name") == name)
+        and (uses is None or step.get("uses") == uses)
+    ]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _shell_invocations(run):
+    normalized = run.replace("\\\n", " ")
+    invocations = []
+    for line in normalized.splitlines():
+        lexer = shlex.shlex(line, posix=True, punctuation_chars=";&|")
+        lexer.whitespace_split = True
+        lexer.commenters = "#"
+        invocation = []
+        for token in lexer:
+            if token and all(character in ";&|" for character in token):
+                if invocation:
+                    invocations.append(invocation)
+                    invocation = []
+                continue
+            invocation.append(token)
+        if invocation:
+            invocations.append(invocation)
+    return invocations
+
+
+def _flag_values(command, flag):
+    values = []
+    index = 0
+    while index < len(command):
+        argument = command[index]
+        if argument == flag:
+            assert index + 1 < len(command), f"{flag} requires a value"
+            values.append(command[index + 1])
+            index += 2
+            continue
+        if argument.startswith(f"{flag}="):
+            value = argument[len(flag) + 1 :]
+            assert value, f"{flag} requires a value"
+            values.append(value)
+        index += 1
+    return values
+
+
+def _linker_x_assignments(ldflags):
+    arguments = shlex.split(ldflags)
+    assignments = []
+    index = 0
+    while index < len(arguments):
+        argument = arguments[index]
+        if argument == "-X":
+            assert index + 1 < len(arguments), "-X requires an assignment"
+            assignments.append(arguments[index + 1])
+            index += 2
+            continue
+        if argument.startswith("-X="):
+            assignment = argument[len("-X=") :]
+            assert assignment, "-X requires an assignment"
+            assignments.append(assignment)
+        index += 1
+    return assignments
+
+
+def _assert_bundle_job_has_no_mutable_input_discovery(bundle_job):
+    assert "GITHUB_TOKEN" not in bundle_job.get("env", {})
+    for step in bundle_job["steps"]:
+        assert "GITHUB_TOKEN" not in step.get("env", {})
+        for command in _shell_invocations(step.get("run", "")):
+            is_lock_resolver = any(
+                "scripts/resolve-release-inputs" in argument.replace("\\", "/")
+                for argument in command
+            )
+            is_latest_api = any(
+                "/releases/latest" in argument for argument in command
+            )
+            is_implicit_latest_release = any(
+                command[index : index + 3] == ["gh", "release", "view"]
+                for index in range(len(command) - 2)
+            )
+
+            assert not is_lock_resolver, (
+                "bundle job must not invoke the input-lock resolver"
+            )
+            assert not is_latest_api, "bundle job must not query the latest-release API"
+            assert not is_implicit_latest_release, (
+                "bundle job must not resolve the latest release"
+            )
+
+
+def _assert_release_build_wiring(document):
+    build = _workflow_step(document, "build", name="Build")
+    commands = [
+        command
+        for command in _shell_invocations(build["run"])
+        if command[:2] == ["go", "build"]
+    ]
+    assert len(commands) == 1, "release build step must invoke go build exactly once"
+    command = commands[0]
+
+    buildvcs_flags = [
+        argument
+        for argument in command
+        if argument == "-buildvcs" or argument.startswith("-buildvcs=")
+    ]
+    trimpath_flags = [
+        argument
+        for argument in command
+        if argument == "-trimpath" or argument.startswith("-trimpath=")
+    ]
+    assert buildvcs_flags == ["-buildvcs=false"]
+    assert trimpath_flags == ["-trimpath"]
+
+    ldflags_values = _flag_values(command, "-ldflags")
+    assert len(ldflags_values) == 1, "release build requires exactly one -ldflags"
+    version_symbol = "github.com/mihari-proxy/mihari/internal/buildinfo.Version"
+    version_prefix = f"{version_symbol}="
+    version_values = [
+        assignment[len(version_prefix) :]
+        for assignment in _linker_x_assignments(ldflags_values[0])
+        if assignment.startswith(version_prefix)
+    ]
+    assert version_values == ["${VERSION}"]
+
+
+def _assert_release_bundle_wiring(document):
+    bundle_job = document["jobs"]["bundle"]
+    _assert_bundle_job_has_no_mutable_input_discovery(bundle_job)
+    bundle = _workflow_step(document, "bundle", name="Build all-in-one bundles")
+    commands = [
+        command
+        for command in _shell_invocations(bundle["run"])
+        if command[:3] == ["go", "run", "./scripts/build-all-in-one"]
+    ]
+    assert len(commands) == 1, "bundle step must invoke the AIO builder exactly once"
+    lock_values = _flag_values(commands[0], "--lock")
+    assert lock_values == ["scripts/release-inputs.lock.json"]
+
+
+def _assert_release_setup_go_wiring(document):
+    action = "actions/setup-go"
+    for job_name in ("build", "bundle"):
+        setup_go_steps = [
+            step
+            for step in document["jobs"][job_name]["steps"]
+            if step.get("uses") == action
+            or str(step.get("uses", "")).startswith(f"{action}@")
+        ]
+        assert len(setup_go_steps) == 1, (
+            f"{job_name} job must contain exactly one setup-go step"
+        )
+        setup_go = setup_go_steps[0]
+        assert setup_go["uses"] == "actions/setup-go@v7"
+        assert setup_go.get("with", {}).get("go-version-file") == "go.mod"
+
+
+@pytest.fixture
+def bundle_job_with_resolver_in_another_step():
+    document = yaml.safe_load(STABLE_WORKFLOW.read_text(encoding="utf-8"))
+    bundle_job = copy.deepcopy(document["jobs"]["bundle"])
+    for step in bundle_job["steps"]:
+        step.get("env", {}).pop("GITHUB_TOKEN", None)
+    bundle_job["steps"].insert(
+        1,
+        {
+            "name": "Resolve inputs behind the build step",
+            "run": (
+                "go run ./scripts/resolve-release-inputs "
+                "--channel stable --out scripts/release-inputs.lock.json"
+            ),
+        },
+    )
+    return bundle_job
+
+
+def test_release_build_jobs_use_pinned_go_and_reproducible_binary_flags():
+    for workflow_path in (STABLE_WORKFLOW, WORKFLOW):
+        document = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+        _assert_release_setup_go_wiring(document)
+        _assert_release_build_wiring(document)
+
+
+@pytest.mark.parametrize("mutation", ["move", "replace"])
+def test_setup_go_guard_binds_pinned_action_to_the_bundle_job(mutation):
+    document = yaml.safe_load(STABLE_WORKFLOW.read_text(encoding="utf-8"))
+    bundle_steps = document["jobs"]["bundle"]["steps"]
+    setup_go = next(
+        step for step in bundle_steps if step.get("uses") == "actions/setup-go@v7"
+    )
+    if mutation == "move":
+        bundle_steps.remove(setup_go)
+        document["jobs"]["release"]["steps"].append(setup_go)
+    else:
+        setup_go["uses"] = "actions/setup-go@main"
+
+    with pytest.raises(AssertionError):
+        _assert_release_setup_go_wiring(document)
+
+
+def test_release_bundle_jobs_consume_the_reviewed_input_lock_without_resolving_latest():
+    for workflow_path in (STABLE_WORKFLOW, WORKFLOW):
+        document = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+        _assert_release_bundle_wiring(document)
+
+
+def test_build_wiring_guard_rejects_later_buildvcs_override():
+    document = yaml.safe_load(STABLE_WORKFLOW.read_text(encoding="utf-8"))
+    build = _workflow_step(document, "build", name="Build")
+    build["run"] = build["run"].replace(
+        "go build -buildvcs=false",
+        "go build -buildvcs=false -buildvcs=true",
+        1,
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_release_build_wiring(document)
+
+
+def test_build_wiring_guard_rejects_later_wrong_version_assignment():
+    document = yaml.safe_load(STABLE_WORKFLOW.read_text(encoding="utf-8"))
+    build = _workflow_step(document, "build", name="Build")
+    canonical = "github.com/mihari-proxy/mihari/internal/buildinfo.Version=${VERSION}"
+    build["run"] = build["run"].replace(
+        canonical,
+        f"{canonical} -X github.com/mihari-proxy/mihari/internal/buildinfo.Version=v9.9.9",
+        1,
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_release_build_wiring(document)
+
+
+def test_bundle_wiring_guard_rejects_second_lock_override():
+    document = yaml.safe_load(STABLE_WORKFLOW.read_text(encoding="utf-8"))
+    bundle = _workflow_step(document, "bundle", name="Build all-in-one bundles")
+    bundle["run"] = bundle["run"].replace(
+        "--lock scripts/release-inputs.lock.json",
+        "--lock scripts/release-inputs.lock.json --lock=scripts/unreviewed.lock.json",
+        1,
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_release_bundle_wiring(document)
+
+
+def test_bundle_job_guard_rejects_resolver_after_shell_separator():
+    document = yaml.safe_load(STABLE_WORKFLOW.read_text(encoding="utf-8"))
+    bundle_job = document["jobs"]["bundle"]
+    bundle_job["steps"].append(
+        {
+            "name": "Hide mutable discovery after another command",
+            "run": (
+                "echo ok; go run ./scripts/resolve-release-inputs "
+                "--channel stable --out scripts/release-inputs.lock.json"
+            ),
+        }
+    )
+
+    with pytest.raises(AssertionError, match="must not invoke the input-lock resolver"):
+        _assert_bundle_job_has_no_mutable_input_discovery(bundle_job)
+
+
+def test_bundle_job_guard_rejects_gh_release_view_with_output_redirection():
+    document = yaml.safe_load(STABLE_WORKFLOW.read_text(encoding="utf-8"))
+    bundle_job = document["jobs"]["bundle"]
+    bundle_job["steps"].append(
+        {
+            "name": "Hide latest release lookup behind redirection",
+            "run": "gh release view > /tmp/latest.txt",
+        }
+    )
+
+    with pytest.raises(AssertionError, match="must not resolve the latest release"):
+        _assert_bundle_job_has_no_mutable_input_discovery(bundle_job)
+
+
+def test_bundle_job_guard_detects_resolver_hidden_in_another_step(
+    bundle_job_with_resolver_in_another_step,
+):
+    with pytest.raises(AssertionError, match="must not invoke the input-lock resolver"):
+        _assert_bundle_job_has_no_mutable_input_discovery(
+            bundle_job_with_resolver_in_another_step
+        )
+
+
+def test_bundle_job_guard_allows_comments_and_messages_about_latest_releases():
+    document = yaml.safe_load(STABLE_WORKFLOW.read_text(encoding="utf-8"))
+    bundle_job = copy.deepcopy(document["jobs"]["bundle"])
+    for step in bundle_job["steps"]:
+        step.get("env", {}).pop("GITHUB_TOKEN", None)
+    bundle_job["steps"].append(
+        {
+            "name": "Explain locked inputs",
+            "run": (
+                "# The latest release is resolved only during reviewed maintenance.\n"
+                'echo "The latest release inputs are already locked."'
+            ),
+        }
+    )
+
+    _assert_bundle_job_has_no_mutable_input_discovery(bundle_job)
 
 
 def test_stable_release_and_retract_pin_the_stable_alist_channel():
@@ -806,16 +1116,14 @@ def test_release_document_scopes_main_dispatch_to_stable_release_and_retract_sec
     assert "选择 `main` 分支/ref" in retract
 
 
-def test_release_document_requires_tag_ruleset_because_pre_and_post_checks_are_not_atomic():
+def test_release_document_records_active_tag_ruleset_and_non_atomic_tag_checks():
     release = RELEASE_DOCUMENT.read_text(encoding="utf-8")
     stable_dispatch = _markdown_section(release, "## 手动触发发布")
 
-    assert "前后复核并非原子操作" in stable_dispatch
-    assert "stable tag-target ruleset" in stable_dispatch
-    assert "真实 stable 发布前" in stable_dispatch
-    assert "禁止更新和删除" in stable_dispatch
-    assert "另行授权" in stable_dispatch
-    assert "配置并回读" in stable_dispatch
+    assert "该复核不是原子操作" in stable_dispatch
+    assert "已 active" in stable_dispatch
+    assert "`refs/tags/v*`" in stable_dispatch
+    assert "禁止删除、更新和 non-fast-forward" in stable_dispatch
 
 
 def test_release_documents_keep_retracted_stable_tags_and_require_a_higher_fix_version():
@@ -834,7 +1142,7 @@ def test_release_documents_keep_retracted_stable_tags_and_require_a_higher_fix_v
         assert "--cleanup-tag" not in section
 
 
-def test_release_document_requires_authorized_tag_ruleset_for_real_dev_release():
+def test_release_document_records_verified_dev_release_and_active_tag_ruleset():
     release = RELEASE_DOCUMENT.read_text(encoding="utf-8")
     channel_overview = _markdown_section(release, "## Stable 与 Dev 发布通道")
     dev_dispatch = _markdown_section(release, "### Dev 手动发布")
@@ -845,11 +1153,11 @@ def test_release_document_requires_authorized_tag_ruleset_for_real_dev_release()
     assert "校验 canonical `vX.Y.Z-dev.N` 版本身份" in channel_overview
     assert "身份不符即拒绝且不覆盖" in channel_overview
     assert "canonical `vX.Y.Z-dev.N` 格式" in dev_dispatch
-    assert "dev 前后复核并非原子操作" in dev_dispatch
-    assert "真实 dev 发布前" in dev_dispatch
-    assert "dev tag-target ruleset" in dev_dispatch
-    assert "另行授权" in dev_dispatch
-    assert "配置并回读" in dev_dispatch
+    assert "`v0.9.0-dev.2` 已" in dev_dispatch
+    assert "前后复核不是原子操作" in dev_dispatch
+    assert "已 active" in dev_dispatch
+    assert "`refs/tags/v*`" in dev_dispatch
+    assert "禁止删除、更新和 non-fast-forward" in dev_dispatch
 
 
 def test_distribution_document_explains_how_to_recover_the_uploaded_index_backup():
@@ -900,20 +1208,48 @@ def test_distribution_document_limits_backup_artifacts_to_alist_mutation_failure
     assert "无需恢复旧 index" in publication
 
 
-def test_release_documents_describe_batch_a_as_code_prepared_and_keep_p2_alist_unavailable():
+def test_release_documents_record_verified_dev_github_release_and_unavailable_dev_alist():
     release = RELEASE_DOCUMENT.read_text(encoding="utf-8")
     distribution = DISTRIBUTION_DOCUMENT.read_text(encoding="utf-8")
 
     for document in (release, distribution):
-        assert "dev 发布代码已准备" in document
-        assert "P2 AList 发布与撤回 workflow 尚不可用" in document
+        assert "v0.9.0-dev.2" in document
+        assert "dev AList 发布与 dev retract workflow" in document
         assert "publish-dev-alist.yml" not in document
         assert "retract-dev.yml" not in document
 
     assert "Actions 产物或 dev 版本目录" not in distribution
-    assert "不创建或操作该目录" in distribution
+    assert "当前不创建或操作该目录" in distribution
 
-    assert "GitHub dev tag、prerelease 与 14 个 assets" in release
-    assert "仅写 GitHub" in release
+    assert "GitHub dev tag、prerelease 与精确 14 个 assets" in release
     assert "不写 AList" in release
     assert "lightweight 或 annotated" in release
+
+
+def test_release_document_uses_main_dispatch_as_the_stable_runbook():
+    release = RELEASE_DOCUMENT.read_text(encoding="utf-8")
+    workflow_table = _markdown_section(release, "## 工作流触发机制")
+    runbook = _markdown_section(release, "## 发版流程")
+    stable_dispatch = _markdown_section(release, "## 手动触发发布")
+
+    assert "主路径：从 `main` 执行 `workflow_dispatch`" in workflow_table
+    assert "`dev → main` 晋级 PR" in runbook
+    assert "ref 选择 `main`" in runbook
+    assert "`commit_sha`" in runbook
+    assert "精确的 40 位" in runbook
+    assert "不要把本地创建并推送 tag 作为当前稳定发版操作" in runbook
+    assert "兼容入口仍接受 `v*` tag push" in stable_dispatch
+    assert "不作为当前人工 runbook" in stable_dispatch
+
+
+def test_release_documents_scope_existing_asset_preflight_to_dev():
+    release = RELEASE_DOCUMENT.read_text(encoding="utf-8")
+    reproducibility = _markdown_section(release, "## 可复现构建输入")
+    distribution = DISTRIBUTION_DOCUMENT.read_text(encoding="utf-8")
+
+    assert "仅 `release-dev.yml`" in reproducibility
+    assert "dev workflow 会在 tag/asset mutation 前 fail closed" in reproducibility
+    assert "`release.yml` 当前不提供同等的 existing-asset preflight" in reproducibility
+    assert "不要从 dev 的 fail-closed preflight 推断 stable" in reproducibility
+    assert "仅 dev release workflow" in distribution
+    assert "stable release workflow 不提供同等 preflight" in distribution


### PR DESCRIPTION
## Summary

- suppress tag-dependent Go VCS metadata in stable/dev release builds
- pin all mihomo and GeoIP AIO inputs in a strict reviewed lock
- add an atomic release-input resolver and make the AIO builder consume only locked inputs
- make bundle metadata, output transactions, and cancellation behavior deterministic across hosts
- update release governance docs and workflow regression guards

## Root cause

The first v0.9.0-dev.2 build ran before its tag existed and embedded a Go pseudo-version; a retry after tag creation embedded v0.9.0-dev.2. That changed all raw/AIO checksums. The AIO builder also resolved mutable upstream latest/ref inputs on each run.

## Verification

- go test -count=1 ./...
- go test -race -count=1 ./...
- go vet ./...
- golangci-lint run ./...
- 254 Python release tests passed, 2 skipped
- actionlint release.yml release-dev.yml
- six CGO-free target builds
- live resolver output byte-identical to checked-in lock
- two live six-platform AIO builds byte-identical per archive
- independent spec, quality, and final integration reviews passed

## Release validation

The pre-fix v0.9.0-dev.2 release remains immutable. After merge, publish v0.9.0-dev.3 through Actions, verify all 14 assets, then re-run dev.3 to prove idempotency before promotion to main.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mihari-proxy/mihari/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

