### PR TITLE
fix: 将 AList 缺失目录视为不存在而不是检查失败

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - 兼容当前 AList `/api/fs/list` 不再返回分页字段的响应，避免发版脚本拒绝合法目录 listing。
+- 把 AList 对缺失目录返回的 `object not found` 视为不存在，而不是发版检查失败。
 
 ## [v0.9.0] - 2026-08-24
 

--- a/scripts/alist_client.py
+++ b/scripts/alist_client.py
@@ -120,6 +120,7 @@ class AList:
         while True:
             data = self._post(
                 "/api/fs/list",
+                allowed_codes=(200, 500),
                 json={
                     "path": self._fs_path(path),
                     "password": "",
@@ -128,6 +129,18 @@ class AList:
                     "refresh": False,
                 },
             )
+            if data.get("code") == 500:
+                message = data.get("message")
+                missing = (
+                    page == 1
+                    and not entries
+                    and data.get("data") is None
+                    and isinstance(message, str)
+                    and "object not found" in message.lower()
+                )
+                if not missing:
+                    raise AListError("alist operation failed")
+                return []
             payload = data.get("data")
             if not isinstance(payload, dict) or "content" not in payload:
                 raise AListError("invalid directory listing")

--- a/scripts/test_alist_client.py
+++ b/scripts/test_alist_client.py
@@ -210,6 +210,43 @@ def test_exists_and_content_use_parent_listing_when_fs_get_reports_missing_as_50
     assert all(not url.endswith("/api/fs/get") for url in alist.session.paths)
 
 
+def test_exists_treats_missing_parent_directory_as_absent():
+    alist = AList.__new__(AList)
+    alist.base = "https://cloud.invalid"
+    alist.session = PostSession(
+        JSONResponse(
+            {
+                "code": 500,
+                "message": "failed get dir: object not found token=secret",
+                "data": None,
+            }
+        )
+    )
+
+    path = "/mihari-release/mihari-dev/v0.9.0-dev.5/COMPLETE"
+    assert alist.exists(path) is False
+    assert alist.content(path) is None
+
+
+def test_list_dir_rejects_non_missing_500_listing_without_leaking_details():
+    alist = AList.__new__(AList)
+    alist.base = "https://cloud.invalid"
+    alist.session = PostSession(
+        JSONResponse(
+            {
+                "code": 500,
+                "message": "internal backend token=secret",
+                "data": {"content": []},
+            }
+        )
+    )
+
+    with pytest.raises(alist_client.AListError, match="alist operation failed") as error:
+        alist.list_dir("/mihari-release/mihari-dev/v0.9.0-dev.5")
+    assert "secret" not in str(error.value)
+    assert "internal backend" not in str(error.value)
+
+
 def test_list_dir_reads_every_page_and_preserves_second_page_entries():
     first = [{"name": f"v1.0.{index}", "is_dir": True} for index in range(200)]
     highest = {"name": "v9.0.0", "is_dir": True}


### PR DESCRIPTION
## Summary
- 空的 `/mihari-release/mihari-dev` 是预期状态：`ensure_channel_root` 已 mkdir，版本目录还没上传。
- 首次写入会 `exists(.../vX.Y.Z-dev.N/COMPLETE)`，从而 `list_dir` 那个还不存在的版本目录。当前 AList 对缺失目录返回 HTTP 200 + JSON `code=500` + `object not found`，脚本把它当成检查失败（`unable to inspect existing release directory`）。
- `list_dir` 对这种缺失目录返回空列表，`exists()` 即为 False；其它 `500` 仍 fail closed，且不把远端 message 打进错误。

## Test Plan
- [x] `python -m pytest scripts/test_alist_client.py scripts/test_release_alist.py scripts/test_retract_alist.py scripts/test_alist_channel_guard.py -q`（126 passed）
- [x] 现网登录后 `exists(/mihari-release/mihari-dev/v0.9.0-dev.5/COMPLETE)` 为 False
- [ ] CI 绿
- [ ] 合入 `dev` 后重跑 `release-dev` `v0.9.0-dev.5`（GitHub 14 assets 已在，走 checksum preflight 再写 AList）

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mihari-proxy/mihari/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

