### PR TITLE
feat: 为 prerelease 通道增加独立 AList index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Test AIO parallel downloader
         run: python scripts/install/test_parallel_download.py -v
       - name: Test release safety policies
-        run: python -m pytest scripts/test_release_policy.py scripts/test_github_release_policy.py scripts/test_release_workflow.py scripts/test_alist_client.py scripts/test_alist_index.py scripts/test_release_alist.py scripts/test_retract_alist.py scripts/test_regenerate_index.py -q
+        run: python -m pytest scripts/test_release_policy.py scripts/test_github_release_policy.py scripts/test_release_workflow.py scripts/test_alist_client.py scripts/test_alist_index.py scripts/test_release_alist.py scripts/test_retract_alist.py scripts/test_regenerate_index.py scripts/test_alist_channel_guard.py -q
       - name: Test
         run: go test -count=1 ./...
 

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -136,6 +136,9 @@ jobs:
     name: publish dev prerelease
     needs: [resolve, build, bundle]
     runs-on: ubuntu-latest
+    concurrency:
+      group: mihari-dev-alist
+      cancel-in-progress: false
     permissions:
       contents: write
     env:
@@ -143,6 +146,8 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       DEV_RELEASE_NAME: Mihari ${{ inputs.version }} (dev)
       DEV_RELEASE_BODY: "This is a Mihari development release.\n\n<!-- github-release-dev -->"
+      ALIST_CONFIGURED: ${{ secrets.ALIST_URL != '' }}
+      MIHARI_KEEP_VERSIONS: ${{ vars.MIHARI_KEEP_VERSIONS }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -360,3 +365,93 @@ jobs:
             || { echo "::error::unable to read stable latest release after publication"; exit 1; }
           python scripts/github_release_policy.py latest \
             --before /tmp/latest-before.json --after /tmp/latest-after.json --dev-version "${VERSION}"
+
+      - uses: actions/setup-python@v7
+        if: env.ALIST_CONFIGURED == 'true'
+        with:
+          python-version: '3.12'
+
+      - name: Publish to AList drive
+        id: alist_mutation
+        if: env.ALIST_CONFIGURED == 'true'
+        env:
+          ALIST_URL: ${{ secrets.ALIST_URL }}
+          ALIST_USERNAME: ${{ secrets.ALIST_USERNAME }}
+          ALIST_PASSWORD: ${{ secrets.ALIST_PASSWORD }}
+        run: |
+          python -m pip install --disable-pip-version-check -r scripts/requirements-release.txt
+          python scripts/alist_channel_guard.py snapshot \
+            --path /mihari-release/mihari/index.txt \
+            --output-dir "${RUNNER_TEMP}/mihari-index-backup/stable-isolation"
+          set +e
+          python scripts/release-alist.py \
+            --version "${VERSION}" \
+            --dist-dir dist \
+            --repo-root . \
+            --channel dev \
+            --commit-sha "${SHA}" \
+            --base-path /mihari-release/mihari-dev \
+            --keep-versions "${MIHARI_KEEP_VERSIONS:-5}"
+          publish_status=$?
+          python scripts/alist_channel_guard.py compare \
+            --path /mihari-release/mihari/index.txt \
+            --expected-dir "${RUNNER_TEMP}/mihari-index-backup/stable-isolation"
+          compare_status=$?
+          set -e
+          if [ "${compare_status}" -ne 0 ]; then exit "${compare_status}"; fi
+          exit "${publish_status}"
+
+      - name: Upload dev index recovery backup
+        if: "env.ALIST_CONFIGURED == 'true' && ((failure() && steps.alist_mutation.outcome == 'failure') || (cancelled() && steps.alist_mutation.outcome == 'cancelled'))"
+        uses: actions/upload-artifact@v7
+        with:
+          name: dev-index-backup-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/mihari-index-backup/dev/**
+          if-no-files-found: ignore
+          retention-days: 3
+
+      - name: Upload stable index isolation snapshot
+        if: "env.ALIST_CONFIGURED == 'true' && ((failure() && steps.alist_mutation.outcome == 'failure') || (cancelled() && steps.alist_mutation.outcome == 'cancelled'))"
+        uses: actions/upload-artifact@v7
+        with:
+          name: stable-index-isolation-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/mihari-index-backup/stable-isolation/**
+          if-no-files-found: ignore
+          retention-days: 3
+
+      - name: Re-verify stable latest after AList mutation
+        if: env.ALIST_CONFIGURED == 'true'
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/releases/latest" > /tmp/latest-after-alist.json 2> /tmp/latest-after-alist.err \
+            || { echo "::error::unable to read stable latest release after AList mutation"; exit 1; }
+          python scripts/github_release_policy.py latest \
+            --before /tmp/latest-before.json --after /tmp/latest-after-alist.json --dev-version "${VERSION}"
+
+      - name: Append prerelease AList install hook to release notes
+        if: env.ALIST_CONFIGURED == 'true'
+        run: |
+          NOTES="$(gh release view "${VERSION}" --json body -q .body)"
+          MARKER='<!-- aio-install-dev -->'
+          if printf '%s' "$NOTES" | grep -qF "$MARKER"; then
+            echo "dev aio-install section already present — skipping"
+            exit 0
+          fi
+          cat > /tmp/aio_append_dev.md <<'TEMPLATE'
+
+          <!-- aio-install-dev -->
+          ## 国内 prerelease 安装（AList，免 GitHub；覆盖 index，不改默认稳定入口）
+
+          Linux / macOS：
+
+          ```bash
+          curl -fsSL https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.sh | MIHARI_INDEX_URL=https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari-dev/index.txt bash
+          ```
+
+          Windows (PowerShell)：
+
+          ```powershell
+          $env:MIHARI_INDEX_URL='https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari-dev/index.txt'
+          & ([scriptblock]::Create((irm https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.ps1)))
+          ```
+          TEMPLATE
+          gh release edit "${VERSION}" --notes "$(printf '%s\n%s\n' "$NOTES" "$(cat /tmp/aio_append_dev.md)")"

--- a/.github/workflows/retract-dev.yml
+++ b/.github/workflows/retract-dev.yml
@@ -1,0 +1,196 @@
+name: retract dev
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Canonical dev version to retract, e.g. v0.3.0-dev.1 (leading zeroes are rejected)'
+        required: true
+        type: string
+      confirm:
+        description: 'Confirm to permanently remove the GitHub prerelease/assets and AList dev distribution; the canonical dev tag is retained.'
+        required: true
+        type: boolean
+
+permissions:
+  contents: read
+
+env:
+  VERSION: ${{ inputs.version }}
+  CONFIRM: ${{ inputs.confirm }}
+
+jobs:
+  resolve:
+    name: resolve trusted dev source
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      sha: ${{ steps.source.outputs.sha }}
+    steps:
+      - name: Guard dev ref and version
+        run: |
+          [ "${GITHUB_REF}" = "refs/heads/dev" ] \
+            || { echo "::error::dev retraction must be dispatched from refs/heads/dev"; exit 1; }
+          if [[ ! "${VERSION}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-dev\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::version must match the dev prerelease format"
+            exit 1
+          fi
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+      - id: source
+        name: Resolve trusted dev commit
+        run: |
+          SHA="$(git rev-parse HEAD)"
+          [ "${SHA}" = "${GITHUB_SHA}" ] \
+            || { echo "::error::checked-out commit does not equal event commit"; exit 1; }
+          echo "sha=${SHA}" >> "${GITHUB_OUTPUT}"
+
+  retract:
+    name: retract dev release
+    needs: resolve
+    if: github.ref == 'refs/heads/dev' && needs.resolve.outputs.sha != ''
+    runs-on: ubuntu-latest
+    concurrency:
+      group: mihari-dev-alist
+      cancel-in-progress: false
+    permissions:
+      contents: write
+    env:
+      ALIST_CONFIGURED: ${{ secrets.ALIST_URL != '' }}
+      SHA: ${{ needs.resolve.outputs.sha }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+          fetch-depth: 0
+
+      - name: Verify trusted source commit
+        run: |
+          [ "$(git rev-parse HEAD)" = "${SHA}" ] \
+            || { echo "::error::checkout did not resolve the trusted dev commit"; exit 1; }
+
+      - name: Gate (dev semver + confirm)
+        run: |
+          if [[ ! "${VERSION}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-dev\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::version must match the dev prerelease format"
+            exit 1
+          fi
+          [ "${CONFIRM}" = "true" ] \
+            || { echo "::error::confirm must be true to permanently remove prerelease/assets and AList dev distribution; canonical dev tag retained"; exit 1; }
+
+      - name: Peel canonical tag for identity SHA
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${VERSION}" > /tmp/tag-ref.json 2> /tmp/tag-ref.err \
+            || { echo "::error::unable to read release tag"; exit 1; }
+          jq -e '(.object.type | type == "string") and (.object.sha | type == "string")' /tmp/tag-ref.json >/dev/null \
+            || { echo "::error::release tag response is invalid"; exit 1; }
+          jq -c '{type: .object.type, sha: .object.sha}' /tmp/tag-ref.json > /tmp/tag-chain.jsonl
+          tag_type="$(jq -r '.object.type' /tmp/tag-ref.json)"
+          tag_sha="$(jq -r '.object.sha' /tmp/tag-ref.json)"
+          for depth in $(seq 1 7); do
+            [ "${tag_type}" = tag ] || break
+            gh api "repos/${GITHUB_REPOSITORY}/git/tags/${tag_sha}" > /tmp/tag-object.json 2> /tmp/tag-object.err \
+              || { echo "::error::unable to peel release tag"; exit 1; }
+            jq -e '(.object.type | type == "string") and (.object.sha | type == "string")' /tmp/tag-object.json >/dev/null \
+              || { echo "::error::annotated tag response is invalid"; exit 1; }
+            jq -c '{type: .object.type, sha: .object.sha}' /tmp/tag-object.json >> /tmp/tag-chain.jsonl
+            tag_type="$(jq -r '.object.type' /tmp/tag-object.json)"
+            tag_sha="$(jq -r '.object.sha' /tmp/tag-object.json)"
+          done
+          [ "${tag_type}" != tag ] || { echo "::error::release tag peel exceeds the allowed depth"; exit 1; }
+          [ "${tag_type}" = commit ] || { echo "::error::release tag did not peel to a commit"; exit 1; }
+          jq -s . /tmp/tag-chain.jsonl > /tmp/tag-chain.json
+          RELEASE_SHA="${tag_sha}"
+          echo "RELEASE_SHA=${RELEASE_SHA}" >> "${GITHUB_ENV}"
+          python scripts/github_release_policy.py tag-chain \
+            --chain /tmp/tag-chain.json --expected-sha "${RELEASE_SHA}"
+
+      - name: Snapshot stable latest before mutation
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/releases/latest" > /tmp/latest-before.json 2> /tmp/latest-before.err \
+            || { echo "::error::unable to read stable latest release"; exit 1; }
+          python scripts/github_release_policy.py latest \
+            --before /tmp/latest-before.json --after /tmp/latest-before.json --dev-version "${VERSION}"
+
+      - uses: actions/setup-python@v7
+        if: env.ALIST_CONFIGURED == 'true'
+        with:
+          python-version: '3.12'
+
+      - name: Retract from AList drive
+        id: alist_mutation
+        if: env.ALIST_CONFIGURED == 'true'
+        env:
+          ALIST_URL: ${{ secrets.ALIST_URL }}
+          ALIST_USERNAME: ${{ secrets.ALIST_USERNAME }}
+          ALIST_PASSWORD: ${{ secrets.ALIST_PASSWORD }}
+        run: |
+          python -m pip install --disable-pip-version-check -r scripts/requirements-release.txt
+          python scripts/alist_channel_guard.py snapshot \
+            --path /mihari-release/mihari/index.txt \
+            --output-dir "${RUNNER_TEMP}/mihari-index-backup/stable-isolation"
+          set +e
+          python scripts/retract-alist.py \
+            --version "${VERSION}" \
+            --channel dev \
+            --base-path /mihari-release/mihari-dev \
+            --commit-sha "${RELEASE_SHA}"
+          retract_status=$?
+          python scripts/alist_channel_guard.py compare \
+            --path /mihari-release/mihari/index.txt \
+            --expected-dir "${RUNNER_TEMP}/mihari-index-backup/stable-isolation"
+          compare_status=$?
+          set -e
+          if [ "${compare_status}" -ne 0 ]; then exit "${compare_status}"; fi
+          exit "${retract_status}"
+
+      - name: Upload dev index recovery backup
+        if: "env.ALIST_CONFIGURED == 'true' && ((failure() && steps.alist_mutation.outcome == 'failure') || (cancelled() && steps.alist_mutation.outcome == 'cancelled'))"
+        uses: actions/upload-artifact@v7
+        with:
+          name: dev-index-backup-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/mihari-index-backup/dev/**
+          if-no-files-found: ignore
+          retention-days: 3
+
+      - name: Upload stable index isolation snapshot
+        if: "env.ALIST_CONFIGURED == 'true' && ((failure() && steps.alist_mutation.outcome == 'failure') || (cancelled() && steps.alist_mutation.outcome == 'cancelled'))"
+        uses: actions/upload-artifact@v7
+        with:
+          name: stable-index-isolation-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/mihari-index-backup/stable-isolation/**
+          if-no-files-found: ignore
+          retention-days: 3
+
+      - name: Delete GitHub prerelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          release_lookup_error="$(mktemp)"
+          trap 'rm -f "${release_lookup_error}"' EXIT
+          set +e
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${VERSION}" \
+            >/dev/null 2>"${release_lookup_error}"
+          release_lookup_status=$?
+          set -e
+
+          if [ "${release_lookup_status}" -eq 0 ]; then
+            gh release delete "${VERSION}" --yes
+            echo "Permanently removed GitHub prerelease/assets for ${VERSION}; canonical dev tag retained."
+          elif grep -Eq '(^|[^0-9])HTTP 404([^0-9]|$)' "${release_lookup_error}"; then
+            echo "GitHub prerelease ${VERSION} not found (already retracted?) — nothing to delete; canonical dev tag retained."
+          else
+            echo "::error::unable to determine whether the GitHub release exists"
+            exit 1
+          fi
+
+      - name: Re-verify stable latest after GitHub delete
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/releases/latest" > /tmp/latest-after.json 2> /tmp/latest-after.err \
+            || { echo "::error::unable to read stable latest release after retraction"; exit 1; }
+          python scripts/github_release_policy.py latest \
+            --before /tmp/latest-before.json --after /tmp/latest-after.json --dev-version "${VERSION}"

--- a/.github/workflows/retract-dev.yml
+++ b/.github/workflows/retract-dev.yml
@@ -117,7 +117,6 @@ jobs:
             --before /tmp/latest-before.json --after /tmp/latest-before.json --dev-version "${VERSION}"
 
       - uses: actions/setup-python@v7
-        if: env.ALIST_CONFIGURED == 'true'
         with:
           python-version: '3.12'
 
@@ -170,15 +169,23 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          release_lookup_json="$(mktemp)"
           release_lookup_error="$(mktemp)"
-          trap 'rm -f "${release_lookup_error}"' EXIT
+          trap 'rm -f "${release_lookup_json}" "${release_lookup_error}"' EXIT
           set +e
           gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${VERSION}" \
-            >/dev/null 2>"${release_lookup_error}"
+            >"${release_lookup_json}" 2>"${release_lookup_error}"
           release_lookup_status=$?
           set -e
 
           if [ "${release_lookup_status}" -eq 0 ]; then
+            python scripts/github_release_policy.py release \
+              --document "${release_lookup_json}" \
+              --version "${VERSION}" \
+              --release-name "Mihari ${VERSION} (dev)" \
+              --marker "<!-- github-release-dev -->" \
+              --mode preflight \
+              || { echo "::error::GitHub release is not a published dev prerelease"; exit 1; }
             gh release delete "${VERSION}" --yes
             echo "Permanently removed GitHub prerelease/assets for ${VERSION}; canonical dev tag retained."
           elif grep -Eq '(^|[^0-9])HTTP 404([^0-9]|$)' "${release_lookup_error}"; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- 为 prerelease 通道增加独立 AList index（`/mihari-release/mihari-dev`）与 `retract-dev` 撤回入口（#126）。
+
 ### Fixed
 
 ## [v0.9.0] - 2026-08-24

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -20,7 +20,7 @@
 | `retract.yml` | 从 `main` 手动 dispatch（稳定 `version` + `confirm`） | Stable | 删除 stable Release 及其 assets、保留 canonical stable tag，并删除 `/mihari-release/mihari/<version>/`；必要时重建 stable `index.txt` |
 | `retract-dev.yml` | 从受保护的 `dev` 手动 dispatch（dev `version` + `confirm`） | Dev | 删除 `/mihari-release/mihari-dev/<version>/` 与 GitHub prerelease 及其 assets、保留 canonical dev tag；必要时重建 dev `index.txt` |
 
-GitHub dev prerelease 流程已经实际发布并验收 `v0.9.0-dev.2`（精确 14 个 assets，当时 GitHub-only、不写 AList）。独立 AList 根目录 `/mihari-release/mihari-dev` 从本变更落地后的下一个 `vX.Y.Z-dev.N` 开始写入，不回溯该历史版本。稳定 AList、`/mihari-release/mihari/index.txt` 与 `/releases/latest` 不受 dev 发布影响。
+GitHub dev prerelease 流程已经实际发布并验收 `v0.9.0-dev.2`（精确 14 个 assets，当时 GitHub-only、不写 AList）。独立 AList 根目录 `/mihari-release/mihari-dev` 从本变更落地后的下一个 `vX.Y.Z-dev.N` 开始写入。不回溯 `v0.9.0-dev.2` 是首次真实 dispatch 的人工操作规则：workflow 不会因历史 GitHub-only 版本自动拒绝；空的 dev AList 根上重跑会创建通道并写入该版本。稳定 AList、`/mihari-release/mihari/index.txt` 与 `/releases/latest` 不受 dev 发布影响。
 
 远端 active tag ruleset 覆盖 `refs/tags/v*`，禁止删除、更新和 non-fast-forward；canonical stable/dev tag 一旦创建不得改写。`v*` tag push 保留为兼容触发入口，但当前稳定发版操作使用 `main` 上的 `workflow_dispatch`。
 
@@ -175,7 +175,7 @@ Get-FileHash mihari-windows-amd64.exe -Algorithm SHA256
 
 ### Dev 手动发布
 
-从 GitHub Actions 选择 `release-dev` workflow 和受保护的 `dev` ref，填写符合 canonical `vX.Y.Z-dev.N` 格式的版本（各数字段不允许前导零）。workflow 先创建或复用 GitHub dev tag、prerelease 并上传精确 14 个 assets；GitHub 最终验收成功后，若 `ALIST_URL` 存在则写入独立 AList 根目录 `/mihari-release/mihari-dev` 及其 `index.txt`。`v0.9.0-dev.2` 已按 GitHub-only 路径发布并完成公开资产验收；AList 从本变更后的新版本开始，不回溯该历史版本。
+从 GitHub Actions 选择 `release-dev` workflow 和受保护的 `dev` ref，填写符合 canonical `vX.Y.Z-dev.N` 格式的版本（各数字段不允许前导零）。workflow 先创建或复用 GitHub dev tag、prerelease 并上传精确 14 个 assets；GitHub 最终验收成功后，若 `ALIST_URL` 存在则写入独立 AList 根目录 `/mihari-release/mihari-dev` 及其 `index.txt`。`v0.9.0-dev.2` 已按 GitHub-only 路径发布并完成公开资产验收。不回溯该历史版本是首次真实 dispatch 的人工操作规则：workflow 不会因历史 GitHub-only 版本自动拒绝；空的 dev AList 根上重跑会创建通道并写入该版本。请从本变更后的下一个 `vX.Y.Z-dev.N` 开始写入 AList。
 
 AList 是否启用只由 `ALIST_URL` 决定：URL 缺失时 skip AList，GitHub prerelease 仍成功；URL 存在但 `ALIST_USERNAME` 或 `ALIST_PASSWORD` 任一缺失时，客户端 fail closed，workflow 失败。dev 发布与 `retract-dev.yml` 共用 job 级并发组 `mihari-dev-alist`。公开 dev index 为 `https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari-dev/index.txt`。dev 根目录不上传 `install-aio-remote.sh` / `.ps1`；稳定安装入口仍使用 `/mihari-release/mihari/index.txt`，不会指向 dev。
 
@@ -205,9 +205,9 @@ AList 不提供 compare-and-swap（CAS），因此事务前检查与单次 PUT �
 
 1. 在 GitHub 仓库 Actions 页面选择 `dev` 分支/ref，再运行 `retract-dev` workflow；
 2. 填写 `version`（canonical `vX.Y.Z-dev.N`）并勾选 `confirm` 双保险；
-3. workflow 自动：先操作独立 `/mihari-release/mihari-dev`（必要时重建 dev `index.txt`），再永久删除 GitHub prerelease 及其 assets，但保留 canonical dev tag。远端尚未存在 `mihari-dev` 时 AList 为 no-op，仍可删除 GitHub prerelease。
+3. workflow 自动：先操作独立 `/mihari-release/mihari-dev`（必要时重建 dev `index.txt`），再永久删除 GitHub prerelease 及其 assets，但保留 canonical dev tag。AList no-op 的前置条件是存储根 listing 已确认存在稳定目录 `mihari`：缺少或无法确认该目录时 fail closed（`unable to inspect release root`），不会继续删除 GitHub prerelease；只有已确认稳定根存在且缺少 `mihari-dev` 时才是 no-op。
 
-dev 撤回使用并发组 `mihari-dev-alist`，不得触碰稳定目录、稳定 `/mihari-release/mihari/index.txt` 或 `/releases/latest`。历史 GitHub-only 版本 `v0.9.0-dev.2` 也可用该入口撤回 GitHub prerelease。
+dev 撤回使用并发组 `mihari-dev-alist`，不得修改稳定目录、稳定 `/mihari-release/mihari/index.txt` 或 `/releases/latest`。历史 GitHub-only 版本 `v0.9.0-dev.2` 也可用该入口撤回 GitHub prerelease。
 
 ## CI/CD 检查项
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -16,10 +16,11 @@
 | Workflow | 触发方式 | 通道 | 允许写入 |
 |----------|----------|------|----------|
 | `release.yml` | 主路径：从 `main` 手动 dispatch（稳定 `version` + 精确 `commit_sha`）；兼容 `v*` tag push | Stable | GitHub stable Release；`/mihari-release/mihari` 及其 stable `index.txt` |
-| `release-dev.yml` | 从受保护的 `dev` 手动 dispatch（dev `version`） | Dev | 仅写 GitHub dev tag、prerelease 与精确 14 个 assets；不写 AList |
+| `release-dev.yml` | 从受保护的 `dev` 手动 dispatch（dev `version`） | Dev | GitHub prerelease 与精确 14 个 assets；`ALIST_URL` 存在时写入 `/mihari-release/mihari-dev` 及其 dev `index.txt` |
 | `retract.yml` | 从 `main` 手动 dispatch（稳定 `version` + `confirm`） | Stable | 删除 stable Release 及其 assets、保留 canonical stable tag，并删除 `/mihari-release/mihari/<version>/`；必要时重建 stable `index.txt` |
+| `retract-dev.yml` | 从受保护的 `dev` 手动 dispatch（dev `version` + `confirm`） | Dev | 删除 `/mihari-release/mihari-dev/<version>/` 与 GitHub prerelease 及其 assets、保留 canonical dev tag；必要时重建 dev `index.txt` |
 
-GitHub dev prerelease 流程已经实际发布并验收 `v0.9.0-dev.2`（精确 14 个 assets，且不写 AList）。dev AList 发布与 dev retract workflow 仍不可用，因此没有 dev AList 版本目录、下载命令或撤回入口；稳定 AList、stable `index.txt` 与 `/releases/latest` 不受 dev 发布影响。
+GitHub dev prerelease 流程已经实际发布并验收 `v0.9.0-dev.2`（精确 14 个 assets，当时 GitHub-only、不写 AList）。独立 AList 根目录 `/mihari-release/mihari-dev` 从本变更落地后的下一个 `vX.Y.Z-dev.N` 开始写入，不回溯该历史版本。稳定 AList、`/mihari-release/mihari/index.txt` 与 `/releases/latest` 不受 dev 发布影响。
 
 远端 active tag ruleset 覆盖 `refs/tags/v*`，禁止删除、更新和 non-fast-forward；canonical stable/dev tag 一旦创建不得改写。`v*` tag push 保留为兼容触发入口，但当前稳定发版操作使用 `main` 上的 `workflow_dispatch`。
 
@@ -28,9 +29,9 @@ GitHub dev prerelease 流程已经实际发布并验收 `v0.9.0-dev.2`（精确 
 | 通道 | 来源与版本 | GitHub Release | AList 根目录 | 稳定入口影响 |
 |------|------------|----------------|--------------|--------------|
 | Stable | `dev → main` 晋级 PR 合并后的精确 40 位 `main` commit SHA；`vX.Y.Z` | 正式 release，参与 `/releases/latest` | `/mihari-release/mihari` | 更新稳定 `index.txt`，供稳定安装器使用 |
-| Dev | `dev` 上的 `vX.Y.Z-dev.N` | GitHub tag、prerelease 与 14 个 assets；`v0.9.0-dev.2` 已通过实际验收 | 尚不可用 | 不写稳定 `index.txt`、版本目录或 `/releases/latest` |
+| Dev | `dev` 上的 `vX.Y.Z-dev.N` | GitHub tag、prerelease 与 14 个 assets；`v0.9.0-dev.2` 已通过实际验收 | `/mihari-release/mihari-dev` | 不写稳定 `/mihari-release/mihari/index.txt`、版本目录或 `/releases/latest` |
 
-Dev 发布固定 `refs/heads/dev` 来源并校验 canonical `vX.Y.Z-dev.N` 版本身份；已有同名 tag 时必须验证其 commit，身份不符即拒绝且不覆盖。dev AList 发布与 dev retract workflow 尚不可用，不提供 dev AList 操作入口。
+Dev 发布固定 `refs/heads/dev` 来源并校验 canonical `vX.Y.Z-dev.N` 版本身份；已有同名 tag 时必须验证其 commit，身份不符即拒绝且不覆盖。dev 发布与 `retract-dev.yml` 使用独立并发组 `mihari-dev-alist`，不得复用 `mihari-stable-alist`。
 
 ## 发版流程
 
@@ -174,11 +175,13 @@ Get-FileHash mihari-windows-amd64.exe -Algorithm SHA256
 
 ### Dev 手动发布
 
-从 GitHub Actions 选择 `release-dev` workflow 和受保护的 `dev` ref，填写符合 canonical `vX.Y.Z-dev.N` 格式的版本（各数字段不允许前导零）。workflow 只创建或复用 GitHub dev tag、prerelease 并上传精确 14 个 assets，不写 AList。`v0.9.0-dev.2` 已按该路径发布并完成公开资产验收。
+从 GitHub Actions 选择 `release-dev` workflow 和受保护的 `dev` ref，填写符合 canonical `vX.Y.Z-dev.N` 格式的版本（各数字段不允许前导零）。workflow 先创建或复用 GitHub dev tag、prerelease 并上传精确 14 个 assets；GitHub 最终验收成功后，若 `ALIST_URL` 存在则写入独立 AList 根目录 `/mihari-release/mihari-dev` 及其 `index.txt`。`v0.9.0-dev.2` 已按 GitHub-only 路径发布并完成公开资产验收；AList 从本变更后的新版本开始，不回溯该历史版本。
+
+AList 是否启用只由 `ALIST_URL` 决定：URL 缺失时 skip AList，GitHub prerelease 仍成功；URL 存在但 `ALIST_USERNAME` 或 `ALIST_PASSWORD` 任一缺失时，客户端 fail closed，workflow 失败。dev 发布与 `retract-dev.yml` 共用 job 级并发组 `mihari-dev-alist`。公开 dev index 为 `https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari-dev/index.txt`。dev 根目录不上传 `install-aio-remote.sh` / `.ps1`；稳定安装入口仍使用 `/mihari-release/mihari/index.txt`，不会指向 dev。
 
 Dev workflow 会在 mutation 前和最终验收时重新读取并 peel 当前 dev tag；前后复核不是原子操作，因此还依赖已 active、覆盖 `refs/tags/v*` 的 tag ruleset 禁止删除、更新和 non-fast-forward。对已有同版本 Release 的 checksum 冲突会在 tag mutation 前 fail closed。
 
-Dev 发布还要求仓库已经存在至少一个合法的 stable GitHub Release，且 `/releases/latest` 能返回非 draft、非 prerelease 的稳定版本；缺少该前置条件时 workflow 会在任何 dev mutation 前 fail closed。dev AList 发布与 dev retract workflow 尚不可用，因此这里不提供 dev AList 命令、版本目录或撤回入口。
+Dev 发布还要求仓库已经存在至少一个合法的 stable GitHub Release，且 `/releases/latest` 能返回非 draft、非 prerelease 的稳定版本；缺少该前置条件时 workflow 会在任何 dev mutation 前 fail closed。
 
 ## 回滚发布（致命错误撤回）
 
@@ -196,7 +199,15 @@ AList 不提供 compare-and-swap（CAS），因此事务前检查与单次 PUT �
 
 > 旧的手动删标签 + 网页删 Release 方式仅删 GitHub 侧、不重建 AList index，已由 `retract` workflow 取代。
 
-Dev AList 发布与 dev retract workflow 尚不可用；dev 撤回没有可执行入口。任何后续 dev 分发操作仍不得触碰稳定目录、稳定 `index.txt` 或 `/releases/latest`。
+### Dev 撤回
+
+发现致命错误需要撤回某 dev 版本时，使用 `retract-dev.yml` 永久移除其 GitHub prerelease、assets 与 `/mihari-release/mihari-dev/<version>/`，但保留 canonical dev tag：
+
+1. 在 GitHub 仓库 Actions 页面选择 `dev` 分支/ref，再运行 `retract-dev` workflow；
+2. 填写 `version`（canonical `vX.Y.Z-dev.N`）并勾选 `confirm` 双保险；
+3. workflow 自动：先操作独立 `/mihari-release/mihari-dev`（必要时重建 dev `index.txt`），再永久删除 GitHub prerelease 及其 assets，但保留 canonical dev tag。远端尚未存在 `mihari-dev` 时 AList 为 no-op，仍可删除 GitHub prerelease。
+
+dev 撤回使用并发组 `mihari-dev-alist`，不得触碰稳定目录、稳定 `/mihari-release/mihari/index.txt` 或 `/releases/latest`。历史 GitHub-only 版本 `v0.9.0-dev.2` 也可用该入口撤回 GitHub prerelease。
 
 ## CI/CD 检查项
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -209,7 +209,7 @@ dev 发布与 `retract-dev.yml` 另有两类 artifact，同样仅在 AList mutat
 
 ## 五、版本撤回（致命错误）
 
-独立 workflow `.github/workflows/retract.yml` 手动触发，永久移除坏版本的 GitHub Release、assets 与 AList 分发数据，但保留 canonical stable tag。dev 通道使用独立的 `.github/workflows/retract-dev.yml`：只操作 `/mihari-release/mihari-dev/<version>/` 与 dev `index.txt`，删除 GitHub prerelease 及其 assets，保留 canonical `vX.Y.Z-dev.N` tag；不得触碰稳定 `index.txt`、稳定版本目录或 `/releases/latest`。
+独立 workflow `.github/workflows/retract.yml` 手动触发，永久移除坏版本的 GitHub Release、assets 与 AList 分发数据，但保留 canonical stable tag。dev 通道使用独立的 `.github/workflows/retract-dev.yml`：只操作 `/mihari-release/mihari-dev/<version>/` 与 dev `index.txt`，删除 GitHub prerelease 及其 assets，保留 canonical `vX.Y.Z-dev.N` tag；不得修改稳定 `index.txt`、稳定版本目录或 `/releases/latest`。当 AList 已配置时，dev 撤回会只读 snapshot/compare 稳定 index 做隔离检查，这不是写入。
 
 稳定撤回步骤：
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -37,7 +37,7 @@ curl -fsSL https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/insta
 
 > 命令中的网址是 AList 网盘的固定公开直链（签名已关闭），永久不变，复制即用。
 
-GitHub dev prerelease `v0.9.0-dev.2` 已发布并完成精确 14 个 assets 的公开验收，且未写 AList。dev AList 发布与 dev retract workflow 仍不可用，因此没有 dev AList 版本目录、下载命令或撤回入口；稳定安装入口不会指向 dev。
+GitHub dev prerelease `v0.9.0-dev.2` 已发布并完成精确 14 个 assets 的公开验收，当时未写 AList。独立 dev AList 根目录为 `/mihari-release/mihari-dev`，公开 index 为 `https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari-dev/index.txt`；稳定安装入口仍读取 `/mihari-release/mihari/index.txt`，不会指向 dev。历史 `v0.9.0-dev.2` 不回溯到 AList。
 
 脚本3 下载器的执行流程：
 
@@ -64,8 +64,16 @@ sh install-aio.sh        # Windows: powershell -File install-aio.ps1
 |------|--------|------|
 | `MIHARI_BIN` | `/usr/local/bin`（Linux/macOS）<br>`%LOCALAPPDATA%\Programs\mihari`（Windows） | mihari 二进制安装目录 |
 | `MIHARI_DATA` | `$HOME/.mihari`（Linux/macOS）<br>`%USERPROFILE%\.mihari`（Windows） | 数据根目录（核心 + GeoIP 落地处） |
-| `MIHARI_INDEX_URL` | 公开直链（见脚本默认值） | index.txt 公开直链（脚本3） |
+| `MIHARI_INDEX_URL` | 公开直链（见脚本默认值） | index.txt 公开直链（脚本3）；默认仍是稳定 `/mihari-release/mihari/index.txt` |
 | `MIHARI_BUNDLE_URL` | 空 | 显式指定整合包 URL，**跳过 index 与 sha256 校验**（信任自担） |
+
+README 默认安装命令仍指向稳定入口。覆盖 `MIHARI_INDEX_URL` 可解析 dev index，下载器本身仍从稳定根目录获取（dev 根不放置 `install-aio-remote.sh` / `.ps1`）：
+
+```bash
+# Linux / macOS：用稳定下载器解析 dev index
+MIHARI_INDEX_URL=https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari-dev/index.txt \
+  curl -fsSL https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.sh | bash
+```
 
 ---
 
@@ -109,7 +117,7 @@ settings 新增可选字段 `core-channel` 与 `core-channel-bundle`（schema �
 
 ## 三、AList 网盘目录结构
 
-AList base path 不是可配置入口：策略层将 stable 固定为 `/mihari-release/mihari`，并为尚未实现的 dev AList 通道保留 `/mihari-release/mihari-dev`；传入其他路径会被拒绝。当前可用的 stable 目录如下：
+AList base path 不是可配置入口：策略层将 stable 固定为 `/mihari-release/mihari`，将 dev 固定为 `/mihari-release/mihari-dev`；传入其他路径会被拒绝。
 
 ```
 stable（仅稳定通道）：
@@ -124,9 +132,19 @@ stable（仅稳定通道）：
 │   └── COMPLETE                    完整标记（内部语义）
 ├── v0.2.0/
 └── v0.1.0/
+
+dev（仅预发布通道；无安装器）：
+
+/mihari-release/mihari-dev/         base_path（fs/API 路径）
+├── index.txt                       路由表；latest 只能是 vX.Y.Z-dev.N
+└── vX.Y.Z-dev.N/                   不可变版本目录（无 install-aio-remote.*）
+    ├── mihari-all-in-one-{linux,darwin,windows}-{amd64,arm64}.tar.gz / .zip
+    ├── SHA256SUMS.txt
+    ├── BUILDINFO
+    └── COMPLETE
 ```
 
-`/mihari-release/mihari-dev` 只是为后续 dev 分发保留的固定策略路径。dev AList 发布与 dev retract workflow 尚不可用，当前不创建或操作该目录；已发布的 GitHub dev prerelease 不改变稳定 `index.txt` 或 `/releases/latest`。
+稳定公开 index：`https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/index.txt`。公开 dev index：`https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari-dev/index.txt`。dev 根不放置 `install-aio-remote.sh` / `.ps1`。已发布的 GitHub dev prerelease 与后续 dev AList 写入均不改变稳定 `index.txt` 或 `/releases/latest`。
 
 > **AList 拓扑 quirk（读路径 / 下载）**：**公开下载 URL** 需在 `/p` 后加 `/public` 挂载点前缀，即 `https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/…`（`alist_client.public_url` 自动处理）。
 >
@@ -166,9 +184,11 @@ release workflow 的 AList 步骤顺序保证用户永远拿不到半成品：
 
 第三方值和不确定 readback 均转入人工恢复，不得触发自动 rollback。AList 不提供 compare-and-swap（CAS）或原子 rename，因此事务前检查与单次 PUT 之间仍有竞态，覆盖期间也可能出现短暂解析窗口，不能声称彻底原子或零失败窗口。
 
-Stable release 与 retract workflow 共用 channel concurrency，避免这两类 Actions writer 互相并行，但它不能约束 workflow 外的管理员操作。执行人工 `regenerate-index` 或 artifact 恢复前，必须确认相关 release/retract workflow 均未运行；从读取现场、判断 metadata、写入到最终回读的整个期间，都必须禁止其他人工或自动 writer。
+Stable release 与 retract workflow 共用 channel concurrency（`mihari-stable-alist`），避免这两类 Actions writer 互相并行；dev 发布与 `retract-dev.yml` 使用独立并发组 `mihari-dev-alist`，不得复用稳定锁。它们不能约束 workflow 外的管理员操作。执行人工 `regenerate-index` 或 artifact 恢复前，必须确认相关 release/retract workflow 均未运行，且两条并发组都空闲；从读取现场、判断 metadata、写入到最终回读的整个期间，都必须禁止其他人工或自动 writer。`regenerate-index.py` 默认 `--channel stable`，写入 `/mihari-release/mihari/index.txt`；修复 dev index 必须显式 `--channel dev`。
 
-Writer 在首次 mutation 前把原状态写入 runner 的 `stable/` 备份目录：`index.txt` 保存原始字节，`metadata.json` 保存 `existed`、`channel`、`path` 和 index 字节的 `sha256`。仅当 AList mutation 失败或 mutation 期间取消时，release/retract workflow 才会将两者作为 `stable-index-backup-<run_id>-<attempt>` workflow artifact 上传并保留 3 天。AList mutation 已成功后若下游步骤失败，workflow 不会上传该 artifact，因为远端 index 已经验证提交成功，无需恢复旧 index。人工恢复时必须从对应 run 下载 artifact，先验证 `channel=stable`、固定 `path=/mihari-release/mihari/index.txt` 及 `sha256`：`existed=false` 表示原对象不存在，应在确认没有合法并发更新后删除该 index；`existed=true` 且 `index.txt` 为空表示恢复为空文件；`existed=true` 且非空则逐字节恢复其内容。恢复后再次下载并逐字节核对；runner 本地 `$RUNNER_TEMP` 不能作为运行结束后的恢复入口。
+Writer 在首次 mutation 前把原状态写入 runner 的通道备份目录：`index.txt` 保存原始字节，`metadata.json` 保存 `existed`、`channel`、`path` 和 index 字节的 `sha256`。仅当 AList mutation 失败或 mutation 期间取消时，release/retract workflow 才会将两者作为 `stable-index-backup-<run_id>-<attempt>` workflow artifact 上传并保留 3 天。AList mutation 已成功后若下游步骤失败，workflow 不会上传该 artifact，因为远端 index 已经验证提交成功，无需恢复旧 index。人工恢复时必须从对应 run 下载 artifact，先验证 `channel=stable`、固定 `path=/mihari-release/mihari/index.txt` 及 `sha256`：`existed=false` 表示原对象不存在，应在确认没有合法并发更新后删除该 index；`existed=true` 且 `index.txt` 为空表示恢复为空文件；`existed=true` 且非空则逐字节恢复其内容。恢复后再次下载并逐字节核对；runner 本地 `$RUNNER_TEMP` 不能作为运行结束后的恢复入口。
+
+dev 发布与 `retract-dev.yml` 另有两类 artifact，同样仅在 AList mutation 失败或 mutation 期间取消时上传并保留 3 天：`dev-index-backup-<run_id>-<attempt>` 的 metadata 为 `channel=dev` 且 `path=/mihari-release/mihari-dev/index.txt`；隔离失败另有 `stable-index-isolation-<run_id>-<attempt>`（`channel=stable` / `path=/mihari-release/mihari/index.txt`）。两类 artifact 不得交叉恢复：禁止用 dev backup 写稳定 index，也禁止用 isolation snapshot 写 dev index。恢复稳定 index 的唯一允许来源是 `stable-index-isolation-*` 或稳定通道自己的 `stable-index-backup-*`。
 
 ---
 
@@ -184,7 +204,9 @@ Writer 在首次 mutation 前把原状态写入 runner 的 `stable/` 备份目�
 
 ## 五、版本撤回（致命错误）
 
-独立 workflow `.github/workflows/retract.yml` 手动触发，永久移除坏版本的 GitHub Release、assets 与 AList 分发数据，但保留 canonical stable tag：
+独立 workflow `.github/workflows/retract.yml` 手动触发，永久移除坏版本的 GitHub Release、assets 与 AList 分发数据，但保留 canonical stable tag。dev 通道使用独立的 `.github/workflows/retract-dev.yml`：只操作 `/mihari-release/mihari-dev/<version>/` 与 dev `index.txt`，删除 GitHub prerelease 及其 assets，保留 canonical `vX.Y.Z-dev.N` tag；不得触碰稳定 `index.txt`、稳定版本目录或 `/releases/latest`。
+
+稳定撤回步骤：
 
 1. 在 GitHub Actions 选择 `main` 分支/ref 后运行；`workflow_dispatch` 输入 `version`（纯 semver 闸门）+ `confirm`（布尔双保险）；
 2. 读 `index.txt` 判断撤回版本是否为当前 latest；

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -71,8 +71,13 @@ README 默认安装命令仍指向稳定入口。覆盖 `MIHARI_INDEX_URL` 可�
 
 ```bash
 # Linux / macOS：用稳定下载器解析 dev index
-MIHARI_INDEX_URL=https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari-dev/index.txt \
-  curl -fsSL https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.sh | bash
+curl -fsSL https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.sh | MIHARI_INDEX_URL=https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari-dev/index.txt bash
+```
+
+```powershell
+# Windows (PowerShell)：用稳定下载器解析 dev index
+$env:MIHARI_INDEX_URL='https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari-dev/index.txt'
+& ([scriptblock]::Create((irm https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.ps1)))
 ```
 
 ---

--- a/docs/superpowers/plans/2026-08-24-prerelease-alist-index.md
+++ b/docs/superpowers/plans/2026-08-24-prerelease-alist-index.md
@@ -1,0 +1,1270 @@
+# Prerelease AList Index Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 把已有的 `--channel dev` 策略接到 `release-dev.yml` / 新的 `retract-dev.yml`，在 `/mihari-release/mihari-dev/index.txt` 写出独立 prerelease `latest`，且永不改写稳定 `index.txt` 或 GitHub `/releases/latest`。
+
+**Architecture:** 脚本层先补 `_fs_path`-正确的通道根探测、topology-aware Fake、隔离守卫和 CI 测试列表（PR 1，此时文档仍写「P2 不可用」）。然后在**同一个** Actions/文档 PR（PR 2）里接线发布与撤回，避免 `dev` 上出现没有 retract 的 AList writer。
+
+**Tech Stack:** Python 3.12、pytest、GitHub Actions YAML、现有 `scripts/release-alist.py` / `retract-alist.py` / `alist_client.py`。
+
+---
+
+## Global Constraints
+
+- 只在 worktree 分支 `feat/126-prerelease-alist-index` 工作（跟踪 `origin/dev`）。禁止提交 `main` / `dev`。
+- 规范：`docs/superpowers/specs/2026-08-24-prerelease-alist-index-design.md`（已 Approved）。YAML 步骤以该文档为准，不要即兴改顺序。GitHub delete 脚本例外：设计文档里是注释，必须从 `.github/workflows/retract.yml` 第 122–139 行复制真实 lookup + 404 分支（见 Task 10）。
+- Issue：https://github.com/mihari-proxy/mihari/issues/126
+- 已拍板：不回溯 `v0.9.0-dev.2/.3`；notes 追加 `MIHARI_INDEX_URL`；共用 `MIHARI_KEEP_VERSIONS`；`regenerate-index --channel` 进 PR 1；自动 mkdir `mihari-dev`。
+- **生产行为变更**走 Red–Green–Refactor。Task 1–2 是表征钉（characterization pin），不是 TDD，不要写成 red-green。
+- 只提交绿灯。禁止把已知失败的测试当成完成的 Task 提交。红灯测试写完、确认 FAIL 后停住，并入随后的绿灯 commit。
+- 不打公网、不连真实 AList、不改 `/v1` / daemon / TUI / README 快速开始。
+- 不上传 `install-aio-remote.*` 到 dev 根。不把 `mihari-stable-alist` 写进 dev workflow。不改默认安装器 URL。
+- Conventional Commits，摘要中文。下面标了 commit message 的步骤才允许 `git commit`。
+- Windows 上 pytest / go 命令在 worktree 根目录执行。
+
+## File Structure
+
+**PR 1（脚本 + CI 列表）**
+
+- Modify: `scripts/alist_client.py` — `storage_root_entries`
+- Modify: `scripts/release-alist.py` — `ensure_channel_root`，仅 `channel == "dev"` 在 `publish()` 开头调用
+- Modify: `scripts/retract-alist.py` — 同一探测；有 `mihari`、无 `mihari-dev` → AList no-op
+- Create: `scripts/alist_channel_guard.py`
+- Modify: `scripts/regenerate-index.py` — `--channel` + help/notice；`regenerate_index(alist, base_path, channel="stable")`
+- Create: `scripts/test_alist_topology_fake.py` — topology-aware Fake（**内部键一律 fs 路径**）
+- Create: `scripts/test_alist_channel_guard.py`
+- Modify: `scripts/test_alist_client.py`, `test_release_alist.py`, `test_retract_alist.py`, `test_regenerate_index.py`, `test_release_workflow.py`（只改 `RELEASE_SAFETY_TESTS`）
+- Modify: `.github/workflows/ci.yml` — pytest 命令与 constant 同步
+
+**PR 2（发布 + 撤回 + 文档一次翻转）**
+
+- Modify: `.github/workflows/release-dev.yml`
+- Create: `.github/workflows/retract-dev.yml`
+- Modify: `scripts/test_release_workflow.py`（YAML 断言在写 YAML **之前**；文档断言留到 Task 11）
+- Modify: `docs/RELEASE.md`, `docs/distribution.md`, `CHANGELOG.md`
+
+---
+
+### Task 1: 表征钉 `_fs_path("/mihari-release/mihari-dev")` 与 `"/"`
+
+**性质：** characterization pin，不是 TDD。现实现已正确；本 Task 只加回归断言。不要为了「走一遍 red-green」去改生产代码。可单独绿灯提交，也可暂不 commit、并入 Task 4 的 `feat` commit。
+
+**Files:**
+- Modify: `scripts/test_alist_client.py` — `test_fs_path_strips_mount_segment`
+- Modify: `scripts/alist_client.py` — **仅当断言失败才改**；预期现实现已正确
+
+**Step 1: 先跑现有测试确认基线**
+
+Run: `python -m pytest scripts/test_alist_client.py::test_fs_path_strips_mount_segment -q`
+
+Expected: PASS
+
+**Step 2: 追加表征断言**
+
+在 `test_fs_path_strips_mount_segment` 末尾追加：
+
+```python
+    assert alist._fs_path("/mihari-release/mihari-dev") == "/mihari-dev"
+    assert alist._fs_path("/mihari-release/mihari-dev/index.txt") == "/mihari-dev/index.txt"
+    assert alist._fs_path("/") == "/"
+```
+
+保留现有 `assert alist._fs_path("/mihari-release") == "/mihari-release"`。
+
+**Step 3: 再跑**
+
+Run: `python -m pytest scripts/test_alist_client.py::test_fs_path_strips_mount_segment -q`
+
+Expected: PASS（`sep <= 0` 时原样返回 `"/"`, 两段路径丢掉首段得 `/mihari-dev`）。若 FAIL，按 `sep <= 0: return path` / `"/" + rest[sep+1:]` 修，不要改成 list `/mihari-release`。
+
+**Step 4: 可选绿灯 commit**（不要写成 red-green）
+
+```bash
+git add scripts/test_alist_client.py scripts/alist_client.py
+git commit -m "test: 钉死 dev 通道 AList fs 路径映射"
+```
+
+---
+
+### Task 2: 表征钉 `list_dir("/")` 的 fs JSON `path` 必须是 `"/"`
+
+**性质：** characterization pin，不是 TDD。`list_dir` 已发送 `"path": self._fs_path(path)`，`LIST_PAGE_SIZE = 200`。可单独绿灯提交，也可并入 Task 4。
+
+**Files:**
+- Modify: `scripts/test_alist_client.py`
+- Modify: `scripts/alist_client.py` — 仅当断言失败才改
+
+**Step 1: 写表征测试**
+
+追加：
+
+```python
+def test_list_dir_root_sends_slash_fs_path():
+    alist = AList.__new__(AList)
+    captured = {}
+
+    class Session:
+        def post(self, url, timeout=None, json=None):
+            captured["url"] = url
+            captured["json"] = json
+            return list_response(
+                content=[{"name": "mihari", "is_dir": True}],
+                total=1,
+                page=1,
+                per_page=200,
+                has_more=False,
+                pages_total=1,
+            )
+
+    alist.base = "https://cloud.example.com"
+    alist.session = Session()
+    entries = alist.list_dir("/")
+    assert captured["url"].endswith("/api/fs/list")
+    assert captured["json"]["path"] == "/"
+    assert entries == [{"name": "mihari", "is_dir": True}]
+```
+
+`list_response` 的 `per_page` 默认已是 200，与 `LIST_PAGE_SIZE` 对齐即可。
+
+**Step 2: 跑测试**
+
+Run: `python -m pytest scripts/test_alist_client.py::test_list_dir_root_sends_slash_fs_path -q`
+
+Expected: PASS。FAIL 则修 `_fs_path`，禁止为了这个测试去 list `/mihari-release`。
+
+**Step 3: 可选绿灯 commit**
+
+```bash
+git add scripts/test_alist_client.py
+git commit -m "test: 校验存储根 list 使用 fs 路径斜杠"
+```
+
+---
+
+### Task 3: Topology-aware Fake + 红灯 first-publish（不 commit）
+
+**Files:**
+- Create: `scripts/test_alist_topology_fake.py`
+- Modify: `scripts/test_release_alist.py`
+
+本 Task **写 Fake 与失败测试、确认 FAIL、停止。不要 `git commit`。** Fake、红灯测试与 `ensure_channel_root` 一并进入 Task 4 的绿灯 commit。
+
+**Step 1: 实现 Fake（测试辅助，不是生产代码）**
+
+约定（锁定，不要另写「逻辑路径存储」版本）：
+
+1. 内部键是 **fs** 路径。起始 `dirs = {"/", "/mihari"}`。**不要**预置 `/mihari-release` 或 `/mihari-dev`。
+2. `list_dir` / `mkdir` / `exists` / `content` / `upload` / `upload_text` 接收逻辑路径，用真实 `AList._fs_path` 转成 fs 再查表。
+3. `mkdir` 的父目录检查在 fs 空间：`/mihari-dev` 的父是 `"/"`。禁止 `mkdir` 出 fs `"/"`。
+4. 测试断言用 `alist.content(logical)`，**禁止** `logical in alist.files`（`files` 的键是 fs）。
+5. 每次操作记录 `(op, logical, fs)`；测试断言 `fs != "/mihari-release"`。
+6. `content()` 必须先 `self.exists(path)` 再读，与生产 `AList.content` 相同。`exists()` 通过 `list_dir(parent)` 实现，因此 `exists("/mihari-release/mihari-dev")` 会 list 逻辑父 `/mihari-release`（fs `/mihari-release`）——生产代码不得走这条路径。
+
+`scripts/test_alist_topology_fake.py`：
+
+```python
+"""AList fake that honors AList._fs_path and raises on missing fs directories."""
+from pathlib import Path
+
+from alist_client import AList, AListError
+
+
+class TopologyFake:
+    """In-memory AList keyed by fs paths from the real AList._fs_path."""
+
+    def __init__(self):
+        self.files = {}
+        self.dirs = {"/", "/mihari"}
+        self.ops = []
+        self.uploaded = []
+
+    def _fs(self, path):
+        return AList._fs_path(self, path)
+
+    def _record(self, op, logical):
+        fs = self._fs(logical)
+        self.ops.append((op, logical, fs))
+        return fs
+
+    def mkdir(self, path):
+        fs = self._record("mkdir", path)
+        if fs == "/":
+            raise AListError("alist write failed")
+        parent = fs.rsplit("/", 1)[0] or "/"
+        if parent not in self.dirs:
+            raise AListError("alist write failed")
+        self.dirs.add(fs)
+
+    def list_dir(self, path):
+        fs = self._record("list_dir", path)
+        if fs not in self.dirs:
+            raise AListError("invalid directory listing")
+        prefix = fs.rstrip("/") + "/"
+        names = set()
+        for item in list(self.dirs) + list(self.files):
+            if item == fs:
+                continue
+            if item.startswith(prefix):
+                names.add(item[len(prefix):].split("/", 1)[0])
+        entries = []
+        for name in names:
+            child = "/" + name if fs == "/" else prefix + name
+            entries.append({"name": name, "is_dir": child in self.dirs})
+        return entries
+
+    def exists(self, path):
+        self._record("exists", path)
+        parent, name = path.rsplit("/", 1)
+        if not name:
+            raise AListError("invalid object path")
+        return any(entry["name"] == name for entry in self.list_dir(parent or "/"))
+
+    def upload(self, local, remote):
+        fs = self._record("upload", remote)
+        self.files[fs] = Path(local).read_bytes()
+        self.uploaded.append(remote)
+
+    def upload_text(self, text, remote):
+        fs = self._record("upload_text", remote)
+        self.files[fs] = text.encode()
+        self.uploaded.append(remote)
+
+    def content(self, path):
+        self._record("content", path)
+        if not self.exists(path):
+            return None
+        value = self.files.get(self._fs(path))
+        return value.decode() if value is not None else None
+
+    def read_bytes(self, path, **_kwargs):
+        fs = self._record("read_bytes", path)
+        return self.files[fs]
+
+    def remove(self, base, names):
+        self._record("remove", base)
+        for name in names:
+            logical = base.rstrip("/") + "/" + name
+            fs = self._fs(logical)
+            self.files = {
+                key: value
+                for key, value in self.files.items()
+                if key != fs and not key.startswith(fs + "/")
+            }
+            self.dirs = {
+                key for key in self.dirs if key != fs and not key.startswith(fs + "/")
+            }
+
+    def public_url(self, path):
+        return "https://example.invalid" + path
+```
+
+缺失 fs 目录时 `list_dir` **raise `AListError`**（相对现有 Fake 返回 `[]` 的关键差异）。不得在空的旧 `FakeAList` 上写 first-publish——旧 Fake 对缺失目录返回 `[]`，会假绿。
+
+**Step 2: 红灯测试**
+
+`scripts/test_release_alist.py`：
+
+```python
+from test_alist_topology_fake import TopologyFake
+
+
+def test_publish_dev_bootstraps_missing_channel_root(tmp_path):
+    alist = TopologyFake()
+    args = SimpleNamespace(
+        version="v1.2.3-dev.1",
+        dist_dir=make_dist(tmp_path),
+        repo_root=tmp_path,
+        base_path="/mihari-release/mihari-dev",
+        commit_sha="a" * 40,
+        channel="dev",
+        keep_versions=5,
+    )
+    release.publish(alist, args)
+    assert any(
+        op == "mkdir" and logical == "/mihari-release/mihari-dev" and fs == "/mihari-dev"
+        for op, logical, fs in alist.ops
+    )
+    assert not any(fs == "/mihari-release" for _, _, fs in alist.ops)
+    index = f"{args.base_path}/index.txt"
+    assert alist.content(index) is not None
+    assert "latest v1.2.3-dev.1" in alist.content(index)
+    assert index not in alist.files
+```
+
+**Step 3: 跑测试确认因缺少 `ensure_channel_root` 而失败**
+
+Run: `python -m pytest scripts/test_release_alist.py::test_publish_dev_bootstraps_missing_channel_root -q`
+
+Expected: FAIL，`SystemExit` / `unable to inspect release baseline`（`content(index)` → `exists` → `list_dir` 缺失 fs `/mihari-dev` raise）。
+
+**Step 4: 不要 commit。** 进入 Task 4。
+
+---
+
+### Task 4: `storage_root_entries` + `ensure_channel_root`，first-publish 变绿
+
+**Files:**
+- Modify: `scripts/alist_client.py`
+- Modify: `scripts/release-alist.py`
+- Modify: `scripts/test_release_alist.py`
+- Create: `scripts/test_alist_topology_fake.py`（来自 Task 3，本 Task 才进 commit）
+- Modify: `scripts/test_alist_client.py`（可选：直接测 `storage_root_entries`）
+
+**Step 1: 再加红灯测试（全部走 `TopologyFake`）**
+
+```python
+def test_ensure_channel_root_fails_closed_without_mihari_sibling(tmp_path):
+    alist = TopologyFake()
+    alist.dirs.discard("/mihari")
+    args = SimpleNamespace(
+        version="v1.2.3-dev.1",
+        dist_dir=make_dist(tmp_path),
+        repo_root=tmp_path,
+        base_path="/mihari-release/mihari-dev",
+        commit_sha="a" * 40,
+        channel="dev",
+        keep_versions=5,
+    )
+    with pytest.raises(SystemExit):
+        release.publish(alist, args)
+    assert not any(op == "mkdir" for op, _, _ in alist.ops)
+    assert not any(fs == "/mihari-release" for _, _, fs in alist.ops)
+
+
+def test_ensure_channel_root_is_noop_when_mihari_dev_already_a_directory(tmp_path):
+    alist = TopologyFake()
+    alist.dirs.add("/mihari-dev")
+    release.ensure_channel_root(alist, "/mihari-release/mihari-dev", "dev")
+    assert not any(op == "mkdir" for op, _, _ in alist.ops)
+    args = SimpleNamespace(
+        version="v1.2.3-dev.1",
+        dist_dir=make_dist(tmp_path),
+        repo_root=tmp_path,
+        base_path="/mihari-release/mihari-dev",
+        commit_sha="a" * 40,
+        channel="dev",
+        keep_versions=5,
+    )
+    release.publish(alist, args)
+    assert not any(
+        op == "mkdir" and logical == "/mihari-release/mihari-dev"
+        for op, logical, _ in alist.ops
+    )
+    assert alist.content(f"{args.base_path}/index.txt") is not None
+    assert not any(fs == "/mihari-release" for _, _, fs in alist.ops)
+
+
+def test_ensure_channel_root_fails_when_mihari_dev_is_not_a_directory(tmp_path):
+    alist = TopologyFake()
+    alist.files["/mihari-dev"] = b"not-a-directory"
+    args = SimpleNamespace(
+        version="v1.2.3-dev.1",
+        dist_dir=make_dist(tmp_path),
+        repo_root=tmp_path,
+        base_path="/mihari-release/mihari-dev",
+        commit_sha="a" * 40,
+        channel="dev",
+        keep_versions=5,
+    )
+    with pytest.raises(SystemExit):
+        release.publish(alist, args)
+    assert not any(op == "mkdir" for op, _, _ in alist.ops)
+    assert not any(fs == "/mihari-release" for _, _, fs in alist.ops)
+
+
+def test_stable_publish_does_not_list_storage_root_or_mkdir_dev(tmp_path):
+    alist = TopologyFake()
+    repo_root = tmp_path / "repo"
+    write_root_installers(repo_root)
+    args = SimpleNamespace(
+        version="v1.2.3",
+        dist_dir=make_dist(tmp_path),
+        repo_root=repo_root,
+        base_path="/mihari-release/mihari",
+        commit_sha="a" * 40,
+        channel="stable",
+        keep_versions=5,
+    )
+    release.publish(alist, args)
+    assert not any(op == "list_dir" and logical == "/" for op, logical, _ in alist.ops)
+    assert not any(op == "mkdir" and "mihari-dev" in logical for op, logical, _ in alist.ops)
+    assert not any(fs == "/mihari-release" for _, _, fs in alist.ops)
+    assert alist.content("/mihari-release/mihari/index.txt") is not None
+    assert "/mihari-release/mihari/index.txt" not in alist.files
+
+
+def test_ensure_channel_root_skips_stable_without_listing():
+    alist = TopologyFake()
+    release.ensure_channel_root(alist, "/mihari-release/mihari", "stable")
+    assert alist.ops == []
+```
+
+`test_stable_publish_does_not_list_storage_root_or_mkdir_dev` **必须调用 `release.publish()`**，不得用 `ensure_channel_root(..., "stable")` 代替。`write_root_installers` 已在同文件后部定义。helper 单测 `test_ensure_channel_root_skips_stable_without_listing` 是附加项，不是替代。
+
+**Step 2: 跑，确认 FAIL**
+
+Run: `python -m pytest scripts/test_release_alist.py::test_publish_dev_bootstraps_missing_channel_root scripts/test_release_alist.py::test_ensure_channel_root_fails_closed_without_mihari_sibling scripts/test_release_alist.py::test_ensure_channel_root_is_noop_when_mihari_dev_already_a_directory scripts/test_release_alist.py::test_ensure_channel_root_fails_when_mihari_dev_is_not_a_directory scripts/test_release_alist.py::test_stable_publish_does_not_list_storage_root_or_mkdir_dev scripts/test_release_alist.py::test_ensure_channel_root_skips_stable_without_listing -q`
+
+Expected: FAIL（尚无 `ensure_channel_root` / `storage_root_entries`）。
+
+**Step 3: 最小实现**
+
+`scripts/alist_client.py`（`fail` 已在同文件）：
+
+```python
+def storage_root_entries(alist):
+    try:
+        entries = alist.list_dir("/")
+    except Exception:
+        fail("unable to inspect release root")
+    if not isinstance(entries, list):
+        fail("unable to inspect release root")
+    mihari = [e for e in entries if isinstance(e, dict) and e.get("name") == "mihari"]
+    if len(mihari) != 1 or mihari[0].get("is_dir") is not True:
+        fail("unable to inspect release root")
+    return entries
+```
+
+`scripts/release-alist.py` 的 import 行改为包含 `storage_root_entries`：
+
+```python
+from alist_client import AListError, DEFAULT_BASE_PATH, DEFAULT_KEEP_VERSIONS, PLATFORMS, bundle_name, connect, fail, info, sha256_file, storage_root_entries
+```
+
+```python
+def ensure_channel_root(alist, base_path, channel):
+    if channel != "dev":
+        return
+    entries = storage_root_entries(alist)
+    matches = [e for e in entries if isinstance(e, dict) and e.get("name") == "mihari-dev"]
+    if not matches:
+        alist.mkdir(base_path)
+        return
+    if len(matches) != 1 or matches[0].get("is_dir") is not True:
+        fail("channel base path is not a directory")
+
+
+def publish(alist, args):
+    if args.channel == "dev":
+        ensure_channel_root(alist, args.base_path, args.channel)
+    ensure_monotonic_version(...)
+    # 其余保持不变
+```
+
+`list_dir("/")` 的 JSON path 已由 Task 2 钉死。禁止 `list_dir("/mihari-release")`。
+
+**Step 4: 给仍走旧 `FakeAList` 的 `publish(channel="dev")` 测试补存储根**
+
+旧 Fake 的 `list_dir("/")` 按**第一段**切名。逻辑路径 `/mihari-release/mihari-dev/...` 会让 `"/" ` 列出 `name="mihari-release"`，于是 `storage_root_entries` fail-closed。探测本身就是存储根行为变化，旧测试必须认识 `"/"`。
+
+在 `scripts/test_release_alist.py` 的 `FakeAList` 旁加入：
+
+```python
+def seed_storage_root(fake, *, has_dev_channel=True):
+    # Old Fake lists "/" by first logical/fs segment. These two fs-shaped
+    # siblings make storage_root_entries see mihari [+ mihari-dev]
+    # without preloading the forbidden logical path /mihari-release.
+    fake.dirs.add("/mihari")
+    if has_dev_channel:
+        fake.dirs.add("/mihari-dev")
+```
+
+对每一个仍走旧 Fake、且调用 `release.publish(..., channel="dev")` 的测试，在 `publish()` 前调用 `seed_storage_root(alist)`（publish 缺 `/mihari-dev` 时会 mkdir 逻辑 base，空 Fake 可接受；为少一次 mkdir 噪音，publish 测试也 seed 两个 sibling）：
+
+- `test_publish_dev_never_uploads_root_installers`
+- `test_publish_rechecks_index_at_commit_point_and_preserves_newer_index`
+- `test_post_index_retention_list_failure_skips_safely_without_leaking_details`
+
+`LateListFailureAList`：**不要**把 `path == "/"` 计入 `list_calls`，并且 seed：
+
+```python
+        def list_dir(self, path):
+            if path == "/":
+                return super().list_dir(path)
+            self.list_calls += 1
+            if self.list_calls > 2:
+                raise RuntimeError("https://cloud.invalid/list?token=retention-secret body")
+            return super().list_dir(path)
+```
+
+只调 `upload_version_dir` / `ensure_monotonic_version` / `prune_versions` / `write_index_reliably` 的测试不走 `publish()`，不必 seed。
+
+**Step 5: 跑新测试 + 全文件**
+
+Run: `python -m pytest scripts/test_release_alist.py::test_publish_dev_bootstraps_missing_channel_root scripts/test_release_alist.py::test_ensure_channel_root_fails_closed_without_mihari_sibling scripts/test_release_alist.py::test_ensure_channel_root_is_noop_when_mihari_dev_already_a_directory scripts/test_release_alist.py::test_ensure_channel_root_fails_when_mihari_dev_is_not_a_directory scripts/test_release_alist.py::test_stable_publish_does_not_list_storage_root_or_mkdir_dev scripts/test_release_alist.py::test_ensure_channel_root_skips_stable_without_listing scripts/test_release_alist.py::test_publish_dev_never_uploads_root_installers -q`
+
+Expected: PASS
+
+Run: `python -m pytest scripts/test_release_alist.py -q`
+
+Expected: PASS
+
+**Step 6: Commit（含 Task 3 的 Fake 与 first-publish 测试）**
+
+```bash
+git add scripts/alist_client.py scripts/release-alist.py scripts/test_release_alist.py scripts/test_alist_topology_fake.py scripts/test_alist_client.py
+git commit -m "feat: 仅在 dev 通道自动创建 AList 根目录"
+```
+
+---
+
+### Task 5: retract 在已确认存储根上缺失 `mihari-dev` 时 AList no-op
+
+**Files:**
+- Modify: `scripts/retract-alist.py`
+- Modify: `scripts/test_retract_alist.py`
+
+**Step 1: 红灯测试（新行为走 `TopologyFake`）**
+
+在 `scripts/test_retract_alist.py` 增加 `from test_alist_topology_fake import TopologyFake` 以及 `from alist_client import AListError`。
+
+```python
+def test_dev_retract_noops_when_storage_root_has_mihari_but_no_dev_channel():
+    fake = TopologyFake()
+    retract_mod.retract(fake, "/mihari-release/mihari-dev", "v1.0.0-dev.1", "dev", "a" * 40)
+    assert not any(
+        op in {"remove", "upload", "upload_text", "mkdir"} for op, _, _ in fake.ops
+    )
+    assert fake.files == {}
+    assert fake.dirs == {"/", "/mihari"}
+    assert not any(fs == "/mihari-release" for _, _, fs in fake.ops)
+
+
+def test_dev_retract_fails_closed_when_storage_root_lacks_mihari():
+    fake = TopologyFake()
+    fake.dirs.discard("/mihari")
+    with pytest.raises(SystemExit):
+        retract_mod.retract(fake, "/mihari-release/mihari-dev", "v1.0.0-dev.1", "dev", "a" * 40)
+    assert not any(op in {"remove", "upload", "upload_text", "mkdir"} for op, _, _ in fake.ops)
+
+
+def test_dev_retract_fails_closed_when_storage_root_list_raises():
+    fake = TopologyFake()
+    original = fake.list_dir
+
+    def list_dir(path):
+        if path == "/":
+            raise AListError("invalid directory listing")
+        return original(path)
+
+    fake.list_dir = list_dir
+    with pytest.raises(SystemExit):
+        retract_mod.retract(fake, "/mihari-release/mihari-dev", "v1.0.0-dev.1", "dev", "a" * 40)
+    assert not any(op in {"remove", "upload", "upload_text"} for op, _, _ in fake.ops)
+
+
+def test_dev_retract_uses_existing_logic_when_channel_root_exists(tmp_path, monkeypatch):
+    monkeypatch.setenv("RUNNER_TEMP", str(tmp_path))
+    fake = TopologyFake()
+    fake.dirs.add("/mihari-dev")
+    _add_topology_complete(fake, "/mihari-release/mihari-dev", "v1.0.0-dev.1")
+    _add_topology_complete(fake, "/mihari-release/mihari-dev", "v1.1.0-dev.1")
+    fake.upload_text("latest v1.1.0-dev.1\n", "/mihari-release/mihari-dev/index.txt")
+    retract_mod.retract(
+        fake, "/mihari-release/mihari-dev", "v1.1.0-dev.1", "dev", "a" * 40
+    )
+    body = fake.content("/mihari-release/mihari-dev/index.txt")
+    assert body is not None and body.startswith("latest v1.0.0-dev.1\n")
+    assert not fake.exists("/mihari-release/mihari-dev/v1.1.0-dev.1")
+    assert not any(fs == "/mihari-release" for _, _, fs in fake.ops)
+```
+
+`_add_topology_complete` 用 Fake 的逻辑路径 API（`mkdir` / `upload_text`）写入，让键落在 fs 空间；不要把逻辑路径塞进 `fake.files`。可按 `test_retract_alist.add_complete` 的 COMPLETE / BUILDINFO / 六包 / SHA256SUMS 形状移植。
+
+**Step 2: 跑，确认 FAIL**
+
+Run: `python -m pytest scripts/test_retract_alist.py::test_dev_retract_noops_when_storage_root_has_mihari_but_no_dev_channel scripts/test_retract_alist.py::test_dev_retract_fails_closed_when_storage_root_lacks_mihari scripts/test_retract_alist.py::test_dev_retract_fails_closed_when_storage_root_list_raises scripts/test_retract_alist.py::test_dev_retract_uses_existing_logic_when_channel_root_exists -q`
+
+Expected: FAIL（当前 `directory_exists` → `exists(base/version)` → `list_dir(parent)` 在缺失根上 fail `"unable to inspect retraction target"`，不是成功 no-op；list `"/"` 尚未成为 fail-closed 探测）。
+
+**Step 3: 实现**
+
+`scripts/retract-alist.py` 的 import 行必须加上 `storage_root_entries`：
+
+```python
+from alist_client import DEFAULT_BASE_PATH, PLATFORMS, bundle_name, connect, fail, info, storage_root_entries
+```
+
+在 `retract()` 里 `validate_inputs` 之后、`directory_exists` 之前：
+
+```python
+    if channel == "dev":
+        entries = storage_root_entries(alist)
+        matches = [e for e in entries if isinstance(e, dict) and e.get("name") == "mihari-dev"]
+        if not matches:
+            return
+        if len(matches) != 1 or matches[0].get("is_dir") is not True:
+            fail("channel base path is not a directory")
+```
+
+`storage_root_entries` 失败（无 `mihari`、listing 不是 list、传输/`AListError`）已经 `fail("unable to inspect release root")`，不要当成 no-op。
+
+**Step 4: 给仍走旧 `Fake` 的 `retract(..., "dev")` 测试补存储根**
+
+在 `scripts/test_retract_alist.py` 的 `Fake` 旁加入与 Task 4 **相同**的 `seed_storage_root`。
+
+对每一个调用 `retract_mod.retract(..., "dev")` 且应继续走现有 retract 语义的旧 Fake 测试，在调用前 `seed_storage_root(fake, has_dev_channel=True)`：
+
+- `test_retract_refuses_noncanonical_checksum_manifest_without_mutation`
+- `test_dev_retract_rebuilds_highest_remaining_complete`
+- `test_dev_retract_refuses_mismatched_identity`
+- `test_retract_missing_dev_directory_is_idempotent`
+- `test_latest_retraction_switches_verified_index_before_removing_target`
+- `test_latest_retraction_keeps_target_when_index_commit_fails`
+- `test_remove_failure_after_index_commit_preserves_new_index_and_rerun_removes_orphan`
+- `test_last_latest_retraction_commits_empty_index_before_removing_target`
+- `test_latest_retraction_aborts_when_remaining_candidate_cannot_be_read`
+- `test_latest_retraction_aborts_on_malformed_directory_listing`
+- `test_non_latest_retraction_leaves_index_bytes_unchanged`
+- `test_non_latest_retraction_fails_closed_when_index_changes_concurrently`
+- `test_missing_target_referenced_by_index_fails_closed`
+- `test_missing_target_not_referenced_by_index_is_idempotent`
+
+`test_retract_missing_dev_directory_is_idempotent` 保持「**版本目录缺失、通道根存在**」：必须 seed **两个** sibling（`has_dev_channel=True`）。不要把它和新的「存储根有 `mihari`、无 `mihari-dev`」no-op 混成一个测试。seed 后断言改为：`mutations(fake) == []`，且 `"/mihari"` / `"/mihari-dev"` 仍在 `fake.dirs`（不要再要求 `fake.dirs == set()`）。
+
+`test_latest_retraction_aborts_on_malformed_directory_listing` 当前用 `fake.list_dir = lambda _path: ...` 覆盖**所有**路径。probe 之后 `list_dir("/")` 会先被畸形 listing 打成 fail-closed，测不到 `highest_complete`。改为 seed 后只对非根路径返回畸形条目：
+
+```python
+    seed_storage_root(fake, has_dev_channel=True)
+    original = fake.list_dir
+    fake.list_dir = (
+        lambda path: original(path) if path == "/" else [{"name": 123, "is_dir": True}]
+    )
+```
+
+只调 `validate_inputs` / `verified_directory` 的测试不必 seed。
+
+**Step 5: 跑相关 retract 测试**
+
+Run: `python -m pytest scripts/test_retract_alist.py -q`
+
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add scripts/retract-alist.py scripts/test_retract_alist.py
+git commit -m "feat: 缺失 dev AList 根时撤回改为空操作"
+```
+
+---
+
+### Task 6: `alist_channel_guard.py` snapshot / compare
+
+**Files:**
+- Create: `scripts/alist_channel_guard.py`
+- Create: `scripts/test_alist_channel_guard.py`
+
+**Step 1: 红灯测试（写完整，不要留 `...`）**
+
+```python
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+import alist_channel_guard as guard
+
+STABLE_INDEX = "/mihari-release/mihari/index.txt"
+
+
+class GuardFake:
+    def __init__(self, body=None):
+        self.body = body
+
+    def content(self, path):
+        assert path == STABLE_INDEX
+        return self.body
+
+
+def test_snapshot_missing_index_records_existed_false(tmp_path):
+    output = tmp_path / "stable-isolation"
+    guard.snapshot(GuardFake(None), STABLE_INDEX, output)
+    assert (output / "index.txt").read_bytes() == b""
+    metadata = json.loads((output / "metadata.json").read_text(encoding="utf-8"))
+    assert metadata["channel"] == "stable"
+    assert metadata["existed"] is False
+    assert metadata["path"] == STABLE_INDEX
+    assert metadata["sha256"] == hashlib.sha256(b"").hexdigest()
+
+
+def test_compare_accepts_unchanged_bytes(tmp_path):
+    output = tmp_path / "stable-isolation"
+    body = "latest v1.2.3\n"
+    guard.snapshot(GuardFake(body), STABLE_INDEX, output)
+    guard.compare(GuardFake(body), STABLE_INDEX, output)
+
+
+def test_compare_rejects_changed_index_without_logging_body(tmp_path, capsys):
+    output = tmp_path / "stable-isolation"
+    guard.snapshot(GuardFake("latest v1.2.3\n"), STABLE_INDEX, output)
+    with pytest.raises(SystemExit):
+        guard.compare(GuardFake("latest v9.0.0\n"), STABLE_INDEX, output)
+    err = capsys.readouterr().err
+    assert "foreign channel index changed during this mutation" in err
+    assert "latest " not in err
+    assert "v9.0.0" not in err
+
+
+def test_guard_rejects_non_stable_index_path(tmp_path):
+    output = tmp_path / "stable-isolation"
+    fake = GuardFake("latest v1.2.3\n")
+    for path in (
+        "/mihari-release/mihari-dev/index.txt",
+        "/mihari-release/mihari/other.txt",
+        "/mihari/index.txt",
+        "/",
+    ):
+        with pytest.raises(SystemExit):
+            guard.snapshot(fake, path, output)
+        with pytest.raises(SystemExit):
+            guard.compare(fake, path, output)
+```
+
+**Step 2: 跑 FAIL**（模块不存在）
+
+Run: `python -m pytest scripts/test_alist_channel_guard.py -q`
+
+Expected: FAIL（`ModuleNotFoundError` 或导入失败）
+
+**Step 3: 按设计文档实现 CLI**
+
+- `snapshot --path --output-dir`
+- `compare --path --expected-dir`
+- path 必须**精确等于** `/mihari-release/mihari/index.txt`，否则 `fail`
+- 单元测试注入 Fake：`snapshot(alist, path, output_dir)` / `compare(alist, path, expected_dir)`；`main()` 再 `connect()`
+- snapshot：`content` 为 `None` → 空 `index.txt`，`metadata.json` 含 `channel=stable`、`existed=false`、`path`、空字节 sha256；`metadata.json` 按设计 `sort_keys=True` 并追加 `\n`
+- compare 不相等：`fail("foreign channel index changed during this mutation")`，stderr 不得含 index 正文
+
+**Step 4: 跑 PASS**
+
+Run: `python -m pytest scripts/test_alist_channel_guard.py -q`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add scripts/alist_channel_guard.py scripts/test_alist_channel_guard.py
+git commit -m "feat: 增加稳定 index 隔离快照与比对"
+```
+
+---
+
+### Task 7: `regenerate-index.py --channel`
+
+**Files:**
+- Modify: `scripts/regenerate-index.py`
+- Modify: `scripts/test_regenerate_index.py`
+
+**Step 1: 红灯测试**
+
+现有 `test_regenerate_index_uses_highest_verified_stable_release_and_reliable_writer` 继续用两参数 `regenerate_index(fake, base)`，签名必须是 `regenerate_index(alist, base_path, channel="stable")`。
+
+追加：
+
+```python
+def test_regenerate_index_rebuilds_dev_index_for_highest_complete(tmp_path, monkeypatch):
+    monkeypatch.setenv("RUNNER_TEMP", str(tmp_path))
+    fake = FakeAList()
+    base = "/mihari-release/mihari-dev"
+    add_complete(fake, base, "v1.2.3-dev.1")
+    add_complete(fake, base, "v1.2.3-dev.2")
+    regenerate.regenerate_index(fake, base, channel="dev")
+    body = fake.files[f"{base}/index.txt"].decode()
+    assert body.startswith("latest v1.2.3-dev.2\n")
+    assert len(body.splitlines()) == 1 + len(PLATFORMS)
+
+
+def test_regenerate_index_rejects_dev_channel_with_stable_path():
+    fake = FakeAList()
+    with pytest.raises(SystemExit):
+        regenerate.regenerate_index(fake, "/mihari-release/mihari", channel="dev")
+    assert fake.uploads == []
+
+
+def test_regenerate_index_help_names_stable_default_path(monkeypatch, capsys):
+    monkeypatch.setattr("sys.argv", ["regenerate-index.py", "--help"])
+    with pytest.raises(SystemExit) as exc:
+        regenerate.main()
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "stable" in out
+    assert "/mihari-release/mihari" in out
+
+
+def test_main_channel_dev_without_base_path_targets_dev_root(monkeypatch, capsys):
+    captured = {}
+
+    def fake_connect():
+        return object()
+
+    def fake_regenerate(alist, base_path, channel="stable"):
+        captured["base_path"] = base_path
+        captured["channel"] = channel
+
+    monkeypatch.setattr(regenerate, "connect", fake_connect)
+    monkeypatch.setattr(regenerate, "regenerate_index", fake_regenerate)
+    monkeypatch.setattr("sys.argv", ["regenerate-index.py", "--channel", "dev"])
+    regenerate.main()
+    assert captured == {
+        "base_path": "/mihari-release/mihari-dev",
+        "channel": "dev",
+    }
+    logged = capsys.readouterr()
+    text = logged.out + logged.err
+    assert "regenerating dev index at /mihari-release/mihari-dev/index.txt" in text
+```
+
+`info(...)` 必须在 `connect()` / `regenerate_index` / 任何 PUT **之前**。`info()` 走 stdout（`::notice::`）。
+
+默认不传 `--channel` 仍 stable：现有两参数测试覆盖 `regenerate_index`；CLI 默认由 `--help` 与 `expected_base_path(args.channel)` 钉死。
+
+**Step 2: 跑 FAIL**
+
+Run: `python -m pytest scripts/test_regenerate_index.py -q`
+
+Expected: FAIL（尚无 `channel` 参数 / `--channel`）
+
+**Step 3: 实现**
+
+```python
+# 在现有 `from release_policy import validate_base_path` 上追加 expected_base_path
+from release_policy import expected_base_path, validate_base_path
+
+
+def regenerate_index(alist, base_path, channel="stable"):
+    """Rebuild the channel index through the shared reliable writer."""
+    try:
+        validate_base_path(channel, base_path)
+    except ValueError as error:
+        fail(str(error))
+    retract = _load_retract()
+    index_path = f"{base_path}/index.txt"
+    previous = retract.read_index(alist, index_path)
+    try:
+        latest = retract.highest_complete(
+            alist, base_path, excluded=None, channel=channel
+        )
+    except retract.RemoteScanError:
+        fail("unable to inspect release versions")
+    if latest is None:
+        fail("no COMPLETE version dir found — nothing to rebuild index from")
+    info(f"highest complete version: {latest}")
+    try:
+        body = retract.index_body(alist, base_path, latest, channel)
+    except retract.RemoteScanError:
+        fail("unable to verify release directory")
+    retract.write_index_reliably(
+        alist, index_path, body, previous, channel=channel
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Regenerate index.txt for the current AList topology."
+    )
+    parser.add_argument(
+        "--channel",
+        choices=("stable", "dev"),
+        default="stable",
+        help="Index channel to rebuild (default: stable, writes /mihari-release/mihari/index.txt)",
+    )
+    parser.add_argument("--base-path", default=None)
+    args = parser.parse_args()
+    channel = args.channel
+    base_path = args.base_path or expected_base_path(channel)
+    info(f"regenerating {channel} index at {base_path}/index.txt")
+    alist = connect()
+    regenerate_index(alist, base_path, channel)
+    info("index.txt regenerated with current public_url() links")
+```
+
+默认 `--base-path` 今天是 `DEFAULT_BASE_PATH`（stable）。改成 `None` 后，CLI 省略 base-path 时用 `expected_base_path(channel)`。显式传错路径仍由 `validate_base_path` 拒绝。`--channel dev` 且不传 `--base-path` 必须打到 `/mihari-release/mihari-dev`。
+
+**Step 4: PASS + Commit**
+
+Run: `python -m pytest scripts/test_regenerate_index.py -q`
+
+Expected: PASS
+
+```bash
+git add scripts/regenerate-index.py scripts/test_regenerate_index.py
+git commit -m "feat: regenerate-index 支持显式 dev 通道"
+```
+
+---
+
+### Task 8: 把新测试送进 CI 列表
+
+**Files:**
+- Modify: `scripts/test_release_workflow.py` — `RELEASE_SAFETY_TESTS`
+- Modify: `.github/workflows/ci.yml` — unit job pytest 命令
+
+**Step 1: 改 constant（先改测试侧，跑 CI 锁定测试应红）**
+
+`RELEASE_SAFETY_TESTS` 改为（注意末尾 `-q` 仍在字符串里）：
+
+```
+scripts/test_release_policy.py scripts/test_github_release_policy.py scripts/test_release_workflow.py scripts/test_alist_client.py scripts/test_alist_index.py scripts/test_release_alist.py scripts/test_retract_alist.py scripts/test_regenerate_index.py scripts/test_alist_channel_guard.py -q
+```
+
+**Step 2: 跑**
+
+Run: `python -m pytest scripts/test_release_workflow.py::test_ci_runs_release_safety_suite_from_pinned_requirements_on_all_integration_branches -q`
+
+Expected: FAIL（`ci.yml` 仍是旧命令）
+
+**Step 3: 同步 `ci.yml` 那一行 `run:` 与 constant **逐字相同**（含 `-q`）。
+
+**Step 4: PASS 全量 release-safety**
+
+Run: `python -m pytest scripts/test_release_policy.py scripts/test_github_release_policy.py scripts/test_release_workflow.py scripts/test_alist_client.py scripts/test_alist_index.py scripts/test_release_alist.py scripts/test_retract_alist.py scripts/test_regenerate_index.py scripts/test_alist_channel_guard.py -q`
+
+Expected: PASS。`test_release_documents_record_verified_dev_github_release_and_unavailable_dev_alist` 此时必须仍绿（尚未建 `retract-dev.yml`，文档仍写不写 AList）。
+
+**Step 5: Commit（PR 1 收尾）**
+
+```bash
+git add scripts/test_release_workflow.py .github/workflows/ci.yml
+git commit -m "test: 将通道守卫测试列入 CI 发版安全套件"
+```
+
+---
+
+### Task 9: 先写失败的 YAML 测试，再接 `release-dev.yml`
+
+**Files:**
+- Modify: `scripts/test_release_workflow.py` — **先写测试，此时两个 YAML 都还没改/还不存在**
+- Modify: `.github/workflows/release-dev.yml` — 测试红了之后才写
+
+YAML **完整步骤、并发组、compare-first exit、两条 artifact、notes marker** 复制设计文档「`release-dev.yml` 接线」一节。不要发明第二种退出结构。
+
+**本 Task 与 Task 10–11 共用一次绿灯 commit。写完测试与 `release-dev.yml` 后不要 commit。不要改 `test_release_documents_*`。**
+
+**Step 1: 在任一 YAML 改动之前写入失败测试**
+
+在 `scripts/test_release_workflow.py` 增加：
+
+```python
+RETRACT_DEV_WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "retract-dev.yml"
+```
+
+把 `test_release_workflow_is_github_only_and_limits_tag_peeling` **拆开**：删除 `ALIST_` / `mihari-dev` 禁令，保留 peel 深度断言（函数可改名为 `test_release_workflow_limits_tag_peeling`，或留原名但去掉 github-only 断言）。文档测试一字不改。
+
+然后新增（函数名锁定）：
+
+```python
+def test_dev_publish_and_retract_use_independent_alist_lock():
+    release_dev = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    retract_dev = yaml.safe_load(RETRACT_DEV_WORKFLOW.read_text(encoding="utf-8"))
+    expected = {"group": "mihari-dev-alist", "cancel-in-progress": False}
+    assert release_dev["jobs"]["publish"].get("concurrency") == expected
+    assert retract_dev["jobs"]["retract"].get("concurrency") == expected
+    assert "mihari-stable-alist" not in WORKFLOW.read_text(encoding="utf-8")
+    assert "mihari-stable-alist" not in RETRACT_DEV_WORKFLOW.read_text(encoding="utf-8")
+    assert release_dev.get("concurrency", {}).get("group") == "dev-release-${{ inputs.version }}"
+
+
+def test_dev_alist_mutation_uses_compare_first_exit():
+    cases = (
+        (WORKFLOW, "publish", "Publish to AList drive", "release-alist.py", "publish_status"),
+        (RETRACT_DEV_WORKFLOW, "retract", "Retract from AList drive", "retract-alist.py", "retract_status"),
+    )
+    for path, job, step_name, writer, status_var in cases:
+        document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        run = _workflow_step(document, job, name=step_name)["run"]
+        assert "set +e" in run
+        assert run.index(writer) < run.index("alist_channel_guard.py compare")
+        compare_exit = 'if [ "${compare_status}" -ne 0 ]; then exit "${compare_status}"; fi'
+        assert compare_exit in run
+        assert run.index(compare_exit) < run.index(f'exit "${{{status_var}}}"')
+
+
+def test_dev_retract_peel_expected_sha_is_release_sha_not_job_sha():
+    document = yaml.safe_load(RETRACT_DEV_WORKFLOW.read_text(encoding="utf-8"))
+    peel = _workflow_step(document, "retract", name="Peel canonical tag for identity SHA")
+    run = peel["run"]
+    assert "github_release_policy.py tag-chain" in run
+    assert '--expected-sha "${RELEASE_SHA}"' in run or '--expected-sha "${tag_sha}"' in run
+    assert '--expected-sha "${SHA}"' not in run
+    mutation = _workflow_step(document, "retract", name="Retract from AList drive")
+    assert '--commit-sha "${RELEASE_SHA}"' in mutation["run"]
+    assert '--commit-sha "${SHA}"' not in mutation["run"]
+
+
+def test_dev_alist_isolation_artifacts_are_separate_from_writer_backup():
+    expected_if = (
+        "env.ALIST_CONFIGURED == 'true' && "
+        "((failure() && steps.alist_mutation.outcome == 'failure') || "
+        "(cancelled() && steps.alist_mutation.outcome == 'cancelled'))"
+    )
+    for path, job in ((WORKFLOW, "publish"), (RETRACT_DEV_WORKFLOW, "retract")):
+        document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        text = path.read_text(encoding="utf-8")
+        steps = document["jobs"][job]["steps"]
+        dev_backup = next(
+            step for step in steps
+            if str(step.get("with", {}).get("name", "")).startswith("dev-index-backup-")
+        )
+        isolation = next(
+            step for step in steps
+            if str(step.get("with", {}).get("name", "")).startswith("stable-index-isolation-")
+        )
+        assert dev_backup["if"] == expected_if
+        assert isolation["if"] == expected_if
+        assert dev_backup["with"]["path"] == "${{ runner.temp }}/mihari-index-backup/dev/**"
+        assert isolation["with"]["path"] == "${{ runner.temp }}/mihari-index-backup/stable-isolation/**"
+        assert isolation["with"]["path"] != "${{ runner.temp }}/mihari-index-backup/stable/**"
+        assert "${{ runner.temp }}/mihari-index-backup/stable/**" not in text
+
+
+def test_dev_retract_resolve_outputs_sha_and_alist_runs_before_github_delete():
+    document = yaml.safe_load(RETRACT_DEV_WORKFLOW.read_text(encoding="utf-8"))
+    resolve = document["jobs"]["resolve"]
+    retract = document["jobs"]["retract"]
+    assert resolve["outputs"]["sha"] == "${{ steps.source.outputs.sha }}"
+    assert "refs/heads/dev" in retract["if"]
+    checkout = next(step for step in retract["steps"] if step.get("uses") == "actions/checkout@v7")
+    assert checkout["with"]["ref"] == "${{ needs.resolve.outputs.sha }}"
+    names = [step.get("name") for step in retract["steps"]]
+    assert names.index("Retract from AList drive") < names.index("Delete GitHub prerelease")
+```
+
+再补设计表里其余可执行断言（同样在写 YAML 之前）：
+
+```python
+def test_dev_alist_writers_pin_channel_base_path_and_commit_sha():
+    publish = WORKFLOW.read_text(encoding="utf-8")
+    retract = RETRACT_DEV_WORKFLOW.read_text(encoding="utf-8")
+    assert "--channel dev" in publish
+    assert "--base-path /mihari-release/mihari-dev" in publish
+    assert '--commit-sha "${SHA}"' in publish
+    assert "--channel dev" in retract
+    assert "--base-path /mihari-release/mihari-dev" in retract
+
+
+def test_dev_publish_mutates_alist_after_final_github_verify():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    assert workflow.index("Final verify prerelease and stable latest") < workflow.index(
+        "Publish to AList drive"
+    )
+
+
+def test_dev_release_notes_append_index_url_with_stable_root_downloaders():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    assert "<!-- aio-install-dev -->" in workflow
+    assert "mihari-dev/index.txt" in workflow
+    assert "mihari-release/mihari/install-aio-remote.sh" in workflow
+
+
+def test_dev_retract_github_delete_is_idempotent_and_retains_canonical_tag():
+    document = yaml.safe_load(RETRACT_DEV_WORKFLOW.read_text(encoding="utf-8"))
+    delete = _workflow_step(document, "retract", name="Delete GitHub prerelease")
+    run = delete["run"]
+    assert "gh release delete" in run
+    assert "--cleanup-tag" not in run
+    assert "canonical dev tag retained" in run
+    gate = next(
+        step["run"]
+        for step in document["jobs"]["retract"]["steps"]
+        if str(step.get("name", "")).startswith("Gate")
+    )
+    assert 'echo "${VERSION}"' not in gate
+
+
+def test_alist_runtime_dependencies_are_pinned_after_checkout_in_dev_workflows():
+    release_dev = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    retract_dev = yaml.safe_load(RETRACT_DEV_WORKFLOW.read_text(encoding="utf-8"))
+    for workflow, job_name, install_step_name in (
+        (release_dev, "publish", "Publish to AList drive"),
+        (retract_dev, "retract", "Retract from AList drive"),
+    ):
+        steps = workflow["jobs"][job_name]["steps"]
+        checkout_index = next(
+            index for index, step in enumerate(steps) if step.get("uses") == "actions/checkout@v7"
+        )
+        setup_index = next(
+            index for index, step in enumerate(steps) if step.get("uses") == "actions/setup-python@v7"
+        )
+        install_index = next(
+            index for index, step in enumerate(steps) if step.get("name") == install_step_name
+        )
+        install = steps[install_index]["run"]
+        assert checkout_index < setup_index < install_index
+        assert steps[setup_index]["with"] == {"python-version": "3.12"}
+        assert (
+            "python -m pip install --disable-pip-version-check -r scripts/requirements-release.txt"
+            in install
+        )
+        assert "pip install requests" not in install
+```
+
+关键钉死字符串（实现 YAML 时对照，测试覆盖）：
+
+- `jobs.publish.concurrency.group: mihari-dev-alist`，`cancel-in-progress: false`（YAML 布尔 `false` → Python `False`）
+- 文件级 `dev-release-${{ inputs.version }}` 保留
+- 不含 `mihari-stable-alist`
+- `ALIST_CONFIGURED: ${{ secrets.ALIST_URL != '' }}`
+- secrets 只出现在 `id: alist_mutation`
+- mutation 在 `Final verify prerelease and stable latest` **之后**
+- `release-alist.py --channel dev --base-path /mihari-release/mihari-dev --commit-sha "${SHA}"`
+- `if [ "${compare_status}" -ne 0 ]; then exit "${compare_status}"; fi` 然后 `exit "${publish_status}"`
+- artifacts: `dev-index-backup-` → `${{ runner.temp }}/mihari-index-backup/dev/**`；`stable-index-isolation-` → `${{ runner.temp }}/mihari-index-backup/stable-isolation/**`（**不是** `.../stable/**`）
+- notes：`<!-- aio-install-dev -->` 与 `MIHARI_INDEX_URL=.../mihari-dev/index.txt`，下载器仍是稳定根 `install-aio-remote.sh`
+- 仍 `-buildvcs=false -trimpath`；`make_latest=false`
+
+**Step 2: 跑，确认因 YAML 未接线 / `retract-dev.yml` 不存在而失败**
+
+Run: `python -m pytest scripts/test_release_workflow.py::test_dev_publish_and_retract_use_independent_alist_lock scripts/test_release_workflow.py::test_dev_alist_mutation_uses_compare_first_exit scripts/test_release_workflow.py::test_dev_retract_peel_expected_sha_is_release_sha_not_job_sha scripts/test_release_workflow.py::test_dev_alist_isolation_artifacts_are_separate_from_writer_backup scripts/test_release_workflow.py::test_dev_retract_resolve_outputs_sha_and_alist_runs_before_github_delete scripts/test_release_workflow.py::test_dev_alist_writers_pin_channel_base_path_and_commit_sha scripts/test_release_workflow.py::test_dev_publish_mutates_alist_after_final_github_verify scripts/test_release_workflow.py::test_dev_release_notes_append_index_url_with_stable_root_downloaders scripts/test_release_workflow.py::test_dev_retract_github_delete_is_idempotent_and_retains_canonical_tag scripts/test_release_workflow.py::test_alist_runtime_dependencies_are_pinned_after_checkout_in_dev_workflows -q`
+
+Expected: FAIL（`release-dev.yml` 无 `ALIST_`；`retract-dev.yml` 不存在 → `FileNotFoundError`）。
+
+文档测试此时必须仍绿：
+
+Run: `python -m pytest scripts/test_release_workflow.py::test_release_documents_record_verified_dev_github_release_and_unavailable_dev_alist -q`
+
+Expected: PASS
+
+**Step 3: 按设计复制 `release-dev.yml` 接线**（此时还不要创建 `retract-dev.yml`）
+
+**Step 4: 再跑 Step 2 的测试**
+
+Expected: 依赖 `release-dev.yml` 的断言变绿或接近绿；**所有读取 `retract-dev.yml` 的测试仍 FAIL**。不要为了让 retract 测试假绿而去 skip。
+
+**Step 5: 不要 commit。** 进入 Task 10。
+
+---
+
+### Task 10: 新增 `retract-dev.yml`
+
+**Files:**
+- Create: `.github/workflows/retract-dev.yml`
+- Modify: `scripts/test_release_workflow.py`（仅当 Task 9 测试需微调断言字符串；不要在本 Task 才第一次写测试）
+
+**Step 1: 先跑 Task 9 的 YAML 测试，确认 retract-dev 断言仍红**
+
+Run: `python -m pytest scripts/test_release_workflow.py::test_dev_publish_and_retract_use_independent_alist_lock scripts/test_release_workflow.py::test_dev_alist_mutation_uses_compare_first_exit scripts/test_release_workflow.py::test_dev_retract_peel_expected_sha_is_release_sha_not_job_sha scripts/test_release_workflow.py::test_dev_alist_isolation_artifacts_are_separate_from_writer_backup scripts/test_release_workflow.py::test_dev_retract_resolve_outputs_sha_and_alist_runs_before_github_delete scripts/test_release_workflow.py::test_dev_retract_github_delete_is_idempotent_and_retains_canonical_tag -q`
+
+Expected: FAIL（`retract-dev.yml` 仍不存在，或尚未写入 peel / delete 块）。
+
+**Step 2: 按设计文档创建完整 job 图**
+
+必须包含：
+
+- `jobs.resolve.outputs.sha: ${{ steps.source.outputs.sha }}`
+- `retract.if`: `github.ref == 'refs/heads/dev' && needs.resolve.outputs.sha != ''`
+- checkout `needs.resolve.outputs.sha`
+- confirm 布尔；错误路径不 echo `${VERSION}`
+- Peel：`--expected-sha "${RELEASE_SHA}"`（peel 出的 commit）。**仅 peel 步骤文本**不得出现 `--expected-sha "${SHA}"`（用 `_workflow_step(..., name="Peel canonical tag for identity SHA")` 切片；全文件 grep 会被 `release-dev.yml` 的合法 `"${SHA}"` 和 retract job env `SHA:` 污染）
+- `--commit-sha "${RELEASE_SHA}"` 给 `retract-alist.py`
+- AList mutation **字面量上**出现在 `Delete GitHub prerelease` 之前
+- 与发布相同的 snapshot/compare-first、两条 artifact、`mihari-dev-alist`
+- 事后再校验 `/releases/latest`
+
+**GitHub delete 不要留设计文档里的注释。** 从 `.github/workflows/retract.yml` 第 122–139 行复制 lookup + HTTP 404 分支，把 stable 字样改成 dev，且 `gh release delete "${VERSION}" --yes` **无** `--cleanup-tag`：
+
+```yaml
+      - name: Delete GitHub prerelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          release_lookup_error="$(mktemp)"
+          trap 'rm -f "${release_lookup_error}"' EXIT
+          set +e
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${VERSION}" \
+            >/dev/null 2>"${release_lookup_error}"
+          release_lookup_status=$?
+          set -e
+
+          if [ "${release_lookup_status}" -eq 0 ]; then
+            gh release delete "${VERSION}" --yes
+            echo "Permanently removed GitHub prerelease/assets for ${VERSION}; canonical dev tag retained."
+          elif grep -Eq '(^|[^0-9])HTTP 404([^0-9]|$)' "${release_lookup_error}"; then
+            echo "GitHub prerelease ${VERSION} not found (already retracted?) — nothing to delete; canonical dev tag retained."
+          else
+            echo "::error::unable to determine whether the GitHub release exists"
+            exit 1
+          fi
+```
+
+**Step 3: YAML 测试变绿；文档测试保持「P2 不可用」**
+
+Run: `python -m pytest scripts/test_release_workflow.py::test_dev_publish_and_retract_use_independent_alist_lock scripts/test_release_workflow.py::test_dev_alist_mutation_uses_compare_first_exit scripts/test_release_workflow.py::test_dev_retract_peel_expected_sha_is_release_sha_not_job_sha scripts/test_release_workflow.py::test_dev_alist_isolation_artifacts_are_separate_from_writer_backup scripts/test_release_workflow.py::test_dev_retract_resolve_outputs_sha_and_alist_runs_before_github_delete scripts/test_release_workflow.py::test_dev_alist_writers_pin_channel_base_path_and_commit_sha scripts/test_release_workflow.py::test_dev_publish_mutates_alist_after_final_github_verify scripts/test_release_workflow.py::test_dev_release_notes_append_index_url_with_stable_root_downloaders scripts/test_release_workflow.py::test_dev_retract_github_delete_is_idempotent_and_retains_canonical_tag scripts/test_release_workflow.py::test_alist_runtime_dependencies_are_pinned_after_checkout_in_dev_workflows scripts/test_release_workflow.py::test_release_documents_record_verified_dev_github_release_and_unavailable_dev_alist -q`
+
+Expected: 全部 YAML 接线测试 PASS；`test_release_documents_*` 仍 PASS（文档尚未翻转）。
+
+**Step 4: 不要 commit。** 进入 Task 11。
+
+---
+
+### Task 11: 翻转 workflow 文档断言与文档
+
+**Files:**
+- Modify: `scripts/test_release_workflow.py`
+- Modify: `docs/RELEASE.md`
+- Modify: `docs/distribution.md`
+- Modify: `CHANGELOG.md`
+
+**Step 1: 只在本 Task 改文档测试**（先改测试，跑红，再改文档）
+
+`test_release_documents_record_verified_dev_github_release_and_unavailable_dev_alist` 目标：
+
+- 两份文档仍含 `v0.9.0-dev.2`
+- **必须**出现 `retract-dev.yml`
+- 删除对「不写 AList」「当前不创建或操作该目录」的强制
+- 改为断言独立 `/mihari-release/mihari-dev`、公开 index URL、`mihari-dev-alist`、稳定入口不变
+- 保留「不得把稳定安装入口指向 dev」
+
+**Step 2: 跑 FAIL**
+
+Run: `python -m pytest scripts/test_release_workflow.py::test_release_documents_record_verified_dev_github_release_and_unavailable_dev_alist -q`
+
+Expected: FAIL（文档仍写 P2 不可用）
+
+**Step 3: 改 `docs/RELEASE.md` / `docs/distribution.md` 直到测试绿**
+
+要点见设计「文档更新要点」。CHANGELOG `[Unreleased] Added`：
+
+```
+- 为 prerelease 通道增加独立 AList index（`/mihari-release/mihari-dev`）与 `retract-dev` 撤回入口（#126）。
+```
+
+不要改 README 快速开始。
+
+**Step 4: 全量安全套件**
+
+Run: `python -m pytest scripts/test_release_policy.py scripts/test_github_release_policy.py scripts/test_release_workflow.py scripts/test_alist_client.py scripts/test_alist_index.py scripts/test_release_alist.py scripts/test_retract_alist.py scripts/test_regenerate_index.py scripts/test_alist_channel_guard.py -q`
+
+Expected: PASS
+
+**Step 5: Commit PR 2（Task 9–11 唯一绿灯 commit）**
+
+```bash
+git add .github/workflows/release-dev.yml .github/workflows/retract-dev.yml scripts/test_release_workflow.py docs/RELEASE.md docs/distribution.md CHANGELOG.md
+git commit -m "feat: 为 prerelease 通道接入独立 AList index 与 retract-dev"
+```
+
+---
+
+### Task 12: 收尾验证
+
+**Step 1:** `gofmt` 未改 Go 文件则跳过。
+
+**Step 2:** `git diff origin/dev -- README.md README.zh-CN.md scripts/install/install-aio-remote.sh scripts/install/install-aio-remote.ps1 .github/workflows/release.yml .github/workflows/retract.yml`
+
+Expected: 空。
+
+**Step 3:** 确认 `release-dev.yml` / `retract-dev.yml` 不含 `mihari-stable-alist`，含 `mihari-dev-alist`。隔离 artifact 路径是 `stable-isolation/**` 不是 `stable/**`。
+
+**Step 4:** 不要在本计划里 dispatch 真实 `release-dev`。首次真实发布需用户授权，且 version 必须是新的 `vX.Y.Z-dev.N`。
+
+---
+
+## Execution notes
+
+- PR 1 = Task 1–8。Task 1–2 是表征钉（可单独绿灯 commit 或并入 Task 4）。Task 3 不 commit。Task 4 是 Fake + `ensure_channel_root` 的绿灯 commit。
+- PR 2 = Task 9–11，**禁止**只合发布 YAML 不合 `retract-dev.yml`。Task 9 先写失败 YAML 测试；Task 10 先跑这些测试（retract-dev 仍红）再写 YAML；文档测试只在 Task 11 翻转。三次任务一次 commit。
+- 实现时对照 `@docs/superpowers/specs/2026-08-24-prerelease-alist-index-design.md` 的 YAML；本计划不重复整份 workflow。GitHub delete 以 `retract.yml` 122–139 为准，不以设计注释为准。

--- a/docs/superpowers/specs/2026-08-24-prerelease-alist-index-design.md
+++ b/docs/superpowers/specs/2026-08-24-prerelease-alist-index-design.md
@@ -100,7 +100,7 @@ _BASE_PATHS = {
 
 3. **`ALIST_URL` 是唯一启用开关；凭据缺失 fail closed。** 复制 `release.yml` 的 `ALIST_CONFIGURED: ${{ secrets.ALIST_URL != '' }}`。`connect()` 在三个变量任一为空时 `fail("ALIST_URL / ALIST_USERNAME / ALIST_PASSWORD are required")`。不得把 username/password 放进 skip 判定。
 
-4. **dev AList 使用独立并发组 `mihari-dev-alist`，禁止复用 `mihari-stable-alist`。** 稳定 release/retract 已经靠该组互斥。共享会导致稳定发版被 dev 发布堵住，或更糟：两个 writer 在不同路径上交错时仍竞争同一把锁的语义含糊。dev 只锁 dev。workflow 级 `dev-release-${{ inputs.version }}` 保留，用于同版本 GitHub 重试互斥。
+4. **dev AList 使用独立并发组 `mihari-dev-alist`，禁止复用 `mihari-stable-alist`。** 稳定 release/retract 已经靠该组互斥。共享会导致稳定发版被 dev 发布堵住，或更糟：两个 writer 在不同路径上交错时仍竞争同一把锁的语义含糊。dev 只锁 dev。workflow 级 `dev-release-${{ inputs.version }}` 保留，用于同版本 GitHub 重试互斥。副作用：稳定发版若在 dev mutation 的 snapshot→compare 窗口改写稳定 `index.txt`，dev run 会 fail closed（`foreign channel index changed during this mutation`），无法与真实隔离破坏区分。接受该误报并重跑；不把两通道合成一把锁。
 
 5. **不上传 `install-aio-remote.sh/.ps1` 到 `/mihari-release/mihari-dev/`。** `publish()` 已对 `channel == "dev"` 跳过 `upload_root_scripts`，且有回归测试。若上传当前脚本，dev 根目录的「安装器」仍会指向**稳定** index，形成静默装稳定的陷阱。#125 之前的消费钩子是 `MIHARI_INDEX_URL` + 稳定根目录上已经公开的下载器。
 
@@ -136,7 +136,7 @@ _BASE_PATHS = {
 
 **没有** `install-aio-remote.sh` / `.ps1`。
 
-公开直链（`alist_client.AList.public_url` 规则：`{ALIST_URL}/p/public{fs_path}`，无 `?sign=`）：
+公开直链（`alist_client.AList.public_url` 规则：`{ALIST_URL}/p/public{path}`（逻辑路径，含 `mihari-release` 挂载段），无 `?sign=`）：
 
 | 对象 | URL |
 |------|-----|

--- a/docs/superpowers/specs/2026-08-24-prerelease-alist-index-design.md
+++ b/docs/superpowers/specs/2026-08-24-prerelease-alist-index-design.md
@@ -1,0 +1,1047 @@
+# P2：为 prerelease 通道增加独立 AList index
+
+| 字段 | 值 |
+|------|----|
+| **Status** | Approved |
+| **Author** | TBD |
+| **Date** | 2026-08-24 |
+| **Issue** | [#126](https://github.com/mihari-proxy/mihari/issues/126) `[feat] 为 prerelease 通道增加独立 AList index` |
+| **Branch / worktree** | `feat/126-prerelease-alist-index` @ `C:\Users\Kinema\Documents\modular_dev\mihari\.worktrees\issue-126-prerelease-alist-index`（跟踪 `origin/dev` @ `cd180e3`） |
+| **相关** | #115（dev 发版 P1，已落地）、#125（安装脚本 / 应用内通道消费，本 issue 不实现）、#96（稳定国内加速渠道，不得混写） |
+
+## Overview
+
+Mihari 的稳定通道已经通过 `release.yml` 把 AIO 包写入 AList `/mihari-release/mihari`，并由 `index.txt` 的 `latest vX.Y.Z` 驱动国内安装器。预发布通道（`release-dev.yml`，版本 `vX.Y.Z-dev.N`）目前只创建 GitHub prerelease（`prerelease=true`、`make_latest=false`），**完全不写 AList**。已发布的 `v0.9.0-dev.2` / `v0.9.0-dev.3` 因此只有 GitHub 资产，墙内部署没有可解析的 prerelease `latest`。
+
+本设计把现成的策略层接到 `release-dev.yml`：在 GitHub prerelease **成功之后**，条件化调用已存在的 `scripts/release-alist.py --channel dev --base-path /mihari-release/mihari-dev`，写出独立的 `/mihari-release/mihari-dev/index.txt`。同时新增 `retract-dev.yml`，只撤回 dev AList 目录 / dev index 与 GitHub prerelease 资产，保留 canonical dev tag。稳定 `index.txt`、稳定版本目录和 `/releases/latest` 在任何路径下都不得被改写。
+
+策略、writer、跨通道拒绝在脚本层已经就绪；本 issue 的核心是 **workflow 接线、首次根目录创建、通道级并发锁、稳定面隔离验收、dev retract，以及文档/测试从「P2 不可用」翻转到「P2 可用」**。
+
+## Background & Motivation
+
+### 当前两条发布线
+
+| 通道 | 来源 | 版本 | GitHub | AList |
+|------|------|------|--------|-------|
+| Stable | 受保护 `main`，`release.yml` | `vX.Y.Z` | 正式 Release，参与 `/releases/latest` | `/mihari-release/mihari`，`index.txt` 的 `latest` 为 `vX.Y.Z` |
+| Dev | 受保护 `dev`，`release-dev.yml` | `vX.Y.Z-dev.N` | prerelease；`make_latest=false`；精确 14 个 assets | **无。** `release-dev.yml` 不含任何 `ALIST_*` 步骤 |
+
+稳定国内入口（不可改默认）：
+
+```
+https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/index.txt
+```
+
+`scripts/install/install-aio-remote.sh` / `.ps1` 把该 URL 硬编码为默认 `INDEX_URL`，并已支持环境变量 `MIHARI_INDEX_URL` 覆盖。
+
+### 策略层已预留、workflow 未接线
+
+`scripts/release_policy.py` 已经固定：
+
+```python
+_BASE_PATHS = {
+    "stable": "/mihari-release/mihari",
+    "dev": "/mihari-release/mihari-dev",
+}
+```
+
+`parse_version(value, channel)` 拒绝跨通道版本；`validate_base_path` 拒绝任何非精确匹配路径（含 `..` 与把 stable 路径传给 `dev`）。
+
+`scripts/release-alist.py`、`retract-alist.py`、`alist_index.py` 已接受 `--channel dev`：
+
+- writer `alist_index.write_index_reliably` 要求 `latest` 能被 `parse_version(..., channel)` 接受；空 index 仅允许 retract。
+- `publish()` 仅在 `args.channel == "stable"` 时调用 `upload_root_scripts()`。`test_publish_dev_never_uploads_root_installers` 已锁定该行为。
+- 单元测试大量使用 `/mihari-release/mihari-dev`（`scripts/test_release_alist.py`、`test_retract_alist.py`、`test_alist_index.py`）。
+
+缺口在 Actions：
+
+- `.github/workflows/release-dev.yml`：GitHub-only。workflow 级并发 `dev-release-${{ inputs.version }}`。**没有** job 级 AList 锁，**没有** `release-alist.py`。
+- `.github/workflows/release.yml` / `retract.yml`：`--channel stable --base-path /mihari-release/mihari`，job 级并发 `mihari-stable-alist`。
+- 文档与 `scripts/test_release_workflow.py` 明确断言「不写 AList」「`ALIST_` not in workflow」「`retract-dev.yml` not in document」。
+
+远端 AList **尚未** 存在 `mihari-dev` 目录或 index。不得把测试夹具或策略常量误当成远端已就绪。
+
+### 痛点
+
+后续 #125 的墙内 prerelease 安装需要一份与稳定通道同格式、但身份完全隔离的 `index.txt`。若把 `-dev.N` 写入稳定 index，国内默认安装会装到预发布；若继续只走 GitHub，墙内没有稳定入口。这正是 #115 拆出的 P2。
+
+## Goals & Non-Goals
+
+### Goals
+
+1. 在 `/mihari-release/mihari-dev/index.txt` 维护独立路由表，`latest` 只能是 `vX.Y.Z-dev.N`。
+2. 钉死公开直链契约，供后续脚本硬编码或用 `MIHARI_INDEX_URL` 指向：
+   `https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari-dev/index.txt`
+3. 在 `release-dev.yml` 于 GitHub prerelease **最终验收成功之后** 条件化调用现有 `release-alist.py --channel dev`。
+4. `ALIST_URL` 缺失 → skip AList，GitHub prerelease 仍成功；URL 存在但 `ALIST_USERNAME` / `ALIST_PASSWORD` 任一缺失 → `connect()` fail closed，workflow 失败。
+5. 任何 dev 写入都不得改动稳定 index、稳定版本目录或 `/releases/latest`；workflow 必须在 AList mutation 前后用字节级比对证明稳定 index 未变。
+6. 提供 **dev retract**：只操作 `/mihari-release/mihari-dev/<version>/` 与 **dev** index，删除 GitHub prerelease 及其 assets，**保留** canonical `vX.Y.Z-dev.N` tag（与 `retract.yml` 对齐）。
+7. 文档从「P2 不可用」改为「P2 可用」，并写明稳定安装入口不会指向 dev index。
+8. 为后续 #125 留下最小消费钩子：文档化 `MIHARI_INDEX_URL`；**不**改默认安装命令。
+
+### Non-Goals
+
+- 修改 README / README.zh-CN 快速开始，或稳定 `install-aio-remote.{sh,ps1}` 的默认 URL。
+- 把 prerelease 混入稳定 `index.txt`。
+- 让 GitHub `/releases/latest` 指向 prerelease。
+- 实现 #125（`MIHARI_CHANNEL`、`self update`、TUI 切通道、应用内通道切换）。
+- 改 `/v1`、daemon、TUI、CLI 默认行为。
+- 在每次 `dev` push 上自动发 AList；保持手动 `workflow_dispatch`。
+- 为历史 GitHub-only 版本 `v0.9.0-dev.2` / `v0.9.0-dev.3` 做回溯发布（见 Open Questions；默认不回溯）。
+- 把稳定硬编码的 `install-aio-remote.*` 上传到 dev AList 根目录。
+- 改变可复现构建：继续 `-buildvcs=false -trimpath` 与 `scripts/release-inputs.lock.json`。
+- 新增网络监听、CGO、或把 secrets 打进日志。
+
+## Key Decisions
+
+1. **独立 index，路径由策略钉死。** `latest` 只存在于 `/mihari-release/mihari-dev/index.txt`，格式与稳定通道相同。理由：`release_policy._BASE_PATHS` 与 `validate_base_path` 已经拒绝混写；公开 URL 必须稳定，才能给 #125 硬编码。
+
+2. **GitHub prerelease 成功之后再写 AList，失败不回滚 GitHub。** 与 `release.yml` 一致：GitHub 是规范身份源；AList 是国内镜像。AList 失败时 GitHub prerelease 保留，重跑同一 `vX.Y.Z-dev.N` 走现有 checksum preflight + AList identity fail-closed。AList 绝不能在 GitHub 验收前启动，以免半成品目录配上未完成的 GitHub 身份。
+
+3. **`ALIST_URL` 是唯一启用开关；凭据缺失 fail closed。** 复制 `release.yml` 的 `ALIST_CONFIGURED: ${{ secrets.ALIST_URL != '' }}`。`connect()` 在三个变量任一为空时 `fail("ALIST_URL / ALIST_USERNAME / ALIST_PASSWORD are required")`。不得把 username/password 放进 skip 判定。
+
+4. **dev AList 使用独立并发组 `mihari-dev-alist`，禁止复用 `mihari-stable-alist`。** 稳定 release/retract 已经靠该组互斥。共享会导致稳定发版被 dev 发布堵住，或更糟：两个 writer 在不同路径上交错时仍竞争同一把锁的语义含糊。dev 只锁 dev。workflow 级 `dev-release-${{ inputs.version }}` 保留，用于同版本 GitHub 重试互斥。
+
+5. **不上传 `install-aio-remote.sh/.ps1` 到 `/mihari-release/mihari-dev/`。** `publish()` 已对 `channel == "dev"` 跳过 `upload_root_scripts`，且有回归测试。若上传当前脚本，dev 根目录的「安装器」仍会指向**稳定** index，形成静默装稳定的陷阱。#125 之前的消费钩子是 `MIHARI_INDEX_URL` + 稳定根目录上已经公开的下载器。
+
+6. **独立 `retract-dev.yml`，不给 `retract.yml` 加 `channel` 输入。** 稳定 retract 强制 `refs/heads/main` + 纯 semver + `mihari-stable-alist`。dev 需要 `refs/heads/dev` + `vX.Y.Z-dev.N` + `mihari-dev-alist` + `--commit-sha`。混在一个文件里会把闸门、checkout、并发组缠在一起，误 dispatch 的爆炸半径更大。GitHub 侧对齐稳定：删 Release/assets，**保留 tag**（`refs/tags/v*` ruleset 禁止删 tag）。
+
+7. **首次发布只对 `channel == "dev"` 自动 `mkdir` 逻辑路径 `/mihari-release/mihari-dev`（fs `/mihari-dev`）。** 远端今天没有该目录。探测时 **`list_dir("/")`**（`_fs_path("/")` 保持 `"/"`，即存储根）。**在解读 `mihari-dev` 之前必须先确认恰好一条名为 `mihari` 且 `is_dir is True` 的条目**——这是「当前 listing 就是含稳定通道的存储根」的活证据。缺少该兄弟项 → `fail("unable to inspect release root")`，不得 mkdir，也不得当作 retract no-op。**禁止** `list_dir("/mihari-release")` 或 `exists("/mihari-release/mihari-dev")`——后者会 list 父路径 `/mihari-release`，而 `_fs_path("/mihari-release")` 原样返回，AList 会再拼一次存储根，落到加倍路径（v0.3.0 同类 bug）。`ensure_channel_root` **不得**在 `channel == "stable"` 上运行。
+
+8. **不在本 issue 为 `release-dev.yml` 增加 `commit_sha` 输入。** 源身份仍是受保护 `dev` 的 dispatch HEAD（现有 P1）。历史 `v0.9.0-dev.2/3` 保持 GitHub-only、不回溯到 AList；AList 从本变更落地后的下一个 `vX.Y.Z-dev.N` 开始。它们仍可用 `retract-dev.yml` 撤回 GitHub prerelease（见决策 12）。
+
+9. **隔离验收发生在同一个 AList mutation step 内**（snapshot 稳定 index → 调用 `release-alist.py` / `retract-alist.py` → 再读稳定 index 并逐字节比较），这样 `ALIST_*` secrets 仍然只注入那一步，延续 `test_stable_alist_secrets_are_scoped_only_to_the_mutation_step` 的模型。compare 失败时除 dev writer backup 外，必须另传 **stable isolation snapshot** artifact，作为恢复稳定 index 的唯一允许来源。
+
+10. **可复现构建保持不变。** 不改 `go build -buildvcs=false -trimpath`、不改 lock 消费、不改 14-asset 契约。AList 版本目录仍然只放 6 个 AIO 包 + `SHA256SUMS.txt` + `BUILDINFO` + `COMPLETE`。
+
+11. **发布 GitHub→AList；撤回 AList→GitHub；两条路径都不删 tag。** 与 `release.yml` / `retract.yml` 对齐。发布先冻结 GitHub 身份再镜像；撤回先把国内 `latest` 切离坏版本，GitHub 删除失败时用户至少不会再从 AList 装到它。AList 撤回失败时 **不得** 已经删掉 GitHub prerelease（否则无法对照 BUILDINFO / 重跑 identity）。`gh release delete` 不传 `--cleanup-tag`；canonical `v*` tag 留给 ruleset。
+
+12. **dev retract 把「已确认的存储根上没有 `mihari-dev` 子项」当作 AList no-op，然后仍删除 GitHub prerelease。** 与决策 7 共用同一探测：`list_dir("/")` 必须先看到稳定兄弟 `mihari`（目录），然后才允许把缺失的 `mihari-dev` 当 no-op。若 `"/"` 的 listing 没有 `mihari`，视为探测失败而非「通道不存在」，**不得** skip AList 后仍 `gh release delete`（否则会在错误根上留下 dev `latest` 却删掉 GitHub，颠倒决策 11）。`v0.9.0-dev.2/.3` 在真正的存储根（有 `mihari`、无 `mihari-dev`）上仍可撤回。通道根若存在但不是目录：fail closed。tag peel 的 `--expected-sha` 必须是 peel 得到的 commit，**禁止** job `SHA`（当前 `dev` HEAD）。
+
+## Proposed Design
+
+### 目标目录与公开契约
+
+发布成功后，远端 AList（此前不存在 `mihari-dev`）应呈现：
+
+```
+/mihari-release/mihari-dev/                 base_path（fs/API；策略固定，不可配置）
+├── index.txt                               latest 只能是 vX.Y.Z-dev.N
+└── vX.Y.Z-dev.N/                           不可变版本目录
+    ├── mihari-all-in-one-{linux,darwin,windows}-{amd64,arm64}.tar.gz / .zip
+    ├── SHA256SUMS.txt
+    ├── BUILDINFO                           version=...\ncommit=<40-hex>\n
+    └── COMPLETE                            "<version>\n"
+```
+
+**没有** `install-aio-remote.sh` / `.ps1`。
+
+公开直链（`alist_client.AList.public_url` 规则：`{ALIST_URL}/p/public{fs_path}`，无 `?sign=`）：
+
+| 对象 | URL |
+|------|-----|
+| Dev index | `https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari-dev/index.txt` |
+| Dev 某版本包 | `https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari-dev/<version>/mihari-all-in-one-<goos>-<goarch>.tar.gz` |
+
+`index.txt` 格式与稳定通道字节级同构，仅 `latest` 身份不同：
+
+```
+latest v0.9.0-dev.4
+linux-amd64   <公开直链>  <sha256>
+linux-arm64   <公开直链>  <sha256>
+darwin-amd64  <公开直链>  <sha256>
+darwin-arm64  <公开直链>  <sha256>
+windows-amd64 <公开直链>  <sha256>
+windows-arm64 <公开直链>  <sha256>
+```
+
+`alist_index._validate("dev", body, allow_empty=False)` 会拒绝 `latest v0.9.0`（稳定形状）写入该文件。
+
+### 架构与数据流
+
+```mermaid
+flowchart TB
+  subgraph dispatch [workflow_dispatch on refs/heads/dev]
+    V["inputs.version = vX.Y.Z-dev.N"]
+  end
+
+  subgraph github [GitHub 身份源 — 现有 P1，不改语义]
+    B[build 6 binaries<br/>-buildvcs=false -trimpath]
+    AIO[bundle 6 AIO from release-inputs.lock.json]
+    PF[existing-asset checksum preflight]
+    REL[gh api create prerelease<br/>prerelease=true draft=false make_latest=false]
+    LAT["验证 /releases/latest 前后不变"]
+  end
+
+  subgraph alist [AList 国内镜像 — 本 issue]
+    CFG{"ALIST_URL 非空?"}
+    SKIP[Skip AList<br/>GitHub prerelease 成功]
+    SNAP["snapshot /mihari-release/mihari/index.txt"]
+    MK[ensure_channel_root<br/>/mihari-release/mihari-dev]
+    UP["upload version dir → COMPLETE last"]
+    IDX["write_index_reliably dev index.txt"]
+    CMP["compare 稳定 index 字节"]
+    PRUNE[prune 仅 mihari-dev]
+  end
+
+  V --> B --> AIO --> PF --> REL --> LAT --> CFG
+  CFG -->|否| SKIP
+  CFG -->|是，缺凭据| FAIL[connect fail closed]
+  CFG -->|是，凭据齐全| SNAP --> MK --> UP --> IDX --> CMP --> PRUNE
+```
+
+### AList 提交顺序（不得改）
+
+沿用 `scripts/release-alist.py` 的 `publish()`：
+
+1. **仅当 `args.channel == "dev"`** 调用 `ensure_channel_root`（新增，见下）。`channel == "stable"` 必须直接进入步骤 2，与今天的 `release.yml` 字节级兼容。
+2. `ensure_monotonic_version`：候选版本不得低于通道内「当前合法 latest ∪ 所有可逐字节验证的完整目录」的最高值
+3. `upload_version_dir`：缺目录则 mkdir；先传 6 包与 metadata，逐字节回读，**最后** 写 `COMPLETE`（内容为 `"<version>\n"`）
+4. 再次 `ensure_monotonic_version`
+5. 读现有 `index.txt` 作为 `expected_previous`
+6. `build_index` 生成新 body
+7. `write_index_reliably`：单次 PUT + 权威 readback；stale / 第三方值 / 不确定回读一律 fail closed，不自动 rollback
+8. **不**调用 `upload_root_scripts`（dev）；stable 保持现有上传
+9. `prune_versions`：只扫描 `parse_version(name, channel)` 接受的目录，默认 `MIHARI_KEEP_VERSIONS`（GitHub variable，缺省 5）
+
+已有 `COMPLETE` 的同版本目录：`verified_directory(..., expected_commit, expected_sums)` 全量一致才复用；冲突 fail closed，绝不覆盖。这与 GitHub 侧 existing-asset preflight 是同一身份哲学。
+
+### 首次通道根目录
+
+AList 拓扑（`scripts/alist_client.py` `_fs_path`，`test_fs_path_strips_mount_segment`）：
+
+| 逻辑路径 | `_fs_path` 结果 | 说明 |
+|----------|-----------------|------|
+| `/mihari-release/mihari` | `/mihari` | 稳定通道根；当前 writer 只 list 这条 |
+| `/mihari-release/mihari-dev` | `/mihari-dev` | **必须钉死**；与 `mihari` 同为存储根子目录 |
+| `/` | `/` | 存储根本身；`sep <= 0` 原样返回 |
+| `/mihari-release` | `/mihari-release` | **禁止 list/exists/mkdir**。fs API 会再拼存储根，读到 `/mihari-release/mihari-release` |
+
+`AList.exists(path)` 内部 `list_dir(parent)`。因此 `exists("/mihari-release/mihari-dev")` 会 list `/mihari-release`，与上表最后一行相同，**不能**用来探测通道根。
+
+新增 `ensure_channel_root`。`publish()` 仅在 `args.channel == "dev"` 且任何 `list_dir(base_path)` / `ensure_monotonic_version` 之前调用。函数自身再 guard `channel != "dev": return`。
+
+发布与 retract 共用同一探测函数，放在 `alist_client.py`（或两份 hyphenated 脚本都能 import 的小模块）里，禁止两处各写一份、漏掉 `mihari` 检查：
+
+```python
+def storage_root_entries(alist):
+    """List the AList storage root. Fail unless it contains stable sibling mihari."""
+    try:
+        entries = alist.list_dir("/")  # fs JSON path 必须是 "/"
+    except Exception:
+        fail("unable to inspect release root")
+    if not isinstance(entries, list):
+        fail("unable to inspect release root")
+    mihari = [e for e in entries if isinstance(e, dict) and e.get("name") == "mihari"]
+    if len(mihari) != 1 or mihari[0].get("is_dir") is not True:
+        fail("unable to inspect release root")
+    return entries
+
+
+def ensure_channel_root(alist, base_path, channel):
+    if channel != "dev":
+        return
+    # validate_base_path 已保证 base_path == "/mihari-release/mihari-dev"
+    entries = storage_root_entries(alist)
+    matches = [e for e in entries if isinstance(e, dict) and e.get("name") == "mihari-dev"]
+    if not matches:
+        alist.mkdir(base_path)  # fs path /mihari-dev；相对存储根非递归
+        return
+    if len(matches) != 1 or matches[0].get("is_dir") is not True:
+        fail("channel base path is not a directory")
+```
+
+约束：
+
+- 探测只通过 `list_dir("/")`。**没有恰好一条 `mihari` 目录 → 与传输失败相同，fail closed**；不得 mkdir，retract 也不得 no-op。
+- 只在上述检查通过后，才把缺失的 `mihari-dev` 当作「需要 mkdir」（publish）或「AList no-op」（retract）。
+- 只 `mkdir` 逻辑路径 `expected_base_path("dev")`（fs `/mihari-dev`，其 **fs 父目录是存储根 `/`**，不是逻辑 `/mihari-release`）。不 mkdir `/mihari-release/mihari`，不 mkdir `/mihari-release`，不 mkdir `"/"`。
+- 若 `mihari-dev` 已是目录：no-op。
+- 若同名非目录存在：fail closed。
+- retract **不** mkdir。
+
+实现时必须给 `test_fs_path_strips_mount_segment` 增加：
+
+```python
+assert alist._fs_path("/mihari-release/mihari-dev") == "/mihari-dev"
+assert alist._fs_path("/") == "/"
+```
+
+并增加客户端测试：对 `list_dir("/")` 捕获发往 `/api/fs/list` 的 JSON `path` 等于 `"/"`（可用 httptest/fake session，不打公网）。
+
+### 稳定面隔离守卫
+
+新增小脚本 `scripts/alist_channel_guard.py`（独立文件，不把 writer 变成 CLI）。职责：snapshot / compare **稳定** index；不写 AList。snapshot 必须落盘为可上传 artifact 的目录，而不能只写 runner `/tmp` 里一个无名 bin。
+
+```python
+# 行为规格，不是最终排版
+ISOLATION_DIR = Path(os.environ["RUNNER_TEMP"]) / "mihari-index-backup" / "stable-isolation"
+
+def snapshot(alist, path: str, output_dir: Path) -> None:
+    # path 必须是 /mihari-release/mihari/index.txt
+    output_dir.mkdir(parents=True, exist_ok=True)
+    body = alist.content(path)  # None → 对象不存在
+    raw = b"" if body is None else body.encode("utf-8")
+    (output_dir / "index.txt").write_bytes(raw)
+    (output_dir / "metadata.json").write_text(
+        json.dumps({
+            "channel": "stable",
+            "existed": body is not None,
+            "path": path,
+            "sha256": hashlib.sha256(raw).hexdigest(),
+        }, sort_keys=True)
+        + "\n",
+        encoding="utf-8",
+    )
+
+def compare(alist, path: str, expected_dir: Path) -> None:
+    expected = (expected_dir / "index.txt").read_bytes()
+    live = alist.content(path)
+    live_bytes = b"" if live is None else live.encode("utf-8")
+    if live_bytes != expected:
+        fail("foreign channel index changed during this mutation")
+```
+
+失败信息不得包含 index 正文、URL token 或凭据。
+
+CLI：
+
+```text
+python scripts/alist_channel_guard.py snapshot \
+  --path /mihari-release/mihari/index.txt \
+  --output-dir "${RUNNER_TEMP}/mihari-index-backup/stable-isolation"
+python scripts/alist_channel_guard.py compare \
+  --path /mihari-release/mihari/index.txt \
+  --expected-dir "${RUNNER_TEMP}/mihari-index-backup/stable-isolation"
+```
+
+`release-alist.py` 本身已经不能对 `--channel dev` 使用稳定 `base_path`；守卫是 workflow 层的 fail-closed 验收。
+
+**恢复契约：** 隔离失败后，**唯一**允许用来恢复稳定 index 的字节来源是 artifact `stable-index-isolation-<run_id>-<attempt>`。禁止用 `dev-index-backup-*`（`channel=dev` / `path=/mihari-release/mihari-dev/index.txt`）去写稳定路径。不自动 PUT 回稳定 index。人工恢复须校验 metadata 的 `channel=stable`、`path=/mihari-release/mihari/index.txt` 与 `sha256`，规则与现有 stable writer backup 相同（`existed=false` → 确认无合法并发后删除该 index；空/非空则逐字节恢复）。
+
+### `release-dev.yml` 接线
+
+保留现有 `resolve` / `build` / `bundle` / GitHub `publish` 步骤语义。只在 `publish` job 上追加 AList，并加上通道锁。
+
+#### 并发
+
+```yaml
+# 文件级：保持不变，同版本 GitHub 重试互斥
+concurrency:
+  group: dev-release-${{ inputs.version }}
+  cancel-in-progress: false
+
+# jobs.publish 新增：跨版本、与 retract-dev 互斥的 AList writer 锁
+jobs:
+  publish:
+    concurrency:
+      group: mihari-dev-alist
+      cancel-in-progress: false
+```
+
+禁止 `group: mihari-stable-alist`。`cancel-in-progress` 必须为 `false`，避免取消正在 PUT index 的 run。
+
+GitHub 允许 workflow 级 + job 级同时存在：同版本 run 先被 workflow 组挡住；不同版本的 publish/retract 再被 `mihari-dev-alist` 串行。
+
+#### job env
+
+在现有 `SHA` / `GH_TOKEN` / `DEV_RELEASE_NAME` / `DEV_RELEASE_BODY` 上增加：
+
+```yaml
+ALIST_CONFIGURED: ${{ secrets.ALIST_URL != '' }}
+MIHARI_KEEP_VERSIONS: ${{ vars.MIHARI_KEEP_VERSIONS }}
+```
+
+不要把 `ALIST_USERNAME` / `ALIST_PASSWORD` 放进 job env。
+
+#### 步骤（插在现有 “Final verify prerelease and stable latest” **之后**）
+
+```yaml
+      - uses: actions/setup-python@v7
+        if: env.ALIST_CONFIGURED == 'true'
+        with:
+          python-version: '3.12'
+
+      - name: Publish to AList drive
+        id: alist_mutation
+        if: env.ALIST_CONFIGURED == 'true'
+        env:
+          ALIST_URL: ${{ secrets.ALIST_URL }}
+          ALIST_USERNAME: ${{ secrets.ALIST_USERNAME }}
+          ALIST_PASSWORD: ${{ secrets.ALIST_PASSWORD }}
+        run: |
+          python -m pip install --disable-pip-version-check -r scripts/requirements-release.txt
+          python scripts/alist_channel_guard.py snapshot \
+            --path /mihari-release/mihari/index.txt \
+            --output-dir "${RUNNER_TEMP}/mihari-index-backup/stable-isolation"
+          set +e
+          python scripts/release-alist.py \
+            --version "${VERSION}" \
+            --dist-dir dist \
+            --repo-root . \
+            --channel dev \
+            --commit-sha "${SHA}" \
+            --base-path /mihari-release/mihari-dev \
+            --keep-versions "${MIHARI_KEEP_VERSIONS:-5}"
+          publish_status=$?
+          python scripts/alist_channel_guard.py compare \
+            --path /mihari-release/mihari/index.txt \
+            --expected-dir "${RUNNER_TEMP}/mihari-index-backup/stable-isolation"
+          compare_status=$?
+          set -e
+          if [ "${compare_status}" -ne 0 ]; then exit "${compare_status}"; fi
+          exit "${publish_status}"
+
+      - name: Upload dev index recovery backup
+        if: "env.ALIST_CONFIGURED == 'true' && ((failure() && steps.alist_mutation.outcome == 'failure') || (cancelled() && steps.alist_mutation.outcome == 'cancelled'))"
+        uses: actions/upload-artifact@v7
+        with:
+          name: dev-index-backup-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/mihari-index-backup/dev/**
+          if-no-files-found: ignore
+          retention-days: 3
+
+      - name: Upload stable index isolation snapshot
+        if: "env.ALIST_CONFIGURED == 'true' && ((failure() && steps.alist_mutation.outcome == 'failure') || (cancelled() && steps.alist_mutation.outcome == 'cancelled'))"
+        uses: actions/upload-artifact@v7
+        with:
+          name: stable-index-isolation-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/mihari-index-backup/stable-isolation/**
+          if-no-files-found: ignore
+          retention-days: 3
+
+      - name: Re-verify stable latest after AList mutation
+        if: env.ALIST_CONFIGURED == 'true'
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/releases/latest" > /tmp/latest-after-alist.json 2> /tmp/latest-after-alist.err \
+            || { echo "::error::unable to read stable latest release after AList mutation"; exit 1; }
+          python scripts/github_release_policy.py latest \
+            --before /tmp/latest-before.json --after /tmp/latest-after-alist.json --dev-version "${VERSION}"
+
+      - name: Append prerelease AList install hook to release notes
+        if: env.ALIST_CONFIGURED == 'true'
+        run: |
+          NOTES="$(gh release view "${VERSION}" --json body -q .body)"
+          MARKER='<!-- aio-install-dev -->'
+          if printf '%s' "$NOTES" | grep -qF "$MARKER"; then
+            echo "dev aio-install section already present — skipping"
+            exit 0
+          fi
+          cat > /tmp/aio_append_dev.md <<'TEMPLATE'
+
+          <!-- aio-install-dev -->
+          ## 国内 prerelease 安装（AList，免 GitHub；覆盖 index，不改默认稳定入口）
+
+          Linux / macOS：
+
+          ```bash
+          curl -fsSL https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.sh | MIHARI_INDEX_URL=https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari-dev/index.txt bash
+          ```
+
+          Windows (PowerShell)：
+
+          ```powershell
+          $env:MIHARI_INDEX_URL='https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari-dev/index.txt'
+          & ([scriptblock]::Create((irm https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.ps1)))
+          ```
+          TEMPLATE
+          gh release edit "${VERSION}" --notes "$(printf '%s\n%s\n' "$NOTES" "$(cat /tmp/aio_append_dev.md)")"
+```
+
+要点：
+
+- Python 依赖仍然从 `scripts/requirements-release.txt` 安装（当前仅 `requests==2.32.5`），禁止 `pip install requests`。
+- mutation step **只允许**上面这一种退出结构（compare-first）：`set +e` 包住 `release-alist.py` **和** `compare`，记录 `publish_status` / `compare_status`，`set -e` 之后若 `compare_status != 0` 则 `exit` 该值，否则 `exit "${publish_status}"`。禁止先 `set -e` 再 `compare` 然后无条件 `exit "${publish_status}"`——那会在有人插入命令或拿掉 `set -e` 时吞掉隔离失败。workflow 测试必须断言该守卫字符串存在。
+- `compare` 失败时 `alist_mutation.outcome == 'failure'`，两条 backup 步骤都会跑：`dev-index-backup-*`（writer 的 dev 旧 index）和 `stable-index-isolation-*`（守卫 snapshot）。后者才是恢复稳定 index 的来源。路径不得写成 `.../mihari-index-backup/stable/**`，以免与稳定 workflow 的 writer backup 语义混淆。
+- 追加 release notes 发生在 GitHub 最终验收**之后**，因此不会破坏 `github_release_policy.py release --mode final` 对 `<!-- github-release-dev -->` 的检查。marker 用 `<!-- aio-install-dev -->`，避免与稳定 `<!-- aio-install -->` 混淆。
+- 追加步骤失败不得回滚 AList 或 GitHub assets；它只是文档。`if: env.ALIST_CONFIGURED == 'true'` 且默认 `if` 在 job 未失败时运行——若 mutation 失败，后续非 `if: failure()` 步骤会被跳过，notes 不会在失败的 AList 发布上宣传 index。这是期望行为。
+
+#### 明确不要做的事
+
+- 不要在 GitHub mutation 之前调用 AList。
+- 不要 `softprops/action-gh-release` 的 `make_latest`；继续 `gh api ... -f make_latest=false`。
+- 不要改 build/bundle。
+- 不要把 `MIHARI_INDEX_URL` 写进稳定脚本默认值。
+
+### Dev retract：`.github/workflows/retract-dev.yml`
+
+新文件，结构镜像 `retract.yml`，闸门换成 dev。
+
+```yaml
+name: retract dev
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Canonical dev version to retract, e.g. v0.3.0-dev.1 (leading zeroes are rejected)'
+        required: true
+        type: string
+      confirm:
+        description: 'Confirm to permanently remove the GitHub prerelease/assets and AList dev distribution; the canonical dev tag is retained.'
+        required: true
+        type: boolean
+
+permissions:
+  contents: read
+
+env:
+  VERSION: ${{ inputs.version }}
+  CONFIRM: ${{ inputs.confirm }}
+
+jobs:
+  resolve:
+    name: resolve trusted dev source
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      sha: ${{ steps.source.outputs.sha }}
+    steps:
+      - name: Guard dev ref and version
+        run: |
+          [ "${GITHUB_REF}" = "refs/heads/dev" ] \
+            || { echo "::error::dev retraction must be dispatched from refs/heads/dev"; exit 1; }
+          if [[ ! "${VERSION}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-dev\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::version must match the dev prerelease format"
+            exit 1
+          fi
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+      - id: source
+        name: Resolve trusted dev commit
+        run: |
+          SHA="$(git rev-parse HEAD)"
+          [ "${SHA}" = "${GITHUB_SHA}" ] \
+            || { echo "::error::checked-out commit does not equal event commit"; exit 1; }
+          echo "sha=${SHA}" >> "${GITHUB_OUTPUT}"
+
+  retract:
+    name: retract dev release
+    needs: resolve
+    if: github.ref == 'refs/heads/dev' && needs.resolve.outputs.sha != ''
+    runs-on: ubuntu-latest
+    concurrency:
+      group: mihari-dev-alist
+      cancel-in-progress: false
+    permissions:
+      contents: write
+    env:
+      ALIST_CONFIGURED: ${{ secrets.ALIST_URL != '' }}
+      SHA: ${{ needs.resolve.outputs.sha }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+          fetch-depth: 0
+
+      - name: Verify trusted source commit
+        run: |
+          [ "$(git rev-parse HEAD)" = "${SHA}" ] \
+            || { echo "::error::checkout did not resolve the trusted dev commit"; exit 1; }
+
+      - name: Gate (dev semver + confirm)
+        run: |
+          if [[ ! "${VERSION}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-dev\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::version must match the dev prerelease format"
+            exit 1
+          fi
+          [ "${CONFIRM}" = "true" ] \
+            || { echo "::error::confirm must be true to permanently remove prerelease/assets and AList dev distribution; canonical dev tag retained"; exit 1; }
+
+      - name: Peel canonical tag for identity SHA
+        run: |
+          # 7 层 peel 循环可从 release-dev.yml 抄结构，但 tag-chain 的
+          # --expected-sha 禁止抄 "${SHA}"：job SHA 是当前 dev HEAD，
+          # 撤回历史 v0.9.0-dev.2/.3 时必然不等于 tag commit。
+          gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${VERSION}" > /tmp/tag-ref.json 2> /tmp/tag-ref.err \
+            || { echo "::error::unable to read release tag"; exit 1; }
+          jq -e '(.object.type | type == "string") and (.object.sha | type == "string")' /tmp/tag-ref.json >/dev/null \
+            || { echo "::error::release tag response is invalid"; exit 1; }
+          jq -c '{type: .object.type, sha: .object.sha}' /tmp/tag-ref.json > /tmp/tag-chain.jsonl
+          tag_type="$(jq -r '.object.type' /tmp/tag-ref.json)"
+          tag_sha="$(jq -r '.object.sha' /tmp/tag-ref.json)"
+          for depth in $(seq 1 7); do
+            [ "${tag_type}" = tag ] || break
+            gh api "repos/${GITHUB_REPOSITORY}/git/tags/${tag_sha}" > /tmp/tag-object.json 2> /tmp/tag-object.err \
+              || { echo "::error::unable to peel release tag"; exit 1; }
+            jq -e '(.object.type | type == "string") and (.object.sha | type == "string")' /tmp/tag-object.json >/dev/null \
+              || { echo "::error::annotated tag response is invalid"; exit 1; }
+            jq -c '{type: .object.type, sha: .object.sha}' /tmp/tag-object.json >> /tmp/tag-chain.jsonl
+            tag_type="$(jq -r '.object.type' /tmp/tag-object.json)"
+            tag_sha="$(jq -r '.object.sha' /tmp/tag-object.json)"
+          done
+          [ "${tag_type}" != tag ] || { echo "::error::release tag peel exceeds the allowed depth"; exit 1; }
+          [ "${tag_type}" = commit ] || { echo "::error::release tag did not peel to a commit"; exit 1; }
+          jq -s . /tmp/tag-chain.jsonl > /tmp/tag-chain.json
+          RELEASE_SHA="${tag_sha}"
+          echo "RELEASE_SHA=${RELEASE_SHA}" >> "${GITHUB_ENV}"
+          python scripts/github_release_policy.py tag-chain \
+            --chain /tmp/tag-chain.json --expected-sha "${RELEASE_SHA}"
+
+      - name: Snapshot stable latest before mutation
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/releases/latest" > /tmp/latest-before.json 2> /tmp/latest-before.err \
+            || { echo "::error::unable to read stable latest release"; exit 1; }
+          python scripts/github_release_policy.py latest \
+            --before /tmp/latest-before.json --after /tmp/latest-before.json --dev-version "${VERSION}"
+
+      - uses: actions/setup-python@v7
+        if: env.ALIST_CONFIGURED == 'true'
+        with:
+          python-version: '3.12'
+
+      - name: Retract from AList drive
+        id: alist_mutation
+        if: env.ALIST_CONFIGURED == 'true'
+        env:
+          ALIST_URL: ${{ secrets.ALIST_URL }}
+          ALIST_USERNAME: ${{ secrets.ALIST_USERNAME }}
+          ALIST_PASSWORD: ${{ secrets.ALIST_PASSWORD }}
+        run: |
+          python -m pip install --disable-pip-version-check -r scripts/requirements-release.txt
+          python scripts/alist_channel_guard.py snapshot \
+            --path /mihari-release/mihari/index.txt \
+            --output-dir "${RUNNER_TEMP}/mihari-index-backup/stable-isolation"
+          set +e
+          python scripts/retract-alist.py \
+            --version "${VERSION}" \
+            --channel dev \
+            --base-path /mihari-release/mihari-dev \
+            --commit-sha "${RELEASE_SHA}"
+          retract_status=$?
+          python scripts/alist_channel_guard.py compare \
+            --path /mihari-release/mihari/index.txt \
+            --expected-dir "${RUNNER_TEMP}/mihari-index-backup/stable-isolation"
+          compare_status=$?
+          set -e
+          if [ "${compare_status}" -ne 0 ]; then exit "${compare_status}"; fi
+          exit "${retract_status}"
+
+      - name: Upload dev index recovery backup
+        if: "env.ALIST_CONFIGURED == 'true' && ((failure() && steps.alist_mutation.outcome == 'failure') || (cancelled() && steps.alist_mutation.outcome == 'cancelled'))"
+        uses: actions/upload-artifact@v7
+        with:
+          name: dev-index-backup-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/mihari-index-backup/dev/**
+          if-no-files-found: ignore
+          retention-days: 3
+
+      - name: Upload stable index isolation snapshot
+        if: "env.ALIST_CONFIGURED == 'true' && ((failure() && steps.alist_mutation.outcome == 'failure') || (cancelled() && steps.alist_mutation.outcome == 'cancelled'))"
+        uses: actions/upload-artifact@v7
+        with:
+          name: stable-index-isolation-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/mihari-index-backup/stable-isolation/**
+          if-no-files-found: ignore
+          retention-days: 3
+
+      - name: Delete GitHub prerelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # 复制 retract.yml：lookup 成功则 gh release delete --yes；HTTP 404 视为已撤回。
+          # 禁止 --cleanup-tag。日志：canonical dev tag retained.
+
+      - name: Re-verify stable latest after GitHub delete
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/releases/latest" > /tmp/latest-after.json 2> /tmp/latest-after.err \
+            || { echo "::error::unable to read stable latest release after retraction"; exit 1; }
+          python scripts/github_release_policy.py latest \
+            --before /tmp/latest-before.json --after /tmp/latest-after.json --dev-version "${VERSION}"
+```
+
+workflow 测试必须钉死 `resolve["outputs"]["sha"] == "${{ steps.source.outputs.sha }}"`、`retract.if`、checkout `needs.resolve.outputs.sha`，对齐 `test_stable_retract_runs_secrets_only_from_a_verified_main_checkout`。`--commit-sha` 只能是 peel 写入的 `RELEASE_SHA`，不能是 job env `SHA`。**Peel 步骤内** `github_release_policy.py tag-chain` 的 `--expected-sha` 必须是 `"${RELEASE_SHA}"` 或 `"${tag_sha}"`；该步骤字符串不得出现 `--expected-sha "${SHA}"`（那是 `release-dev.yml` 发布路径的正确写法，撤回路径照抄会挡住历史 tag）。Gate 错误路径不得 echo `${VERSION}`。
+
+顺序是 **AList mutation →（失败则 backup）→ GitHub delete → latest 再校验**。不得先删 GitHub。
+
+### `retract-alist.py`：保留现有语义，仅增加 dev 通道根探测
+
+现有行为保持：
+
+- latest 撤回：先 `write_index_reliably` 切到次高完整 dev 版本（或空），再 `remove` 目标目录。
+- 非 latest：index 字节不变，只删目录。
+- 目录不存在且 index 不再引用：幂等返回。
+- 目录不存在但 index 仍指向该 version：fail closed。
+- BUILDINFO commit 与 `--commit-sha` 不一致：fail closed。
+- 稳定路径 + `channel=dev`：`validate_base_path` 拒绝。
+
+**新增（仅 `channel == "dev"`），插在 `validate_inputs` 之后、`directory_exists` 之前：**
+
+调用与 publish 相同的 `storage_root_entries(alist)`（禁止 list `/mihari-release`，禁止单独再写一份不检查 `mihari` 的 listing）：
+
+- `storage_root_entries` 失败（传输错误、listing 不是 list、**没有恰好一条 `mihari` 目录**）→ fail closed（`unable to inspect release root`）。**这不是 no-op**：不得 skip AList 后继续 `gh release delete`。
+- listing 已证明是存储根，且没有 `mihari-dev` → **AList no-op 成功返回**（不 mkdir、不读 index、不 remove）。workflow 继续 `gh release delete`。
+- `mihari-dev` 存在且 `is_dir is True` → 进入现有 `retract()` 逻辑。
+- `mihari-dev` 存在但不是目录 → fail closed。
+
+这样 `retract-dev.yml` 在 `ALIST_URL` 已配置、存储根上已有稳定 `mihari`、但还从未 bootstrap 过 `mihari-dev` 时，仍能撤回 GitHub-only 的 `v0.9.0-dev.2` / `v0.9.0-dev.3`。若 `fs/list` 的 `"/"` 其实是虚拟根（子项是 `mihari-release` 而不是 `mihari`），会 fail closed 而不是误删 GitHub。
+
+### 保留策略与 prune 隔离
+
+`MIHARI_KEEP_VERSIONS` 两条通道共用，默认 5。`prune_versions(..., channel="dev")` 只列举 `parse_version(name, "dev")` 成功的目录名；`test_dev_retention_never_removes_stable_directories` 已覆盖「稳定目录不被 dev prune 碰到」。不引入第二个 GitHub variable。
+
+### 消费钩子（给 #125，本 issue 只文档化）
+
+| 钩子 | 本 issue 的承诺 |
+|------|------------------|
+| 公开 index URL | 永久契约，见上表 |
+| `MIHARI_INDEX_URL` | 稳定下载器已支持；文档给出覆盖示例 |
+| GitHub prerelease notes 中的 `<!-- aio-install-dev -->` | AList 成功后追加一次 |
+| `MIHARI_CHANNEL` / `self update` / TUI | **不做** |
+| README 默认命令 | **不改** |
+
+墙内用户在 #125 落地前若要装 prerelease，必须显式覆盖 index；漏设则仍走稳定 `latest`。这是安全默认，不是缺陷。
+
+### 历史版本
+
+`v0.9.0-dev.2` / `v0.9.0-dev.3` **不回溯发布到 AList**。`release-dev.yml` 的 ref 闸门是 `GITHUB_REF == refs/heads/dev`，不能从 tag dispatch；当前 `dev` HEAD 也已经不等于那些 tag SHA。本 issue 不增加 `commit_sha` 输入。下一个新的 `vX.Y.Z-dev.N` 才是第一条带 AList 的 dev 发布。
+
+它们 **可以** 用 `retract-dev.yml` 撤回 GitHub prerelease：缺失 `mihari-dev` 根时 AList no-op，随后 `gh release delete`。不要为了撤回它们而先手工 mkdir 通道根。
+
+### `regenerate-index.py`
+
+现仅允许 `validate_base_path("stable", ...)`。扩展 `--channel {stable,dev}`，**默认 `stable`**（省略 flag 不 fail；打断现有运维习惯不值得）。对 dev 调用 `highest_complete(..., channel="dev")` 与 `write_index_reliably(..., channel="dev")`。
+
+默认通道是脚枪：有人以为在修 dev，实际会写 `/mihari-release/mihari/index.txt`。必须：
+
+1. argparse help 明确写出默认通道和路径，例如 `--channel` help：`Index channel to rebuild (default: stable, writes /mihari-release/mihari/index.txt)`。
+2. 在任何 PUT 之前 `info` 一行已解析的 `channel` 与 `{base_path}/index.txt`（无 secret）。
+3. `test_regenerate_index.py` 断言 `--help` 含 `stable` 与 `/mihari-release/mihari`。
+4. `docs/distribution.md`（P2 文档 PR）同样写明默认是稳定通道/路径，修 dev 必须 `--channel dev`。
+
+人工运行前必须确认对应通道的 release/retract workflow 都未在跑。这不是发版主路径，但是拓扑修复工具。
+
+## API / Interface Changes
+
+无 `/v1`、CLI、daemon、TUI 变化。
+
+### Python CLI（已存在，workflow 首次真正传入 `dev`）
+
+```text
+python scripts/release-alist.py \
+  --version vX.Y.Z-dev.N \
+  --dist-dir dist \
+  --repo-root . \
+  --channel dev \
+  --commit-sha <40-hex> \
+  --base-path /mihari-release/mihari-dev \
+  --keep-versions 5
+
+python scripts/retract-alist.py \
+  --version vX.Y.Z-dev.N \
+  --channel dev \
+  --base-path /mihari-release/mihari-dev \
+  --commit-sha <40-hex-from-tag-peel>
+```
+
+`--base-path` 与 `--channel` 必须同时出现且匹配；只靠 default `DEFAULT_BASE_PATH`（稳定）对 `channel=dev` 会在 `validate_inputs` 失败。workflow 测试必须断言两个 flag 的字面值。
+
+`retract-alist.py` 对 `channel=dev` 增加存储根探测：`storage_root_entries` 证明 `"/"` 含稳定 `mihari` 目录之后，没有 `mihari-dev` 子项时成功 no-op（CLI 仍退出 0）；缺少 `mihari` 兄弟项则 fail closed。这是本 issue 唯一对 retract 脚本的生产行为增量。
+
+### 新增 CLI
+
+```text
+python scripts/alist_channel_guard.py snapshot \
+  --path /mihari-release/mihari/index.txt \
+  --output-dir "${RUNNER_TEMP}/mihari-index-backup/stable-isolation"
+python scripts/alist_channel_guard.py compare \
+  --path /mihari-release/mihari/index.txt \
+  --expected-dir "${RUNNER_TEMP}/mihari-index-backup/stable-isolation"
+```
+
+### 新增 workflow
+
+| 文件 | 触发 | 写入范围 |
+|------|------|----------|
+| `.github/workflows/retract-dev.yml` | 从 `dev` 手动 dispatch（`version` + `confirm`） | 删 `/mihari-release/mihari-dev/<version>/`，重建 **dev** `index.txt`；删 GitHub prerelease/assets；保留 dev tag |
+
+### 公开 URL 契约（稳定，后续脚本可硬编码）
+
+```
+https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari-dev/index.txt
+```
+
+## Data Model Changes
+
+无应用持久化 / settings / protocol schema 变化。
+
+AList 对象模型按通道复制稳定布局：
+
+| 字段 | Stable | Dev |
+|------|--------|-----|
+| base path | `/mihari-release/mihari` | `/mihari-release/mihari-dev` |
+| index `latest` | `vX.Y.Z` | `vX.Y.Z-dev.N` |
+| BUILDINFO | 新目录必须有；历史稳定目录可缺 | **必须有**；retract 校验 commit |
+| COMPLETE | `"<version>\n"` | 同左 |
+| 根目录安装脚本 | 上传稳定硬编码 URL 的脚本 | **不上传** |
+| 保留数 | `MIHARI_KEEP_VERSIONS` 默认 5 | 同左，作用域仅 dev 目录 |
+
+无迁移：远端没有旧的 `mihari-dev` 对象需要转换。第一次成功的 `release-alist.py --channel dev` 就是 bootstrap。
+
+Index backup metadata 分两类，不得混用：
+
+```json
+{"channel": "dev", "existed": false, "path": "/mihari-release/mihari-dev/index.txt", "sha256": "<hex>"}
+```
+
+```json
+{"channel": "stable", "existed": true, "path": "/mihari-release/mihari/index.txt", "sha256": "<hex>"}
+```
+
+- `dev-index-backup-<run_id>-<attempt>`：writer 在 mutation **dev** index 前的备份。恢复时校验 `channel=dev` 且 path 精确等于 `/mihari-release/mihari-dev/index.txt`。
+- `stable-index-isolation-<run_id>-<attempt>`：守卫在 dev mutation 前对**稳定** index 的 snapshot。隔离 compare 失败后，**只允许**用这份 artifact 恢复稳定 index。
+
+**禁止**用 dev backup 去写稳定路径，也禁止用 isolation snapshot 去写 `mihari-dev`。
+
+## Alternatives Considered
+
+### 1. 只在 AList 列出版本目录、不写 `index.txt`
+
+脚本无法区分完整目录与半成品（`COMPLETE` 之前）。否决。issue 正文已否决。
+
+### 2. 把 `-dev.N` 写入稳定 `index.txt`
+
+国内默认安装会装到预发布，且破坏 `parse_version(..., "stable")`。否决。
+
+### 3. 继续只走 GitHub prerelease
+
+墙内 #125 没有入口。本 issue 正是为补这一环。否决「什么都不做」。
+
+### 4. 给 `retract.yml` 增加 `channel` 输入，而不是新 workflow
+
+减少文件数，但要把 `main`/`dev` 闸门、两种版本正则、两把并发锁、是否传 `--commit-sha` 编进同一份 YAML。现有测试把 `retract.yml` 钉死为 stable-only（`--channel stable`、`github.ref == refs/heads/main`、`mihari-stable-alist`）。独立 `retract-dev.yml` 的误操作面更小。否决混用。
+
+### 5. 上传 `install-aio-remote.*` 到 dev 根，或在仓库新增 `*-dev.sh` 副本
+
+上传现有文件会让「dev 安装器」安装稳定版。新增硬编码 dev URL 的副本接近 #125 的消费实现，且造成双份脚本。已有 `MIHARI_INDEX_URL` 足够作为保留钩子。否决本 issue 上传/复制安装器。
+
+### 6. AList 与 GitHub 并行，或 AList 先于 GitHub
+
+并行无法保证 GitHub 身份已 freeze 再写镜像，失败窗口变大。AList 先行会在 GitHub 失败时留下无 tag 的国内 `latest`。否决。保持「GitHub 成功 → AList」。
+
+### 7. 共享 `mihari-stable-alist` 锁「以免两个 writer 同时打 AList」
+
+两条通道写的是不同 fs 路径，共享锁只会让稳定发版被 dev 发布排队（或反向），不能提供比路径隔离更强的正确性。真正危险的是 **同通道** 的 release 与 retract 并发，这由 `mihari-dev-alist` 覆盖。否决共享。
+
+### 8. 为回溯 `v0.9.0-dev.3` 增加 `commit_sha` 输入
+
+有用，但改变 P1 的「dispatch HEAD == 源 SHA」不变量，需要 ancestry 检查与新测试。不在 #126 做。
+
+### 9. `list_dir("/mihari-release")` 或 `exists(通道根)` 来 bootstrap
+
+`_fs_path` 对单段 `/mihari-release` 原样返回，AList 会拼出加倍路径。否决。只 list `"/"`。
+
+### 10. 发布接线与 retract 拆成两个合入 `dev` 的 PR
+
+文档测试同时锁「不写 AList」和「不得出现 retract-dev.yml」；中间态要么 CI 红，要么 `dev` 上有 writer 无撤回。否决。脚本层（PR 1）与 Actions/文档（PR 2）仍可拆。
+
+## Security & Privacy Considerations
+
+| 威胁 | 严重度 | 缓解 |
+|------|--------|------|
+| 把 prerelease 写进稳定 `latest`，默认安装被劫持 | 高 | 路径策略 + writer 通道校验 + mutation 步骤内稳定 index 字节比对；compare 在 publish/retract 失败后仍运行；compare 失败上传 `stable-index-isolation-*` 供人工恢复，禁止用 dev backup 覆盖稳定 index |
+| 凭据进入 skip 判定或 job 日志 | 高 | 仅 `ALIST_URL != ''` 决定是否进入 mutation；username/password 只出现在 `alist_mutation` 的 `env`；`fail()` / `info()` 已有的 sanitized 消息不得扩展为打印 URL/index 正文 |
+| 跨通道 `remove` / prune | 高 | `parse_version` 过滤目录名；`validate_base_path`；已有 `test_dev_retention_never_removes_stable_directories` |
+| 上传稳定安装器到 dev 根 | 高 | 保持 `upload_root_scripts` 仅 stable；workflow 测试断言 `release-alist.py` 的 `--channel dev` 且文档/测试继续断言 dev 根无安装器 |
+| 并发覆盖 index | 中 | job 级 `mihari-dev-alist` + writer 的 expected_previous + 单次 PUT/readback；不声称 CAS |
+| 伪造 BUILDINFO 撤回别人的目录 | 中 | retract 要求 tag peel SHA 与 BUILDINFO commit 一致；tag 受 `refs/tags/v*` ruleset 保护 |
+| 公开直链被缓存读到半成品 | 中 | 先 COMPLETE 再写 index；用户只通过 index 发现新版本 |
+| 扩大网络暴露面 | 低 | 无新监听；AList 仍是既有出站 HTTPS |
+| 日志泄漏订阅 URL / controller secret | 低 | 本变更不触及应用运行时；发布脚本已避免打印 token |
+
+`connect()` 在凭据缺失时的退出码必须是失败，不能被 workflow `if` 吃掉。`ALIST_CONFIGURED` 为 true 时 mutation step 无条件运行。
+
+## Observability
+
+- 成功：`release-alist.py` 已有 `::notice::published {version} to {base_path}; index at {index_url}`。dev 的 `index_url` 应为 `https://<ALIST_URL host>/p/public/mihari-release/mihari-dev/index.txt`。
+- 失败：`::error::` 使用现有 sanitized 字符串（`stale index observed before mutation`、`completed version dir conflicts or cannot be verified`、`foreign channel index changed during this mutation` 等）。禁止把远端 body、token、完整 index 打到日志。
+- 恢复：mutation 失败或 mutation 期间取消 → 上传两份保留 3 天的 artifact：
+  - `dev-index-backup-<run_id>-<attempt>`：`$RUNNER_TEMP/mihari-index-backup/dev/**`（writer 的 dev 旧 index）
+  - `stable-index-isolation-<run_id>-<attempt>`：`$RUNNER_TEMP/mihari-index-backup/stable-isolation/**`（稳定 index 字节 + `channel=stable` metadata）
+  成功后下游失败不上传（远端 index 已提交）。隔离 compare 失败时两份都会上传，因为 `alist_mutation` 为 failure。
+- 指标：无新 metrics 系统。验收靠 workflow 绿/红与人工下载 index。
+- 告警：维护者看 Actions；稳定 index compare 失败视为事故，停止自动 rollback，只用 `stable-index-isolation-*` 按 metadata 人工恢复稳定面。
+
+## Rollout Plan
+
+1. **实现与 CI**：按下方 PR Plan 合入 `dev`。PR 1 必须同时改 `RELEASE_SAFETY_TESTS` 与 `.github/workflows/ci.yml` 的 pytest 命令，否则新测试文件不会在 CI 运行。PR 2 同时合入 publish 与 retract，**禁止**在没有 `retract-dev.yml` 的情况下让 AList 写入进 `dev`。
+2. **不改 GitHub Secrets**。复用 `ALIST_URL` / `ALIST_USERNAME` / `ALIST_PASSWORD` 与 `vars.MIHARI_KEEP_VERSIONS`。不新增 secret。
+3. **不在 AList 控制台手工预建 `mihari-dev`**（`ensure_channel_root` 负责）。若运维已经误建了同名文件，首次发布应 fail closed，再人工处理。
+4. **首次真实发布**：从受保护 `dev` dispatch `release-dev`，version 使用**新的** `vX.Y.Z-dev.N`（不要复用 `-dev.2/.3`）。验收清单见下。`ALIST_URL` 若在该仓库未配置，则只验证 GitHub-only skip。
+5. **首次真实撤回**：仅在有致命错误时从 `dev` dispatch `retract-dev`。不要用首次 rollout 当撤回演练，除非准备好下一个更高 dev 版本。GitHub-only 历史 tag 的撤回不需要先有 `mihari-dev` 目录。
+6. **回滚**：
+   - 代码回滚：revert 合入 `dev` 的 PR；不会自动删除已经写上 AList 的 `mihari-dev`。
+   - 对象回滚：对已发布的坏版本跑 `retract-dev`；稳定面应保持不变。
+   - 不要用 `regenerate-index.py` 默认通道去「修」dev；必须显式 `--channel dev`。
+7. **Feature flag**：无应用内 flag。行为开关就是 `ALIST_URL` 是否存在。
+
+### 验收清单（对应 issue「建议验证」）
+
+- [ ] 发布后 `GET` 公开 dev index，`latest` 等于本次 `vX.Y.Z-dev.N`，六条平台行可下载且 sha256 匹配本地 `AIO_SHA256SUMS.txt`
+- [ ] 同一 run 前后，稳定 `/mihari-release/mihari/index.txt` 字节不变（workflow compare + 人工再下一次）
+- [ ] `/releases/latest` 仍为非 draft、非 prerelease 的稳定版本
+- [ ] `parse_version` / `validate_base_path` 单测继续拒绝跨通道
+- [ ] 临时去掉 `ALIST_URL` 的语义在单元/workflow 测试中体现为 skip（无法在 CI 里真删 secret）；代码路径与稳定一致
+- [ ] 重跑同版本且字节一致：GitHub preflight + AList `verified_directory` 幂等；字节冲突 fail closed
+- [ ] 默认 `install-aio-remote` URL 仍指向稳定 index；dev 根不存在这两个文件名
+- [ ] `release-dev.yml` / `retract-dev.yml` 不含 `mihari-stable-alist`
+- [ ] 远端在首次成功发布前没有 `mihari-dev` 不是失败条件
+
+## Testing Plan（TDD）
+
+行为变更先写失败测试。现有 CI pytest 命令（`ci.yml` unit job 与 `RELEASE_SAFETY_TESTS`）**不含**新文件。PR 1 必须把两者改成同一条字面量：
+
+```
+python -m pytest scripts/test_release_policy.py scripts/test_github_release_policy.py scripts/test_release_workflow.py scripts/test_alist_client.py scripts/test_alist_index.py scripts/test_release_alist.py scripts/test_retract_alist.py scripts/test_regenerate_index.py scripts/test_alist_channel_guard.py -q
+```
+
+`test_ci_runs_release_safety_suite_from_pinned_requirements_on_all_integration_branches` 断言 `safety["run"] == f"python -m pytest {RELEASE_SAFETY_TESTS}"`，因此只改测试文件、不改 constant/`ci.yml` 会使新测试永远不跑。
+
+### Topology-aware Fake（PR 1 前置）
+
+现有 `test_release_alist.py` `FakeAList.list_dir` 对缺失目录返回 `[]` 且不走 `_fs_path`；`ensure_monotonic_version` 只在 `Exception` 时 fail closed。因此「空 Fake 上 publish 成功」**在没有 `ensure_channel_root` 时也会绿**，不能当 TDD。
+
+引入 topology-aware fake（可被 `test_release_alist.py` / `test_retract_alist.py` 共用；允许小测试 helper）：
+
+- `list_dir` 对不存在的 **fs** 目录 raise `AListError`（与真实 `fs/list` 一致）。
+- `mkdir` **在 fs 空间不递归**：对逻辑路径 `p` 计算 `fs = AList._fs_path(p)`；`fs == "/"` 禁止；fs 父目录必须已是存储根 `"/"` 或先前 mkdir 出的 fs 目录。`mkdir("/mihari-release/mihari-dev")` 的 fs 是 `/mihari-dev`，父目录是 `"/"`（测试开始时已存在），**不得**要求逻辑父路径 `/mihari-release` 存在——那条路径禁止 list/mkdir。
+- 每次 `list_dir` / `mkdir` / `exists` 记录 `(op, logical_path, fs_path)`，其中 `fs_path` 必须调用真实 `AList._fs_path`。
+- 起始状态：只预置存储根子项 `mihari`（`is_dir True`）。**不要**预置逻辑目录 `/mihari-release`。没有 `mihari-dev`。
+- `list_dir("/mihari-release")` 若被调用，记录的 fs path 是 `/mihari-release`，测试应断言该 op **从未发生**。
+
+针对该 Fake 的 first-publish 测试必须：**当前 `publish()` 失败**；实现 `ensure_channel_root` 后才通过。断言 mkdir 参数是逻辑 `/mihari-release/mihari-dev`、fs `/mihari-dev`，且没有任何 mkdir `/mihari-release/mihari` 或 list `/mihari-release`。
+
+`channel == "stable"` 的 `publish()` 在同一 Fake 上不得调用 `list_dir("/")` 做 bootstrap，也不得 mkdir `mihari-dev`。用记录的 call args 断言，不只靠 Fake dict 里有没有某个 key。
+
+### PR 1 测试（脚本 + CI 列表；不翻转「P2 不可用」文档）
+
+- `test_alist_client.py`：`_fs_path("/mihari-release/mihari-dev") == "/mihari-dev"`；`_fs_path("/") == "/"`；`list_dir("/")` 请求 JSON `path` 为 `"/"`。
+- `test_release_alist.py`：上文 first-publish / 已有 `mihari-dev` no-op / 同名文件 fail / stable 不跑 helper；`list_dir("/")` **没有 `mihari` 兄弟项**时 `ensure_channel_root` / `publish(channel=dev)` fail closed 且不 mkdir。现有 `test_publish_dev_never_uploads_root_installers` 保持。
+- `test_retract_alist.py`：`list_dir("/")` 有 `mihari`、无 `mihari-dev` 时 `retract(..., "dev")` 成功且无 upload/remove；`mihari-dev` 根存在后仍走原逻辑；`list_dir("/")` 传输失败 fail closed；**listing 无 `mihari` 不是 no-op**（fail closed，无 GitHub 侧含义、无 remove）。
+- `test_alist_channel_guard.py`（新）：snapshot None→`existed=false` 空 `index.txt` + metadata `channel=stable` / `path=/mihari-release/mihari/index.txt`；compare 相等通过；compare 不相等 SystemExit 且 stderr 无正文/secret。
+- `test_regenerate_index.py`：`--channel dev` 重建 dev index；默认仍 stable；dev+稳定路径被拒绝；`--help` 含 `stable` 与 `/mihari-release/mihari`；写入前有 notice 含已解析路径。
+- `test_release_workflow.py`：仅扩展 `RELEASE_SAFETY_TESTS` 字符串（加 `scripts/test_alist_channel_guard.py`）。
+- `.github/workflows/ci.yml`：pytest 命令与 constant 逐字相同。
+
+### PR 2 测试（发布 + 撤回 + 文档一次翻转）
+
+必须改写：
+
+| 测试 | 现状 | 目标 |
+|------|------|------|
+| `test_release_workflow_is_github_only_and_limits_tag_peeling` | `ALIST_` / `mihari-dev` 不得出现在 `release-dev.yml` | 拆成：仍限制 tag peel 深度；**新增** AList 接线断言 |
+| `test_release_documents_record_verified_dev_github_release_and_unavailable_dev_alist` | 文档必须包含「dev AList 发布与 dev retract workflow」且 **不得** 出现 `retract-dev.yml` | **本 PR 一次改完**：P2 发布与撤回均可用；文档 **必须** 出现 `retract-dev.yml`；删除「不写 AList」「当前不创建或操作该目录」 |
+| `test_alist_runtime_dependencies_are_pinned_after_checkout_in_both_stable_workflows` | 只覆盖 stable release/retract | 扩展到 `release-dev.yml` 与 `retract-dev.yml` |
+
+新增 workflow 断言（全部属于 PR 2，因为 `retract-dev.yml` 与发布接线同 PR）：
+
+- `publish` job 与 `retract-dev.yml` 的 retract job：`concurrency.group == mihari-dev-alist` 且 `cancel-in-progress is False`
+- 两文件都不含 `mihari-stable-alist`
+- `release-alist.py`：`--channel dev`、`--base-path /mihari-release/mihari-dev`、`--commit-sha "${SHA}"`
+- `retract-alist.py`：`--channel dev`、`--base-path /mihari-release/mihari-dev`、`--commit-sha "${RELEASE_SHA}"`（禁止 `--commit-sha "${SHA}"`）
+- **Peel 步骤**（`name: Peel canonical tag for identity SHA`）含 `github_release_policy.py tag-chain` 与 `--expected-sha "${RELEASE_SHA}"` 或 `"${tag_sha}"`；该步骤文本不得含 `--expected-sha "${SHA}"`（`release-dev.yml` 发布路径仍使用 `"${SHA}"`，不要误伤）
+- `resolve["outputs"]["sha"] == "${{ steps.source.outputs.sha }}"`；retract checkout `needs.resolve.outputs.sha`；`retract.if` 含 `refs/heads/dev`
+- `ALIST_CONFIGURED == '${{ secrets.ALIST_URL != '' }}'`；mutation `if` 为 `env.ALIST_CONFIGURED == 'true'`；secrets 只出现在 `id: alist_mutation`
+- 两条 backup：`dev-index-backup-` → `.../mihari-index-backup/dev/**`；`stable-index-isolation-` → `.../mihari-index-backup/stable-isolation/**`；`if` 与稳定 mutation-failure 结构相同
+- mutation 在 “Final verify prerelease and stable latest” **之后**
+- mutation run：`snapshot` 在 `release-alist.py` / `retract-alist.py` 之前，`compare` 在其后；`if [ "${compare_status}" -ne 0 ]` 出现在 `exit "${publish_status}"` / `exit "${retract_status}"` 之前
+- setup-python `@v7` + `3.12` + `requirements-release.txt`
+- `retract-dev.yml`：confirm 布尔、不 echo 非法 version、`gh release delete` 无 `--cleanup-tag`、AList 步骤字面量出现在 Delete GitHub 步骤之前
+- notes marker `<!-- aio-install-dev -->`，URL 含 `mihari-dev/index.txt` 且仍引用稳定根 `install-aio-remote.sh`
+- build 步仍为 `-buildvcs=false -trimpath`
+
+### 不做的测试
+
+- 不打公网、不连真实 AList、不在 CI 里创建 `mihari-dev`。
+- 不把真实用户目录或真实订阅写进测试。
+
+## Risks
+
+| 风险 | 严重度 | 缓解 |
+|------|--------|------|
+| 首次 list `/mihari-release` 落到加倍 fs 路径 | 高 | 只 `list_dir("/")`；钉死 `_fs_path("/mihari-release/mihari-dev") == "/mihari-dev"`；topology fake 对缺失 fs 目录 raise |
+| `list_dir("/")` 不是存储根（无 `mihari` 兄弟）时 retract no-op 仍删 GitHub | 高 | `storage_root_entries` 要求恰好一条 `mihari` 目录，否则 fail closed，不进入 no-op |
+| 撤回 peel 抄 `--expected-sha "${SHA}"` 挡住历史 tag | 高 | peel 用 peel 出的 commit 作 `--expected-sha`；workflow 测试钉死 peel 步骤不含 `"${SHA}"` |
+| compare 漏跑导致稳定 index 被改而不自知 | 高 | snapshot/compare 包在同一 step，publish/retract 失败也 compare；隔离 snapshot 单独上传 |
+| 文档/测试仍声称 P2 不可用，导致 CI 红或 runbook 错误 | 中 | 发布与撤回同一 PR 翻转文档与 `test_release_workflow.py` |
+| 有 AList writer、无 retract | 高 | 不把 `release-dev.yml` AList 步骤单独合入 `dev` |
+| 运维从 tag ref dispatch 想回溯旧版本 | 中 | 闸门拒绝非 `refs/heads/dev`；文档写明历史版本不回溯 |
+| AList 公共 CDN 缓存旧 index | 低 | 权威 readback 走 `content()`（public_url GET）；缓存过期后用户看到新 latest。不在本 issue 做 cache purge |
+| `set +e` 编写错误吞掉 compare 失败 | 中 | workflow 测试用源字符串顺序/退出结构约束；code review 对照本设计的 compare-first exit |
+| 追加 release notes 的 `gh release edit` 与并发 edit 竞态 | 低 | 同版本已被 `dev-release-${{ inputs.version }}` 串行 |
+
+## Open Questions
+
+无未决项。2026-08-24 审核结论：
+
+1. **不回溯** `v0.9.0-dev.2` / `v0.9.0-dev.3` 到 AList。AList 从下一个新的 `vX.Y.Z-dev.N` 开始。历史 GitHub prerelease 可用 `retract-dev.yml` 删除（AList no-op）。
+2. **追加** GitHub prerelease notes 中的 `MIHARI_INDEX_URL` 示例（`<!-- aio-install-dev -->`）。
+3. **共用** `MIHARI_KEEP_VERSIONS`（默认 5），不为 dev 另开 variable。
+4. **`regenerate-index.py --channel` 打进 PR 1**；默认仍是 stable，help/notice/文档锁住默认路径。
+5. **自动 mkdir** `mihari-dev`（`list_dir("/")` + 稳定兄弟 `mihari` 检查）；不要求运维在 AList UI 预创建。
+
+## References
+
+- Issue: https://github.com/mihari-proxy/mihari/issues/126
+- `#115` P1 GitHub-only prerelease：`.github/workflows/release-dev.yml`
+- 稳定 AList：`.github/workflows/release.yml`（`Publish to AList drive`）、`.github/workflows/retract.yml`
+- 策略与 writer：`scripts/release_policy.py`、`scripts/release-alist.py`、`scripts/retract-alist.py`、`scripts/alist_index.py`、`scripts/alist_client.py`
+- 守卫测试：`scripts/test_release_workflow.py`（含 `RELEASE_SAFETY_TESTS`）、`scripts/test_release_alist.py`、`scripts/test_retract_alist.py`、`scripts/test_alist_index.py`、`scripts/test_alist_client.py`（`_fs_path`）
+- 文档：`docs/RELEASE.md`、`docs/distribution.md`
+- 下载器钩子：`scripts/install/install-aio-remote.sh`、`scripts/install/install-aio-remote.ps1`（`MIHARI_INDEX_URL`）
+- 架构约束：`AGENTS.md`（daemon 单写入者、不改 `/v1`、`CGO_ENABLED=0`）
+- 可复现构建：`docs/superpowers/specs/2026-08-24-reproducible-release-inputs-design.md`
+
+## 文档更新要点（与发布/撤回接线同一 PR，否则现有测试会红）
+
+`docs/RELEASE.md`：
+
+- 触发表：`release-dev.yml` 改为「GitHub prerelease + `ALIST_URL` 存在时写入 `/mihari-release/mihari-dev`」
+- 增加 `retract-dev.yml` 行：从 `dev` dispatch，删 dev AList 与 GitHub prerelease，保留 canonical dev tag
+- 「Stable 与 Dev 发布通道」表：Dev 的 AList 根目录改为 `/mihari-release/mihari-dev`，稳定入口影响仍为「不写稳定 index / `/releases/latest`」
+- 「Dev 手动发布」：删除「不写 AList」；补充 AList 步骤、skip/fail-closed、`mihari-dev-alist`
+- 「回滚发布」：增加 Dev 撤回小节；稳定小节保持「从 `main`」
+- 保留 `v0.9.0-dev.2` 已验收的陈述，并注明当时 GitHub-only、AList 从本变更后的新版本开始
+
+`docs/distribution.md`：
+
+- 删除「尚未实现的 dev AList」「当前不创建或操作该目录」
+- 增加 dev 目录树（无安装器文件）
+- 公开 index URL
+- `MIHARI_INDEX_URL` 覆盖示例（明确默认 README 命令仍是稳定）
+- 并发：stable 用 `mihari-stable-alist`，dev 用 `mihari-dev-alist`；人工 `regenerate-index --channel ...` 前两条锁都要空闲
+- backup 恢复：dev writer backup 的 `channel=dev` 与 path `/mihari-release/mihari-dev/index.txt`；隔离失败另有 `stable-index-isolation-*`（`channel=stable` / `/mihari-release/mihari/index.txt`），不得交叉恢复
+- `regenerate-index.py` 默认 `--channel stable`，写入 `/mihari-release/mihari/index.txt`；修 dev 必须显式 `--channel dev`
+
+`CHANGELOG.md` `[Unreleased] Added`：dev 通道独立 AList index 与 retract-dev（#126）。不要把这件事写进用户默认安装说明。
+
+不要改 `README.md` / `README.zh-CN.md` 快速开始。
+
+## PR Plan
+
+每个 PR 独立可审、可合入 `dev`（经 feature 分支 PR，禁止直接提交 `dev`/`main`）。**发布接线与 retract 必须同一 PR**：`test_release_documents_record_verified_dev_github_release_and_unavailable_dev_alist` 同时锁着「不写 AList」和「不得出现 `retract-dev.yml`」，拆开会要么 CI 红、要么让 `dev` 上出现没有撤回路径的 AList writer。
+
+### PR 1 — `test: 为 dev AList 补齐通道根探测、隔离守卫与 CI 测试列表`
+
+- **Files/components：** `scripts/alist_client.py`（或共享小模块：`storage_root_entries`）、`scripts/release-alist.py`（`ensure_channel_root`，**仅** `channel == "dev"` 在 `publish()` 开头调用）、`scripts/retract-alist.py`（同一探测：有 `mihari`、无 `mihari-dev` → AList no-op；无 `mihari` → fail closed）、`scripts/alist_channel_guard.py`（新）、`scripts/regenerate-index.py`（`--channel` + help/notice）、`scripts/test_release_alist.py`、`scripts/test_retract_alist.py`、`scripts/test_alist_client.py`、`scripts/test_alist_channel_guard.py`（新）、`scripts/test_regenerate_index.py`、`scripts/test_release_workflow.py`（只改 `RELEASE_SAFETY_TESTS`）、`.github/workflows/ci.yml`（pytest 命令与 constant 同步）
+- **Dependencies：** 无
+- **Description：** 纯脚本 + 让新测试真正进入 CI。first-publish 必须在 topology-aware Fake 上对**当前** `publish()` 先红后绿。不改 `release-dev.yml` / 不建 `retract-dev.yml`，不翻转「P2 不可用」文档句。`test_publish_dev_never_uploads_root_installers` 继续通过。
+
+### PR 2 — `feat: 为 prerelease 通道接入独立 AList index 与 retract-dev`
+
+- **Files/components：** `.github/workflows/release-dev.yml`、`.github/workflows/retract-dev.yml`（新）、`scripts/test_release_workflow.py`（除 `RELEASE_SAFETY_TESTS` 以外的 YAML/文档断言）、`docs/RELEASE.md`、`docs/distribution.md`、`CHANGELOG.md`
+- **Dependencies：** PR 1
+- **Description：** GitHub 最终验收之后接 `release-alist.py --channel dev`；job 级 `mihari-dev-alist`；skip/fail-closed；mutation 内 snapshot/compare；`dev-index-backup-*` 与 `stable-index-isolation-*`；`<!-- aio-install-dev -->` notes。同一 PR 增加完整 `retract-dev.yml`（`outputs.sha`、AList-then-GitHub、保留 tag、缺失根 no-op 已在 PR 1 脚本中）。一次翻转文档与 `test_release_documents_*`：P2 发布与撤回均可用，文档必须出现 `retract-dev.yml`。不改 `release.yml` / `retract.yml`。合入前不得在生产 dispatch 启用 AList 的 `release-dev`——本 PR 合入后才允许首次真实发布。
+
+### 不在这些 PR 中出现
+
+- `scripts/install/install-aio-remote.*` 默认 URL
+- README 快速开始
+- `internal/update`、`internal/cli`、`internal/tui`、`internal/control/protocol`
+- `release.yml` 的 `mihari-stable-alist` 组
+- 自动 `push` 触发的 dev AList 发布
+- 为 `v0.9.0-dev.2/.3` 回溯写 AList

--- a/scripts/alist_channel_guard.py
+++ b/scripts/alist_channel_guard.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Snapshot and compare the stable AList index without writing AList."""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+from alist_client import connect, fail
+
+STABLE_INDEX_PATH = "/mihari-release/mihari/index.txt"
+
+
+def _require_stable_index(path):
+    if path != STABLE_INDEX_PATH:
+        fail("path is not the stable channel index")
+
+
+def snapshot(alist, path, output_dir):
+    """Read the stable index and write index.txt plus metadata.json."""
+    _require_stable_index(path)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    body = alist.content(path)
+    raw = b"" if body is None else body.encode("utf-8")
+    (output_dir / "index.txt").write_bytes(raw)
+    (output_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "channel": "stable",
+                "existed": body is not None,
+                "path": path,
+                "sha256": hashlib.sha256(raw).hexdigest(),
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def compare(alist, path, expected_dir):
+    """Fail closed if the live stable index bytes differ from the snapshot."""
+    _require_stable_index(path)
+    expected = (Path(expected_dir) / "index.txt").read_bytes()
+    live = alist.content(path)
+    live_bytes = b"" if live is None else live.encode("utf-8")
+    if live_bytes != expected:
+        fail("foreign channel index changed during this mutation")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Snapshot and compare the stable AList index."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    snapshot_parser = subparsers.add_parser("snapshot")
+    snapshot_parser.add_argument("--path", required=True)
+    snapshot_parser.add_argument("--output-dir", required=True)
+
+    compare_parser = subparsers.add_parser("compare")
+    compare_parser.add_argument("--path", required=True)
+    compare_parser.add_argument("--expected-dir", required=True)
+
+    args = parser.parse_args()
+    alist = connect()
+    if args.command == "snapshot":
+        snapshot(alist, args.path, args.output_dir)
+        return
+    compare(alist, args.path, args.expected_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/alist_channel_guard.py
+++ b/scripts/alist_channel_guard.py
@@ -15,12 +15,19 @@ def _require_stable_index(path):
         fail("path is not the stable channel index")
 
 
+def _read_stable_index(alist, path):
+    try:
+        return alist.content(path)
+    except Exception:
+        fail("unable to read the stable channel index")
+
+
 def snapshot(alist, path, output_dir):
     """Read the stable index and write index.txt plus metadata.json."""
     _require_stable_index(path)
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
-    body = alist.content(path)
+    body = _read_stable_index(alist, path)
     raw = b"" if body is None else body.encode("utf-8")
     (output_dir / "index.txt").write_bytes(raw)
     (output_dir / "metadata.json").write_text(
@@ -39,12 +46,18 @@ def snapshot(alist, path, output_dir):
 
 
 def compare(alist, path, expected_dir):
-    """Fail closed if the live stable index bytes differ from the snapshot."""
+    """Fail closed if the live stable index bytes or existence differ."""
     _require_stable_index(path)
-    expected = (Path(expected_dir) / "index.txt").read_bytes()
-    live = alist.content(path)
+    expected_dir = Path(expected_dir)
+    try:
+        expected = (expected_dir / "index.txt").read_bytes()
+        metadata = json.loads((expected_dir / "metadata.json").read_text(encoding="utf-8"))
+        existed = metadata["existed"]
+    except (OSError, KeyError, TypeError, json.JSONDecodeError, UnicodeDecodeError):
+        fail("unable to read isolation snapshot")
+    live = _read_stable_index(alist, path)
     live_bytes = b"" if live is None else live.encode("utf-8")
-    if live_bytes != expected:
+    if live_bytes != expected or (live is not None) != existed:
         fail("foreign channel index changed during this mutation")
 
 

--- a/scripts/alist_client.py
+++ b/scripts/alist_client.py
@@ -45,6 +45,19 @@ def fail(message):
     sys.exit(1)
 
 
+def storage_root_entries(alist):
+    try:
+        entries = alist.list_dir("/")
+    except Exception:
+        fail("unable to inspect release root")
+    if not isinstance(entries, list):
+        fail("unable to inspect release root")
+    mihari = [e for e in entries if isinstance(e, dict) and e.get("name") == "mihari"]
+    if len(mihari) != 1 or mihari[0].get("is_dir") is not True:
+        fail("unable to inspect release root")
+    return entries
+
+
 def info(message):
     print(f"::notice::{message}")
 

--- a/scripts/regenerate-index.py
+++ b/scripts/regenerate-index.py
@@ -22,8 +22,8 @@ import argparse
 import importlib.util
 from pathlib import Path
 
-from alist_client import DEFAULT_BASE_PATH, connect, fail, info
-from release_policy import validate_base_path
+from alist_client import connect, fail, info
+from release_policy import expected_base_path, validate_base_path
 
 
 def _load_retract():
@@ -36,31 +36,30 @@ def _load_retract():
     return module
 
 
-def regenerate_index(alist, base_path):
-    """Rebuild the fixed stable index through the shared reliable writer."""
+def regenerate_index(alist, base_path, channel="stable"):
+    """Rebuild the channel index through the shared reliable writer."""
     try:
-        validate_base_path("stable", base_path)
+        validate_base_path(channel, base_path)
     except ValueError as error:
         fail(str(error))
-
     retract = _load_retract()
     index_path = f"{base_path}/index.txt"
     previous = retract.read_index(alist, index_path)
     try:
         latest = retract.highest_complete(
-            alist, base_path, excluded=None, channel="stable"
+            alist, base_path, excluded=None, channel=channel
         )
     except retract.RemoteScanError:
-        fail("unable to inspect stable release versions")
+        fail("unable to inspect release versions")
     if latest is None:
         fail("no COMPLETE version dir found — nothing to rebuild index from")
     info(f"highest complete version: {latest}")
     try:
-        body = retract.index_body(alist, base_path, latest, "stable")
+        body = retract.index_body(alist, base_path, latest, channel)
     except retract.RemoteScanError:
-        fail("unable to verify stable release directory")
+        fail("unable to verify release directory")
     retract.write_index_reliably(
-        alist, index_path, body, previous, channel="stable"
+        alist, index_path, body, previous, channel=channel
     )
 
 
@@ -68,13 +67,22 @@ def main():
     parser = argparse.ArgumentParser(
         description="Regenerate index.txt for the current AList topology."
     )
-    parser.add_argument("--base-path", default=DEFAULT_BASE_PATH)
+    parser.add_argument(
+        "--channel",
+        choices=("stable", "dev"),
+        default="stable",
+        help="Index channel to rebuild (default: stable, writes /mihari-release/mihari/index.txt)",
+    )
+    parser.add_argument("--base-path", default=None)
     args = parser.parse_args()
-
+    channel = args.channel
+    base_path = args.base_path or expected_base_path(channel)
+    info(f"regenerating {channel} index at {base_path}/index.txt")
     alist = connect()
-    regenerate_index(alist, args.base_path)
+    regenerate_index(alist, base_path, channel)
     info("index.txt regenerated with current public_url() links")
 
 
 if __name__ == "__main__":
     main()
+

--- a/scripts/regenerate-index.py
+++ b/scripts/regenerate-index.py
@@ -76,7 +76,7 @@ def main():
     parser.add_argument("--base-path", default=None)
     args = parser.parse_args()
     channel = args.channel
-    base_path = args.base_path or expected_base_path(channel)
+    base_path = expected_base_path(channel) if args.base_path is None else args.base_path
     info(f"regenerating {channel} index at {base_path}/index.txt")
     alist = connect()
     regenerate_index(alist, base_path, channel)

--- a/scripts/release-alist.py
+++ b/scripts/release-alist.py
@@ -6,7 +6,7 @@ import os
 import re
 from pathlib import Path
 
-from alist_client import AListError, DEFAULT_BASE_PATH, DEFAULT_KEEP_VERSIONS, PLATFORMS, bundle_name, connect, fail, info, sha256_file
+from alist_client import AListError, DEFAULT_BASE_PATH, DEFAULT_KEEP_VERSIONS, PLATFORMS, bundle_name, connect, fail, info, sha256_file, storage_root_entries
 from alist_index import IndexMutationError, parse_latest, write_index_reliably as _write_index_reliably
 from release_policy import compare_versions, parse_version, validate_base_path
 
@@ -349,8 +349,22 @@ def emit_env(name, value):
             handle.write(f"{name}={value}\n")
 
 
+def ensure_channel_root(alist, base_path, channel):
+    if channel != "dev":
+        return
+    entries = storage_root_entries(alist)
+    matches = [e for e in entries if isinstance(e, dict) and e.get("name") == "mihari-dev"]
+    if not matches:
+        alist.mkdir(base_path)
+        return
+    if len(matches) != 1 or matches[0].get("is_dir") is not True:
+        fail("channel base path is not a directory")
+
+
 def publish(alist, args):
     """Publish only after a final monotonic scan immediately before index write."""
+    if args.channel == "dev":
+        ensure_channel_root(alist, args.base_path, args.channel)
     ensure_monotonic_version(alist, args.base_path, args.version, args.channel)
     version_dir = upload_version_dir(alist, args.dist_dir, args.base_path, args.version, args.commit_sha, args.channel)
     ensure_monotonic_version(alist, args.base_path, args.version, args.channel)

--- a/scripts/retract-alist.py
+++ b/scripts/retract-alist.py
@@ -171,7 +171,7 @@ def retract(alist, base_path, version, channel="stable", commit_sha=None):
         entries = storage_root_entries(alist)
         matches = [e for e in entries if isinstance(e, dict) and e.get("name") == "mihari-dev"]
         if not matches:
-            return
+            return False
         if len(matches) != 1 or matches[0].get("is_dir") is not True:
             fail("channel base path is not a directory")
     root_index = f"{base_path}/index.txt"
@@ -179,7 +179,7 @@ def retract(alist, base_path, version, channel="stable", commit_sha=None):
     if not directory_exists(alist, directory):
         if parse_latest(read_index(alist, root_index)) == version:
             fail("refusing to retract a version still referenced by the index")
-        return
+        return False
 
     try:
         identity_valid = valid_identity(alist, base_path, version, channel, commit_sha)
@@ -195,7 +195,7 @@ def retract(alist, base_path, version, channel="stable", commit_sha=None):
         remove_target(alist, base_path, version)
         if read_index(alist, root_index) != observed_index:
             fail("non-latest retraction changed the release index")
-        return
+        return True
 
     try:
         new_latest = highest_complete(alist, base_path, version, channel)
@@ -212,6 +212,7 @@ def retract(alist, base_path, version, channel="stable", commit_sha=None):
             alist, root_index, replacement_body, observed_index, channel
         )
     remove_target(alist, base_path, version)
+    return True
 
 
 def main():
@@ -221,8 +222,11 @@ def main():
     parser.add_argument("--base-path", default=DEFAULT_BASE_PATH)
     parser.add_argument("--commit-sha")
     args = parser.parse_args()
-    retract(connect(), args.base_path, args.version, args.channel, args.commit_sha)
-    info(f"retraction of {args.version} complete on the AList drive")
+    mutated = retract(connect(), args.base_path, args.version, args.channel, args.commit_sha)
+    if mutated:
+        info(f"retraction of {args.version} complete on the AList drive")
+        return
+    info(f"nothing to retract for {args.version} on the AList drive")
 
 
 if __name__ == "__main__":

--- a/scripts/retract-alist.py
+++ b/scripts/retract-alist.py
@@ -4,7 +4,7 @@ import argparse
 import hashlib
 import re
 
-from alist_client import DEFAULT_BASE_PATH, PLATFORMS, bundle_name, connect, fail, info
+from alist_client import DEFAULT_BASE_PATH, PLATFORMS, bundle_name, connect, fail, info, storage_root_entries
 from alist_index import IndexMutationError, parse_latest, write_index_reliably as _write_index_reliably
 from release_policy import parse_version, validate_base_path
 
@@ -167,6 +167,13 @@ def remove_target(alist, base_path, version):
 
 def retract(alist, base_path, version, channel="stable", commit_sha=None):
     validate_inputs(version, channel, base_path, commit_sha)
+    if channel == "dev":
+        entries = storage_root_entries(alist)
+        matches = [e for e in entries if isinstance(e, dict) and e.get("name") == "mihari-dev"]
+        if not matches:
+            return
+        if len(matches) != 1 or matches[0].get("is_dir") is not True:
+            fail("channel base path is not a directory")
     root_index = f"{base_path}/index.txt"
     directory = f"{base_path}/{version}"
     if not directory_exists(alist, directory):

--- a/scripts/test_alist_channel_guard.py
+++ b/scripts/test_alist_channel_guard.py
@@ -1,0 +1,62 @@
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+import alist_channel_guard as guard
+
+STABLE_INDEX = "/mihari-release/mihari/index.txt"
+
+
+class GuardFake:
+    def __init__(self, body=None):
+        self.body = body
+
+    def content(self, path):
+        assert path == STABLE_INDEX
+        return self.body
+
+
+def test_snapshot_missing_index_records_existed_false(tmp_path):
+    output = tmp_path / "stable-isolation"
+    guard.snapshot(GuardFake(None), STABLE_INDEX, output)
+    assert (output / "index.txt").read_bytes() == b""
+    metadata = json.loads((output / "metadata.json").read_text(encoding="utf-8"))
+    assert metadata["channel"] == "stable"
+    assert metadata["existed"] is False
+    assert metadata["path"] == STABLE_INDEX
+    assert metadata["sha256"] == hashlib.sha256(b"").hexdigest()
+
+
+def test_compare_accepts_unchanged_bytes(tmp_path):
+    output = tmp_path / "stable-isolation"
+    body = "latest v1.2.3\n"
+    guard.snapshot(GuardFake(body), STABLE_INDEX, output)
+    guard.compare(GuardFake(body), STABLE_INDEX, output)
+
+
+def test_compare_rejects_changed_index_without_logging_body(tmp_path, capsys):
+    output = tmp_path / "stable-isolation"
+    guard.snapshot(GuardFake("latest v1.2.3\n"), STABLE_INDEX, output)
+    with pytest.raises(SystemExit):
+        guard.compare(GuardFake("latest v9.0.0\n"), STABLE_INDEX, output)
+    err = capsys.readouterr().err
+    assert "foreign channel index changed during this mutation" in err
+    assert "latest " not in err
+    assert "v9.0.0" not in err
+
+
+def test_guard_rejects_non_stable_index_path(tmp_path):
+    output = tmp_path / "stable-isolation"
+    fake = GuardFake("latest v1.2.3\n")
+    for path in (
+        "/mihari-release/mihari-dev/index.txt",
+        "/mihari-release/mihari/other.txt",
+        "/mihari/index.txt",
+        "/",
+    ):
+        with pytest.raises(SystemExit):
+            guard.snapshot(fake, path, output)
+        with pytest.raises(SystemExit):
+            guard.compare(fake, path, output)

--- a/scripts/test_alist_channel_guard.py
+++ b/scripts/test_alist_channel_guard.py
@@ -36,6 +36,30 @@ def test_compare_accepts_unchanged_bytes(tmp_path):
     guard.compare(GuardFake(body), STABLE_INDEX, output)
 
 
+def test_compare_rejects_missing_versus_empty_index(tmp_path, capsys):
+    output = tmp_path / "stable-isolation"
+    guard.snapshot(GuardFake(None), STABLE_INDEX, output)
+    with pytest.raises(SystemExit):
+        guard.compare(GuardFake(""), STABLE_INDEX, output)
+    err = capsys.readouterr().err
+    assert "foreign channel index changed during this mutation" in err
+
+
+class BoomFake:
+    def content(self, path):
+        assert path == STABLE_INDEX
+        raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "bad")
+
+
+def test_snapshot_maps_read_failures_to_fail_closed(tmp_path, capsys):
+    output = tmp_path / "stable-isolation"
+    with pytest.raises(SystemExit):
+        guard.snapshot(BoomFake(), STABLE_INDEX, output)
+    err = capsys.readouterr().err
+    assert "unable to read the stable channel index" in err
+    assert "UnicodeDecodeError" not in err
+
+
 def test_compare_rejects_changed_index_without_logging_body(tmp_path, capsys):
     output = tmp_path / "stable-isolation"
     guard.snapshot(GuardFake("latest v1.2.3\n"), STABLE_INDEX, output)

--- a/scripts/test_alist_client.py
+++ b/scripts/test_alist_client.py
@@ -469,6 +469,9 @@ def test_fs_path_strips_mount_segment():
     assert alist._fs_path("/mihari-release/mihari") == "/mihari"
     # No leading segment to strip → returned unchanged (no crash on odd shapes).
     assert alist._fs_path("/mihari-release") == "/mihari-release"
+    assert alist._fs_path("/mihari-release/mihari-dev") == "/mihari-dev"
+    assert alist._fs_path("/mihari-release/mihari-dev/index.txt") == "/mihari-dev/index.txt"
+    assert alist._fs_path("/") == "/"
 
 
 def _load_release_alist():

--- a/scripts/test_alist_client.py
+++ b/scripts/test_alist_client.py
@@ -474,6 +474,31 @@ def test_fs_path_strips_mount_segment():
     assert alist._fs_path("/") == "/"
 
 
+def test_list_dir_root_sends_slash_fs_path():
+    alist = AList.__new__(AList)
+    captured = {}
+
+    class Session:
+        def post(self, url, timeout=None, json=None):
+            captured["url"] = url
+            captured["json"] = json
+            return list_response(
+                content=[{"name": "mihari", "is_dir": True}],
+                total=1,
+                page=1,
+                per_page=200,
+                has_more=False,
+                pages_total=1,
+            )
+
+    alist.base = "https://cloud.example.com"
+    alist.session = Session()
+    entries = alist.list_dir("/")
+    assert captured["url"].endswith("/api/fs/list")
+    assert captured["json"]["path"] == "/"
+    assert entries == [{"name": "mihari", "is_dir": True}]
+
+
 def _load_release_alist():
     # release-alist.py has a hyphen in its name, so import it manually.
     path = Path(__file__).with_name("release-alist.py")

--- a/scripts/test_alist_topology_fake.py
+++ b/scripts/test_alist_topology_fake.py
@@ -1,0 +1,96 @@
+"""AList fake that honors AList._fs_path and raises on missing fs directories."""
+from pathlib import Path
+
+from alist_client import AList, AListError
+
+
+class TopologyFake:
+    """In-memory AList keyed by fs paths from the real AList._fs_path."""
+
+    def __init__(self):
+        self.files = {}
+        self.dirs = {"/", "/mihari"}
+        self.ops = []
+        self.uploaded = []
+
+    def _fs(self, path):
+        return AList._fs_path(self, path)
+
+    def _record(self, op, logical):
+        fs = self._fs(logical)
+        self.ops.append((op, logical, fs))
+        return fs
+
+    def mkdir(self, path):
+        fs = self._record("mkdir", path)
+        if fs == "/":
+            raise AListError("alist write failed")
+        parent = fs.rsplit("/", 1)[0] or "/"
+        if parent not in self.dirs:
+            raise AListError("alist write failed")
+        self.dirs.add(fs)
+
+    def list_dir(self, path):
+        fs = self._record("list_dir", path)
+        if fs not in self.dirs:
+            raise AListError("invalid directory listing")
+        prefix = fs.rstrip("/") + "/"
+        names = set()
+        for item in list(self.dirs) + list(self.files):
+            if item == fs:
+                continue
+            if item.startswith(prefix):
+                names.add(item[len(prefix):].split("/", 1)[0])
+        entries = []
+        for name in names:
+            child = "/" + name if fs == "/" else prefix + name
+            entries.append({"name": name, "is_dir": child in self.dirs})
+        return entries
+
+    def exists(self, path):
+        self._record("exists", path)
+        parent, name = path.rsplit("/", 1)
+        if not name:
+            raise AListError("invalid object path")
+        try:
+            return any(entry["name"] == name for entry in self.list_dir(parent or "/"))
+        except AListError:
+            return False
+
+    def upload(self, local, remote):
+        fs = self._record("upload", remote)
+        self.files[fs] = Path(local).read_bytes()
+        self.uploaded.append(remote)
+
+    def upload_text(self, text, remote):
+        fs = self._record("upload_text", remote)
+        self.files[fs] = text.encode()
+        self.uploaded.append(remote)
+
+    def content(self, path):
+        self._record("content", path)
+        if not self.exists(path):
+            return None
+        value = self.files.get(self._fs(path))
+        return value.decode() if value is not None else None
+
+    def read_bytes(self, path, **_kwargs):
+        fs = self._record("read_bytes", path)
+        return self.files[fs]
+
+    def remove(self, base, names):
+        self._record("remove", base)
+        for name in names:
+            logical = base.rstrip("/") + "/" + name
+            fs = self._fs(logical)
+            self.files = {
+                key: value
+                for key, value in self.files.items()
+                if key != fs and not key.startswith(fs + "/")
+            }
+            self.dirs = {
+                key for key in self.dirs if key != fs and not key.startswith(fs + "/")
+            }
+
+    def public_url(self, path):
+        return "https://example.invalid" + path

--- a/scripts/test_regenerate_index.py
+++ b/scripts/test_regenerate_index.py
@@ -108,3 +108,56 @@ def test_regenerate_index_rejects_noncanonical_stable_base_path_without_mutation
         regenerate.regenerate_index(fake, "/mihari-release/other")
 
     assert fake.uploads == []
+
+
+def test_regenerate_index_rebuilds_dev_index_for_highest_complete(tmp_path, monkeypatch):
+    monkeypatch.setenv("RUNNER_TEMP", str(tmp_path))
+    fake = FakeAList()
+    base = "/mihari-release/mihari-dev"
+    add_complete(fake, base, "v1.2.3-dev.1")
+    add_complete(fake, base, "v1.2.3-dev.2")
+    regenerate.regenerate_index(fake, base, channel="dev")
+    body = fake.files[f"{base}/index.txt"].decode()
+    assert body.startswith("latest v1.2.3-dev.2\n")
+    assert len(body.splitlines()) == 1 + len(PLATFORMS)
+
+
+def test_regenerate_index_rejects_dev_channel_with_stable_path():
+    fake = FakeAList()
+    with pytest.raises(SystemExit):
+        regenerate.regenerate_index(fake, "/mihari-release/mihari", channel="dev")
+    assert fake.uploads == []
+
+
+def test_regenerate_index_help_names_stable_default_path(monkeypatch, capsys):
+    monkeypatch.setattr("sys.argv", ["regenerate-index.py", "--help"])
+    with pytest.raises(SystemExit) as exc:
+        regenerate.main()
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "stable" in out
+    assert "/mihari-release/mihari" in out
+
+
+def test_main_channel_dev_without_base_path_targets_dev_root(monkeypatch, capsys):
+    captured = {}
+
+    def fake_connect():
+        return object()
+
+    def fake_regenerate(alist, base_path, channel="stable"):
+        captured["base_path"] = base_path
+        captured["channel"] = channel
+
+    monkeypatch.setattr(regenerate, "connect", fake_connect)
+    monkeypatch.setattr(regenerate, "regenerate_index", fake_regenerate)
+    monkeypatch.setattr("sys.argv", ["regenerate-index.py", "--channel", "dev"])
+    regenerate.main()
+    assert captured == {
+        "base_path": "/mihari-release/mihari-dev",
+        "channel": "dev",
+    }
+    logged = capsys.readouterr()
+    text = logged.out + logged.err
+    assert "regenerating dev index at /mihari-release/mihari-dev/index.txt" in text
+

--- a/scripts/test_regenerate_index.py
+++ b/scripts/test_regenerate_index.py
@@ -139,6 +139,20 @@ def test_regenerate_index_help_names_stable_default_path(monkeypatch, capsys):
     assert "/mihari-release/mihari" in out
 
 
+def test_main_rejects_explicit_empty_base_path(monkeypatch, capsys):
+    fake = FakeAList()
+    monkeypatch.setattr(regenerate, "connect", lambda: fake)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["regenerate-index.py", "--channel", "dev", "--base-path", ""],
+    )
+    with pytest.raises(SystemExit):
+        regenerate.main()
+    err = capsys.readouterr().err
+    assert "invalid release base path" in err
+    assert fake.uploads == []
+
+
 def test_main_channel_dev_without_base_path_targets_dev_root(monkeypatch, capsys):
     captured = {}
 

--- a/scripts/test_release_alist.py
+++ b/scripts/test_release_alist.py
@@ -8,6 +8,7 @@ import pytest
 import requests
 
 from alist_client import AList, AListError, PLATFORMS, bundle_name
+from test_alist_topology_fake import TopologyFake
 
 
 def load_module(name):
@@ -65,6 +66,15 @@ class FakeAList:
 
     def public_url(self, path):
         return "https://example.invalid" + path
+
+
+def seed_storage_root(fake, *, has_dev_channel=True):
+    # Old Fake lists "/" by first logical/fs segment. These two fs-shaped
+    # siblings make storage_root_entries see mihari [+ mihari-dev]
+    # without preloading the forbidden logical path /mihari-release.
+    fake.dirs.add("/mihari")
+    if has_dev_channel:
+        fake.dirs.add("/mihari-dev")
 
 
 def make_dist(tmp_path):
@@ -580,12 +590,15 @@ def test_post_index_retention_list_failure_skips_safely_without_leaking_details(
         list_calls = 0
 
         def list_dir(self, path):
+            if path == "/":
+                return super().list_dir(path)
             self.list_calls += 1
             if self.list_calls > 2:
                 raise RuntimeError("https://cloud.invalid/list?token=retention-secret body")
             return super().list_dir(path)
 
     alist = LateListFailureAList()
+    seed_storage_root(alist)
     base = "/mihari-release/mihari-dev"
     args = SimpleNamespace(
         version="v1.2.3-dev.1", dist_dir=make_dist(tmp_path), repo_root=tmp_path,
@@ -600,8 +613,123 @@ def test_post_index_retention_list_failure_skips_safely_without_leaking_details(
     assert "body" not in captured.out
 
 
+def test_publish_dev_bootstraps_missing_channel_root(tmp_path):
+    alist = TopologyFake()
+    args = SimpleNamespace(
+        version="v1.2.3-dev.1",
+        dist_dir=make_dist(tmp_path),
+        repo_root=tmp_path,
+        base_path="/mihari-release/mihari-dev",
+        commit_sha="a" * 40,
+        channel="dev",
+        keep_versions=5,
+    )
+    release.publish(alist, args)
+    assert any(
+        op == "mkdir" and logical == "/mihari-release/mihari-dev" and fs == "/mihari-dev"
+        for op, logical, fs in alist.ops
+    )
+    assert not any(fs == "/mihari-release" for _, _, fs in alist.ops)
+    index = f"{args.base_path}/index.txt"
+    assert alist.content(index) is not None
+    assert "latest v1.2.3-dev.1" in alist.content(index)
+    assert index not in alist.files
+
+
+def test_ensure_channel_root_fails_closed_without_mihari_sibling(tmp_path, capsys):
+    alist = TopologyFake()
+    alist.dirs.discard("/mihari")
+    args = SimpleNamespace(
+        version="v1.2.3-dev.1",
+        dist_dir=make_dist(tmp_path),
+        repo_root=tmp_path,
+        base_path="/mihari-release/mihari-dev",
+        commit_sha="a" * 40,
+        channel="dev",
+        keep_versions=5,
+    )
+    with pytest.raises(SystemExit):
+        release.publish(alist, args)
+    captured = capsys.readouterr()
+    assert "unable to inspect release root" in captured.err
+    assert any(op == "list_dir" and logical == "/" for op, logical, _ in alist.ops)
+    assert not any(op == "mkdir" for op, _, _ in alist.ops)
+    assert not any(fs == "/mihari-release" for _, _, fs in alist.ops)
+
+
+def test_ensure_channel_root_is_noop_when_mihari_dev_already_a_directory(tmp_path):
+    alist = TopologyFake()
+    alist.dirs.add("/mihari-dev")
+    release.ensure_channel_root(alist, "/mihari-release/mihari-dev", "dev")
+    assert not any(op == "mkdir" for op, _, _ in alist.ops)
+    args = SimpleNamespace(
+        version="v1.2.3-dev.1",
+        dist_dir=make_dist(tmp_path),
+        repo_root=tmp_path,
+        base_path="/mihari-release/mihari-dev",
+        commit_sha="a" * 40,
+        channel="dev",
+        keep_versions=5,
+    )
+    release.publish(alist, args)
+    assert not any(
+        op == "mkdir" and logical == "/mihari-release/mihari-dev"
+        for op, logical, _ in alist.ops
+    )
+    assert alist.content(f"{args.base_path}/index.txt") is not None
+    assert not any(fs == "/mihari-release" for _, _, fs in alist.ops)
+
+
+def test_ensure_channel_root_fails_when_mihari_dev_is_not_a_directory(tmp_path, capsys):
+    alist = TopologyFake()
+    alist.files["/mihari-dev"] = b"not-a-directory"
+    args = SimpleNamespace(
+        version="v1.2.3-dev.1",
+        dist_dir=make_dist(tmp_path),
+        repo_root=tmp_path,
+        base_path="/mihari-release/mihari-dev",
+        commit_sha="a" * 40,
+        channel="dev",
+        keep_versions=5,
+    )
+    with pytest.raises(SystemExit):
+        release.publish(alist, args)
+    captured = capsys.readouterr()
+    assert "channel base path is not a directory" in captured.err
+    assert not any(op == "mkdir" for op, _, _ in alist.ops)
+    assert not any(fs == "/mihari-release" for _, _, fs in alist.ops)
+
+
+def test_stable_publish_does_not_list_storage_root_or_mkdir_dev(tmp_path):
+    alist = TopologyFake()
+    repo_root = tmp_path / "repo"
+    write_root_installers(repo_root)
+    args = SimpleNamespace(
+        version="v1.2.3",
+        dist_dir=make_dist(tmp_path),
+        repo_root=repo_root,
+        base_path="/mihari-release/mihari",
+        commit_sha="a" * 40,
+        channel="stable",
+        keep_versions=5,
+    )
+    release.publish(alist, args)
+    assert not any(op == "list_dir" and logical == "/" for op, logical, _ in alist.ops)
+    assert not any(op == "mkdir" and "mihari-dev" in logical for op, logical, _ in alist.ops)
+    assert not any(fs == "/mihari-release" for _, _, fs in alist.ops)
+    assert alist.content("/mihari-release/mihari/index.txt") is not None
+    assert "/mihari-release/mihari/index.txt" not in alist.files
+
+
+def test_ensure_channel_root_skips_stable_without_listing():
+    alist = TopologyFake()
+    release.ensure_channel_root(alist, "/mihari-release/mihari", "stable")
+    assert alist.ops == []
+
+
 def test_publish_dev_never_uploads_root_installers(tmp_path):
     alist = FakeAList()
+    seed_storage_root(alist)
     repo_root = tmp_path / "repo"
     write_root_installers(repo_root)
     base = "/mihari-release/mihari-dev"
@@ -625,6 +753,7 @@ def test_dev_complete_with_empty_commit_is_not_a_monotonic_baseline():
 def test_publish_rechecks_index_at_commit_point_and_preserves_newer_index(tmp_path):
     base = "/mihari-release/mihari-dev"
     alist = FakeAList()
+    seed_storage_root(alist)
     original_content = alist.content
     calls = {"index": 0}
     def content(path):

--- a/scripts/test_release_workflow.py
+++ b/scripts/test_release_workflow.py
@@ -27,7 +27,8 @@ RELEASE_SAFETY_TESTS = (
     "scripts/test_alist_index.py "
     "scripts/test_release_alist.py "
     "scripts/test_retract_alist.py "
-    "scripts/test_regenerate_index.py -q"
+    "scripts/test_regenerate_index.py "
+    "scripts/test_alist_channel_guard.py -q"
 )
 
 

--- a/scripts/test_release_workflow.py
+++ b/scripts/test_release_workflow.py
@@ -11,6 +11,7 @@ import yaml
 
 
 WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "release-dev.yml"
+RETRACT_DEV_WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "retract-dev.yml"
 STABLE_WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "release.yml"
 STABLE_RETRACT_WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "retract.yml"
 CI_WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "ci.yml"
@@ -953,14 +954,154 @@ def test_release_workflow_revalidates_tag_after_final_asset_verification():
     assert "github_release_policy.py tag-chain" in helper
 
 
-def test_release_workflow_is_github_only_and_limits_tag_peeling():
+def test_release_workflow_limits_tag_peeling():
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
-    assert "ALIST_" not in workflow
-    assert "mihari-dev" not in workflow
     assert "for depth in $(seq 1 7)" in workflow
     assert "jq -c '{type: .object.type, sha: .object.sha}'" in workflow
     assert "jq -s . /tmp/tag-chain.jsonl" in workflow
+
+
+def test_dev_publish_and_retract_use_independent_alist_lock():
+    release_dev = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    retract_dev = yaml.safe_load(RETRACT_DEV_WORKFLOW.read_text(encoding="utf-8"))
+    expected = {"group": "mihari-dev-alist", "cancel-in-progress": False}
+    assert release_dev["jobs"]["publish"].get("concurrency") == expected
+    assert retract_dev["jobs"]["retract"].get("concurrency") == expected
+    assert "mihari-stable-alist" not in WORKFLOW.read_text(encoding="utf-8")
+    assert "mihari-stable-alist" not in RETRACT_DEV_WORKFLOW.read_text(encoding="utf-8")
+    assert release_dev.get("concurrency", {}).get("group") == "dev-release-${{ inputs.version }}"
+
+
+def test_dev_alist_mutation_uses_compare_first_exit():
+    cases = (
+        (WORKFLOW, "publish", "Publish to AList drive", "release-alist.py", "publish_status"),
+        (RETRACT_DEV_WORKFLOW, "retract", "Retract from AList drive", "retract-alist.py", "retract_status"),
+    )
+    for path, job, step_name, writer, status_var in cases:
+        document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        run = _workflow_step(document, job, name=step_name)["run"]
+        assert "set +e" in run
+        assert run.index(writer) < run.index("alist_channel_guard.py compare")
+        compare_exit = 'if [ "${compare_status}" -ne 0 ]; then exit "${compare_status}"; fi'
+        assert compare_exit in run
+        assert run.index(compare_exit) < run.index(f'exit "${{{status_var}}}"')
+
+
+def test_dev_retract_peel_expected_sha_is_release_sha_not_job_sha():
+    document = yaml.safe_load(RETRACT_DEV_WORKFLOW.read_text(encoding="utf-8"))
+    peel = _workflow_step(document, "retract", name="Peel canonical tag for identity SHA")
+    run = peel["run"]
+    assert "github_release_policy.py tag-chain" in run
+    assert '--expected-sha "${RELEASE_SHA}"' in run or '--expected-sha "${tag_sha}"' in run
+    assert '--expected-sha "${SHA}"' not in run
+    mutation = _workflow_step(document, "retract", name="Retract from AList drive")
+    assert '--commit-sha "${RELEASE_SHA}"' in mutation["run"]
+    assert '--commit-sha "${SHA}"' not in mutation["run"]
+
+
+def test_dev_alist_isolation_artifacts_are_separate_from_writer_backup():
+    expected_if = (
+        "env.ALIST_CONFIGURED == 'true' && "
+        "((failure() && steps.alist_mutation.outcome == 'failure') || "
+        "(cancelled() && steps.alist_mutation.outcome == 'cancelled'))"
+    )
+    for path, job in ((WORKFLOW, "publish"), (RETRACT_DEV_WORKFLOW, "retract")):
+        document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        text = path.read_text(encoding="utf-8")
+        steps = document["jobs"][job]["steps"]
+        dev_backup = next(
+            step for step in steps
+            if str(step.get("with", {}).get("name", "")).startswith("dev-index-backup-")
+        )
+        isolation = next(
+            step for step in steps
+            if str(step.get("with", {}).get("name", "")).startswith("stable-index-isolation-")
+        )
+        assert dev_backup["if"] == expected_if
+        assert isolation["if"] == expected_if
+        assert dev_backup["with"]["path"] == "${{ runner.temp }}/mihari-index-backup/dev/**"
+        assert isolation["with"]["path"] == "${{ runner.temp }}/mihari-index-backup/stable-isolation/**"
+        assert isolation["with"]["path"] != "${{ runner.temp }}/mihari-index-backup/stable/**"
+        assert "${{ runner.temp }}/mihari-index-backup/stable/**" not in text
+
+
+def test_dev_retract_resolve_outputs_sha_and_alist_runs_before_github_delete():
+    document = yaml.safe_load(RETRACT_DEV_WORKFLOW.read_text(encoding="utf-8"))
+    resolve = document["jobs"]["resolve"]
+    retract = document["jobs"]["retract"]
+    assert resolve["outputs"]["sha"] == "${{ steps.source.outputs.sha }}"
+    assert "refs/heads/dev" in retract["if"]
+    checkout = next(step for step in retract["steps"] if step.get("uses") == "actions/checkout@v7")
+    assert checkout["with"]["ref"] == "${{ needs.resolve.outputs.sha }}"
+    names = [step.get("name") for step in retract["steps"]]
+    assert names.index("Retract from AList drive") < names.index("Delete GitHub prerelease")
+
+
+def test_dev_alist_writers_pin_channel_base_path_and_commit_sha():
+    publish = WORKFLOW.read_text(encoding="utf-8")
+    retract = RETRACT_DEV_WORKFLOW.read_text(encoding="utf-8")
+    assert "--channel dev" in publish
+    assert "--base-path /mihari-release/mihari-dev" in publish
+    assert '--commit-sha "${SHA}"' in publish
+    assert "--channel dev" in retract
+    assert "--base-path /mihari-release/mihari-dev" in retract
+
+
+def test_dev_publish_mutates_alist_after_final_github_verify():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    assert workflow.index("Final verify prerelease and stable latest") < workflow.index(
+        "Publish to AList drive"
+    )
+
+
+def test_dev_release_notes_append_index_url_with_stable_root_downloaders():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    assert "<!-- aio-install-dev -->" in workflow
+    assert "mihari-dev/index.txt" in workflow
+    assert "mihari-release/mihari/install-aio-remote.sh" in workflow
+
+
+def test_dev_retract_github_delete_is_idempotent_and_retains_canonical_tag():
+    document = yaml.safe_load(RETRACT_DEV_WORKFLOW.read_text(encoding="utf-8"))
+    delete = _workflow_step(document, "retract", name="Delete GitHub prerelease")
+    run = delete["run"]
+    assert "gh release delete" in run
+    assert "--cleanup-tag" not in run
+    assert "canonical dev tag retained" in run
+    gate = next(
+        step["run"]
+        for step in document["jobs"]["retract"]["steps"]
+        if str(step.get("name", "")).startswith("Gate")
+    )
+    assert 'echo "${VERSION}"' not in gate
+
+
+def test_alist_runtime_dependencies_are_pinned_after_checkout_in_dev_workflows():
+    release_dev = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    retract_dev = yaml.safe_load(RETRACT_DEV_WORKFLOW.read_text(encoding="utf-8"))
+    for workflow, job_name, install_step_name in (
+        (release_dev, "publish", "Publish to AList drive"),
+        (retract_dev, "retract", "Retract from AList drive"),
+    ):
+        steps = workflow["jobs"][job_name]["steps"]
+        checkout_index = next(
+            index for index, step in enumerate(steps) if step.get("uses") == "actions/checkout@v7"
+        )
+        setup_index = next(
+            index for index, step in enumerate(steps) if step.get("uses") == "actions/setup-python@v7"
+        )
+        install_index = next(
+            index for index, step in enumerate(steps) if step.get("name") == install_step_name
+        )
+        install = steps[install_index]["run"]
+        assert checkout_index < setup_index < install_index
+        assert steps[setup_index]["with"] == {"python-version": "3.12"}
+        assert (
+            "python -m pip install --disable-pip-version-check -r scripts/requirements-release.txt"
+            in install
+        )
+        assert "pip install requests" not in install
 
 
 def test_dev_version_validation_never_logs_raw_dispatch_input():
@@ -1212,18 +1353,37 @@ def test_distribution_document_limits_backup_artifacts_to_alist_mutation_failure
 def test_release_documents_record_verified_dev_github_release_and_unavailable_dev_alist():
     release = RELEASE_DOCUMENT.read_text(encoding="utf-8")
     distribution = DISTRIBUTION_DOCUMENT.read_text(encoding="utf-8")
+    repo_root = Path(__file__).resolve().parents[1]
+    installers = (
+        (repo_root / "scripts" / "install" / "install-aio-remote.sh").read_text(encoding="utf-8"),
+        (repo_root / "scripts" / "install" / "install-aio-remote.ps1").read_text(encoding="utf-8"),
+    )
+    public_dev_index = (
+        "https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari-dev/index.txt"
+    )
+    public_stable_index = (
+        "https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/index.txt"
+    )
 
     for document in (release, distribution):
         assert "v0.9.0-dev.2" in document
-        assert "dev AList 发布与 dev retract workflow" in document
+        assert "retract-dev.yml" in document
+        assert "/mihari-release/mihari-dev" in document
+        assert public_dev_index in document
+        assert "mihari-dev-alist" in document
         assert "publish-dev-alist.yml" not in document
-        assert "retract-dev.yml" not in document
 
+    assert "当前不创建或操作该目录" not in distribution
+    assert "尚未实现的 dev AList" not in distribution
     assert "Actions 产物或 dev 版本目录" not in distribution
-    assert "当前不创建或操作该目录" in distribution
+    assert "/mihari-release/mihari/index.txt" in release
+    assert "/mihari-release/mihari/index.txt" in distribution
+    assert public_stable_index in distribution
+    for installer in installers:
+        assert public_stable_index in installer
+        assert "/mihari-release/mihari-dev/" not in installer
+        assert "mihari-dev/index.txt" not in installer
 
-    assert "GitHub dev tag、prerelease 与精确 14 个 assets" in release
-    assert "不写 AList" in release
     assert "lightweight 或 annotated" in release
 
 

--- a/scripts/test_release_workflow.py
+++ b/scripts/test_release_workflow.py
@@ -973,6 +973,48 @@ def test_dev_publish_and_retract_use_independent_alist_lock():
     assert release_dev.get("concurrency", {}).get("group") == "dev-release-${{ inputs.version }}"
 
 
+def test_dev_alist_secrets_are_scoped_only_to_the_mutation_step():
+    release = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    retract = yaml.safe_load(RETRACT_DEV_WORKFLOW.read_text(encoding="utf-8"))
+    expected_secret_env = {
+        "ALIST_URL": "${{ secrets.ALIST_URL }}",
+        "ALIST_USERNAME": "${{ secrets.ALIST_USERNAME }}",
+        "ALIST_PASSWORD": "${{ secrets.ALIST_PASSWORD }}",
+    }
+    allowed_job_env = {
+        "ALIST_CONFIGURED",
+        "SHA",
+        "GH_TOKEN",
+        "DEV_RELEASE_NAME",
+        "DEV_RELEASE_BODY",
+        "MIHARI_KEEP_VERSIONS",
+    }
+
+    for workflow, job_name in ((release, "publish"), (retract, "retract")):
+        job = workflow["jobs"][job_name]
+        assert {"ALIST_CONFIGURED", "SHA"} <= set(job["env"])
+        assert set(job["env"]) <= allowed_job_env
+        assert job["env"]["ALIST_CONFIGURED"] == "${{ secrets.ALIST_URL != '' }}"
+        assert "ALIST_USERNAME" not in job["env"]["ALIST_CONFIGURED"]
+        assert "ALIST_PASSWORD" not in job["env"]["ALIST_CONFIGURED"]
+        for secret_name in expected_secret_env:
+            assert secret_name not in job["env"]
+
+        mutation = next(step for step in job["steps"] if step.get("id") == "alist_mutation")
+        assert mutation["env"] == expected_secret_env
+        assert mutation["if"] == "env.ALIST_CONFIGURED == 'true'"
+
+        for step in job["steps"]:
+            if step is mutation:
+                continue
+            step_text = str(step)
+            assert "secrets.ALIST_USERNAME" not in step_text
+            assert "secrets.ALIST_PASSWORD" not in step_text
+            if "secrets.ALIST_URL" in step_text:
+                assert "secrets.ALIST_URL != ''" in step_text
+                assert "${{ secrets.ALIST_URL }}" not in step_text
+
+
 def test_dev_alist_mutation_uses_compare_first_exit():
     cases = (
         (WORKFLOW, "publish", "Publish to AList drive", "release-alist.py", "publish_status"),
@@ -982,6 +1024,7 @@ def test_dev_alist_mutation_uses_compare_first_exit():
         document = yaml.safe_load(path.read_text(encoding="utf-8"))
         run = _workflow_step(document, job, name=step_name)["run"]
         assert "set +e" in run
+        assert run.index("alist_channel_guard.py snapshot") < run.index(writer)
         assert run.index(writer) < run.index("alist_channel_guard.py compare")
         compare_exit = 'if [ "${compare_status}" -ne 0 ]; then exit "${compare_status}"; fi'
         assert compare_exit in run
@@ -1024,6 +1067,9 @@ def test_dev_alist_isolation_artifacts_are_separate_from_writer_backup():
         assert isolation["with"]["path"] == "${{ runner.temp }}/mihari-index-backup/stable-isolation/**"
         assert isolation["with"]["path"] != "${{ runner.temp }}/mihari-index-backup/stable/**"
         assert "${{ runner.temp }}/mihari-index-backup/stable/**" not in text
+        for artifact in (dev_backup, isolation):
+            assert artifact["with"]["if-no-files-found"] == "ignore"
+            assert artifact["with"]["retention-days"] == 3
 
 
 def test_dev_retract_resolve_outputs_sha_and_alist_runs_before_github_delete():
@@ -1060,6 +1106,9 @@ def test_dev_release_notes_append_index_url_with_stable_root_downloaders():
     assert "<!-- aio-install-dev -->" in workflow
     assert "mihari-dev/index.txt" in workflow
     assert "mihari-release/mihari/install-aio-remote.sh" in workflow
+    assert "| MIHARI_INDEX_URL=" in workflow
+    assert "$env:MIHARI_INDEX_URL=" in workflow
+    assert "mihari-release/mihari/install-aio-remote.ps1" in workflow
 
 
 def test_dev_retract_github_delete_is_idempotent_and_retains_canonical_tag():
@@ -1379,6 +1428,10 @@ def test_release_documents_record_verified_dev_github_release_and_unavailable_de
     assert "/mihari-release/mihari/index.txt" in release
     assert "/mihari-release/mihari/index.txt" in distribution
     assert public_stable_index in distribution
+    assert "| MIHARI_INDEX_URL=" in distribution
+    assert "$env:MIHARI_INDEX_URL=" in distribution
+    assert "mihari-release/mihari/install-aio-remote.sh" in distribution
+    assert "mihari-release/mihari/install-aio-remote.ps1" in distribution
     for installer in installers:
         assert public_stable_index in installer
         assert "/mihari-release/mihari-dev/" not in installer

--- a/scripts/test_release_workflow.py
+++ b/scripts/test_release_workflow.py
@@ -19,6 +19,13 @@ AGENTS = Path(__file__).resolve().parents[1] / "AGENTS.md"
 CONTRIBUTING = Path(__file__).resolve().parents[1] / ".github" / "CONTRIBUTING.md"
 RELEASE_DOCUMENT = Path(__file__).resolve().parents[1] / "docs" / "RELEASE.md"
 DISTRIBUTION_DOCUMENT = Path(__file__).resolve().parents[1] / "docs" / "distribution.md"
+DESIGN_DOCUMENT = (
+    Path(__file__).resolve().parents[1]
+    / "docs"
+    / "superpowers"
+    / "specs"
+    / "2026-08-24-prerelease-alist-index-design.md"
+)
 
 RELEASE_SAFETY_TESTS = (
     "scripts/test_release_policy.py "
@@ -1118,6 +1125,11 @@ def test_dev_retract_github_delete_is_idempotent_and_retains_canonical_tag():
     assert "gh release delete" in run
     assert "--cleanup-tag" not in run
     assert "canonical dev tag retained" in run
+    assert "github_release_policy.py release" in run
+    assert "--mode preflight" in run
+    assert "<!-- github-release-dev -->" in run
+    assert 'Mihari ${VERSION} (dev)' in run
+    assert '>/dev/null' not in run
     gate = next(
         step["run"]
         for step in document["jobs"]["retract"]["steps"]
@@ -1438,6 +1450,40 @@ def test_release_documents_record_verified_dev_github_release_and_unavailable_de
         assert "mihari-dev/index.txt" not in installer
 
     assert "lightweight 或 annotated" in release
+
+
+def test_release_documents_treat_historical_dev_alist_backfill_as_operator_rule():
+    release = RELEASE_DOCUMENT.read_text(encoding="utf-8")
+    trigger = _markdown_section(release, "## 工作流触发机制")
+    dev_dispatch = _markdown_section(release, "### Dev 手动发布")
+    for section in (trigger, dev_dispatch):
+        assert "人工操作规则" in section
+        assert "不会因历史 GitHub-only 版本自动拒绝" in section
+
+
+def test_release_document_dev_retract_noop_requires_confirmed_stable_root():
+    release = _markdown_section(
+        RELEASE_DOCUMENT.read_text(encoding="utf-8"), "### Dev 撤回"
+    )
+    assert "稳定目录 `mihari`" in release
+    assert "unable to inspect release root" in release
+    assert "缺少 `mihari-dev`" in release
+
+
+def test_distribution_document_says_dev_retract_must_not_modify_stable_index():
+    retract = _markdown_section(
+        DISTRIBUTION_DOCUMENT.read_text(encoding="utf-8"), "## 五、版本撤回（致命错误）"
+    )
+    assert "不得修改" in retract
+    assert "不得触碰稳定 `index.txt`" not in retract
+
+
+def test_design_document_records_isolation_false_fail_and_logical_public_url():
+    spec = DESIGN_DOCUMENT.read_text(encoding="utf-8")
+    assert "foreign channel index changed during this mutation" in spec
+    assert "重跑" in spec
+    assert "{ALIST_URL}/p/public{path}" in spec
+    assert "{ALIST_URL}/p/public{fs_path}" not in spec
 
 
 def test_release_document_uses_main_dispatch_as_the_stable_runbook():

--- a/scripts/test_retract_alist.py
+++ b/scripts/test_retract_alist.py
@@ -3,7 +3,8 @@ from pathlib import Path
 
 import pytest
 import hashlib
-from alist_client import PLATFORMS, bundle_name
+from alist_client import AListError, PLATFORMS, bundle_name
+from test_alist_topology_fake import TopologyFake
 
 
 def load_module():
@@ -62,6 +63,15 @@ class Fake:
     def public_url(self, p): return "https://example.invalid" + p
 
 
+def seed_storage_root(fake, *, has_dev_channel=True):
+    # Old Fake lists "/" by first logical/fs segment. These two fs-shaped
+    # siblings make storage_root_entries see mihari [+ mihari-dev]
+    # without preloading the forbidden logical path /mihari-release.
+    fake.dirs.add("/mihari")
+    if has_dev_channel:
+        fake.dirs.add("/mihari-dev")
+
+
 def add_complete(fake, base, version):
     d = f"{base}/{version}"
     fake.dirs.add(d)
@@ -76,6 +86,24 @@ def add_complete(fake, base, version):
     fake.files[f"{d}/SHA256SUMS.txt"] = "".join(
         f"{sums[name]}  {name}\n" for name in sorted(sums)
     ).encode()
+
+
+def _add_topology_complete(fake, base, version):
+    directory = f"{base}/{version}"
+    fake.mkdir(directory)
+    fake.upload_text(f"{version}\n", f"{directory}/COMPLETE")
+    fake.upload_text(
+        f"version={version}\ncommit={'a' * 40}\n", f"{directory}/BUILDINFO"
+    )
+    sums = {}
+    for goos, goarch in PLATFORMS:
+        name = bundle_name(goos, goarch)
+        fake.upload_text(name, f"{directory}/{name}")
+        sums[name] = hashlib.sha256(name.encode()).hexdigest()
+    fake.upload_text(
+        "".join(f"{sums[name]}  {name}\n" for name in sorted(sums)),
+        f"{directory}/SHA256SUMS.txt",
+    )
 
 
 def root_index(base, version):
@@ -141,6 +169,7 @@ def test_retract_refuses_noncanonical_checksum_manifest_without_mutation(invalid
     sums_path = f"{base}/{version}/SHA256SUMS.txt"
     fake.files[sums_path] = invalid_manifest(fake.files[sums_path].decode()).encode()
     fake.files[f"{base}/index.txt"] = f"latest {version}\n".encode()
+    seed_storage_root(fake, has_dev_channel=True)
 
     with pytest.raises(SystemExit):
         retract_mod.retract(fake, base, version, "dev", "a" * 40)
@@ -158,6 +187,7 @@ def test_dev_retract_rebuilds_highest_remaining_complete(tmp_path, monkeypatch):
     fake.files[f"{base}/v1.0.0-dev.1/BUILDINFO"] = b"version=v1.0.0-dev.1\ncommit=" + b"a" * 40 + b"\n"
     fake.files[f"{base}/v1.1.0-dev.1/BUILDINFO"] = b"version=v1.1.0-dev.1\ncommit=" + b"a" * 40 + b"\n"
     fake.files[f"{base}/index.txt"] = b"latest v1.1.0-dev.1\n"
+    seed_storage_root(fake, has_dev_channel=True)
     retract_mod.retract(fake, base, "v1.1.0-dev.1", "dev", "a" * 40)
     assert fake.files[f"{base}/index.txt"].startswith(b"latest v1.0.0-dev.1\n")
 
@@ -172,6 +202,7 @@ def test_dev_retract_refuses_mismatched_identity(tmp_path, monkeypatch):
     fake = Fake()
     base = "/mihari-release/mihari-dev"
     add_complete(fake, base, "v1.1.0-dev.1")
+    seed_storage_root(fake, has_dev_channel=True)
     with pytest.raises(SystemExit):
         retract_mod.retract(fake, base, "v1.1.0-dev.1", "dev", "b" * 40)
     assert fake.exists(f"{base}/v1.1.0-dev.1")
@@ -180,11 +211,13 @@ def test_dev_retract_refuses_mismatched_identity(tmp_path, monkeypatch):
 def test_retract_missing_dev_directory_is_idempotent(tmp_path, monkeypatch):
     monkeypatch.setenv("RUNNER_TEMP", str(tmp_path))
     fake = Fake()
+    seed_storage_root(fake, has_dev_channel=True)
     retract_mod.retract(fake, "/mihari-release/mihari-dev", "v1.1.0-dev.1", "dev", "a" * 40)
 
     assert fake.files == {}
-    assert fake.dirs == set()
     assert mutations(fake) == []
+    assert "/mihari" in fake.dirs
+    assert "/mihari-dev" in fake.dirs
 
 
 def test_latest_retraction_switches_verified_index_before_removing_target(tmp_path, monkeypatch):
@@ -197,6 +230,7 @@ def test_latest_retraction_switches_verified_index_before_removing_target(tmp_pa
     add_complete(fake, base, replacement)
     path, previous = root_index(base, target)
     fake.files[path] = previous.encode()
+    seed_storage_root(fake, has_dev_channel=True)
 
     retract_mod.retract(fake, base, target, "dev", "a" * 40)
 
@@ -216,6 +250,7 @@ def test_latest_retraction_keeps_target_when_index_commit_fails(tmp_path, monkey
     add_complete(fake, base, "v1.0.0-dev.1")
     path, previous = root_index(base, target)
     fake.files[path] = previous.encode()
+    seed_storage_root(fake, has_dev_channel=True)
 
     def fail_index_write(text, remote):
         fake.calls.append(("upload", remote, text))
@@ -243,6 +278,7 @@ def test_remove_failure_after_index_commit_preserves_new_index_and_rerun_removes
     path, _ = root_index(base, target)
     fake.files[path] = f"latest {target}\n".encode()
     fake.fail_target_remove = True
+    seed_storage_root(fake, has_dev_channel=True)
 
     with pytest.raises(SystemExit):
         retract_mod.retract(fake, base, target, "dev", "a" * 40)
@@ -270,6 +306,7 @@ def test_last_latest_retraction_commits_empty_index_before_removing_target(tmp_p
     add_complete(fake, base, target)
     path, _ = root_index(base, target)
     fake.files[path] = f"latest {target}\n".encode()
+    seed_storage_root(fake, has_dev_channel=True)
 
     retract_mod.retract(fake, base, target, "dev", "a" * 40)
 
@@ -290,6 +327,7 @@ def test_latest_retraction_aborts_when_remaining_candidate_cannot_be_read(
     path, previous = root_index(base, target)
     fake.files[path] = previous.encode()
     remaining_buildinfo = f"{base}/{remaining}/BUILDINFO"
+    seed_storage_root(fake, has_dev_channel=True)
     original_content = fake.content
 
     def content(remote):
@@ -322,7 +360,11 @@ def test_latest_retraction_aborts_on_malformed_directory_listing(
     add_complete(fake, base, target)
     path, previous = root_index(base, target)
     fake.files[path] = previous.encode()
-    fake.list_dir = lambda _path: [{"name": 123, "is_dir": True}]
+    seed_storage_root(fake, has_dev_channel=True)
+    original = fake.list_dir
+    fake.list_dir = (
+        lambda path: original(path) if path == "/" else [{"name": 123, "is_dir": True}]
+    )
 
     with pytest.raises(SystemExit):
         retract_mod.retract(fake, base, target, "dev", "a" * 40)
@@ -343,6 +385,7 @@ def test_non_latest_retraction_leaves_index_bytes_unchanged(tmp_path, monkeypatc
     path = f"{base}/index.txt"
     original = f"latest {latest}\nlinux-amd64 https://example.invalid/a deadbeef\n".encode()
     fake.files[path] = original
+    seed_storage_root(fake, has_dev_channel=True)
 
     retract_mod.retract(fake, base, target, "dev", "a" * 40)
 
@@ -359,6 +402,7 @@ def test_non_latest_retraction_fails_closed_when_index_changes_concurrently(tmp_
     path = f"{base}/index.txt"
     fake.files[path] = b"latest v1.1.0-dev.1\n"
     fake.index_reads = ["latest v1.1.0-dev.1\n", "latest v9.0.0-dev.1\n"]
+    seed_storage_root(fake, has_dev_channel=True)
 
     with pytest.raises(SystemExit):
         retract_mod.retract(fake, base, target, "dev", "a" * 40)
@@ -374,6 +418,7 @@ def test_missing_target_referenced_by_index_fails_closed(tmp_path, monkeypatch):
     target = "v1.1.0-dev.1"
     path, previous = root_index(base, target)
     fake.files[path] = previous.encode()
+    seed_storage_root(fake, has_dev_channel=True)
 
     with pytest.raises(SystemExit):
         retract_mod.retract(fake, base, target, "dev", "a" * 40)
@@ -388,8 +433,59 @@ def test_missing_target_not_referenced_by_index_is_idempotent(tmp_path, monkeypa
     target = "v1.1.0-dev.1"
     path = f"{base}/index.txt"
     fake.files[path] = b"latest v1.2.0-dev.1\n"
+    seed_storage_root(fake, has_dev_channel=True)
 
     retract_mod.retract(fake, base, target, "dev", "a" * 40)
 
     assert fake.files[path] == b"latest v1.2.0-dev.1\n"
     assert mutations(fake) == []
+
+
+def test_dev_retract_noops_when_storage_root_has_mihari_but_no_dev_channel():
+    fake = TopologyFake()
+    retract_mod.retract(fake, "/mihari-release/mihari-dev", "v1.0.0-dev.1", "dev", "a" * 40)
+    assert not any(
+        op in {"remove", "upload", "upload_text", "mkdir"} for op, _, _ in fake.ops
+    )
+    assert fake.files == {}
+    assert fake.dirs == {"/", "/mihari"}
+    assert not any(fs == "/mihari-release" for _, _, fs in fake.ops)
+
+
+def test_dev_retract_fails_closed_when_storage_root_lacks_mihari():
+    fake = TopologyFake()
+    fake.dirs.discard("/mihari")
+    with pytest.raises(SystemExit):
+        retract_mod.retract(fake, "/mihari-release/mihari-dev", "v1.0.0-dev.1", "dev", "a" * 40)
+    assert not any(op in {"remove", "upload", "upload_text", "mkdir"} for op, _, _ in fake.ops)
+
+
+def test_dev_retract_fails_closed_when_storage_root_list_raises():
+    fake = TopologyFake()
+    original = fake.list_dir
+
+    def list_dir(path):
+        if path == "/":
+            raise AListError("invalid directory listing")
+        return original(path)
+
+    fake.list_dir = list_dir
+    with pytest.raises(SystemExit):
+        retract_mod.retract(fake, "/mihari-release/mihari-dev", "v1.0.0-dev.1", "dev", "a" * 40)
+    assert not any(op in {"remove", "upload", "upload_text"} for op, _, _ in fake.ops)
+
+
+def test_dev_retract_uses_existing_logic_when_channel_root_exists(tmp_path, monkeypatch):
+    monkeypatch.setenv("RUNNER_TEMP", str(tmp_path))
+    fake = TopologyFake()
+    fake.dirs.add("/mihari-dev")
+    _add_topology_complete(fake, "/mihari-release/mihari-dev", "v1.0.0-dev.1")
+    _add_topology_complete(fake, "/mihari-release/mihari-dev", "v1.1.0-dev.1")
+    fake.upload_text("latest v1.1.0-dev.1\n", "/mihari-release/mihari-dev/index.txt")
+    retract_mod.retract(
+        fake, "/mihari-release/mihari-dev", "v1.1.0-dev.1", "dev", "a" * 40
+    )
+    body = fake.content("/mihari-release/mihari-dev/index.txt")
+    assert body is not None and body.startswith("latest v1.0.0-dev.1\n")
+    assert not fake.exists("/mihari-release/mihari-dev/v1.1.0-dev.1")
+    assert not any(fs == "/mihari-release" for _, _, fs in fake.ops)

--- a/scripts/test_retract_alist.py
+++ b/scripts/test_retract_alist.py
@@ -441,6 +441,29 @@ def test_missing_target_not_referenced_by_index_is_idempotent(tmp_path, monkeypa
     assert mutations(fake) == []
 
 
+def test_main_reports_noop_when_dev_channel_root_is_missing(monkeypatch, capsys):
+    fake = TopologyFake()
+    monkeypatch.setattr(retract_mod, "connect", lambda: fake)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "retract-alist.py",
+            "--version",
+            "v1.0.0-dev.1",
+            "--channel",
+            "dev",
+            "--base-path",
+            "/mihari-release/mihari-dev",
+            "--commit-sha",
+            "a" * 40,
+        ],
+    )
+    retract_mod.main()
+    text = capsys.readouterr().out
+    assert "nothing to retract" in text
+    assert "complete on the AList drive" not in text
+
+
 def test_dev_retract_noops_when_storage_root_has_mihari_but_no_dev_channel():
     fake = TopologyFake()
     retract_mod.retract(fake, "/mihari-release/mihari-dev", "v1.0.0-dev.1", "dev", "a" * 40)


### PR DESCRIPTION
## 变更内容

为 prerelease 通道增加**独立** AList index，方便后续安装脚本走 `MIHARI_INDEX_URL` 覆盖，而不污染稳定 `latest`。

- `release-dev.yml` 在 GitHub prerelease 最终验收成功后，条件化写入 `/mihari-release/mihari-dev`
- 新增 `retract-dev.yml`：先改 dev AList，再删 GitHub prerelease，保留 canonical tag
- 稳定 `/mihari-release/mihari/index.txt`、`/releases/latest`、README 默认安装命令均不改
- `v0.9.0-dev.2` / `.3` 不回溯；AList 从下一个新的 `vX.Y.Z-dev.N` 开始

## 类型

- [x] feat: 新功能
- [ ] fix: Bug 修复
- [ ] refactor: 重构
- [ ] docs: 文档
- [x] test: 测试
- [ ] chore: 构建/工具

## 检查清单

- [x] 发版安全套件 pytest 通过（279 passed）
- [ ] CI `go test` / `go test -race` / `go vet` / `gofmt`（本 PR 未改 Go 源码，等待 Actions）
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] 未修改 `internal/control/protocol`、CLI 退出码或跨平台生产行为

## 相关 Issues

Closes #126

Related: #115（P2）、#125（消费侧通道，本 PR 不实现）

## 其他

公开契约：

```
https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari-dev/index.txt
```

墙内装 pre 需显式覆盖 index（env 必须作用在安装器进程上）：

```bash
curl -fsSL https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.sh | MIHARI_INDEX_URL=https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari-dev/index.txt bash
```

首次真实 `release-dev` 应使用**新的** `vX.Y.Z-dev.N`，不要复用 `-dev.2/.3`。本 PR 不 dispatch 真实 AList。

设计与实施计划：

- `docs/superpowers/specs/2026-08-24-prerelease-alist-index-design.md`
- `docs/superpowers/plans/2026-08-24-prerelease-alist-index.md`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mihari-proxy/mihari/pull/128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

