### PR TITLE
feat(ci): add PR source check for main branch

### DIFF
--- a/.github/workflows/pr-source-check.yml
+++ b/.github/workflows/pr-source-check.yml
@@ -1,0 +1,21 @@
+name: PR Source Check
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-source:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR source branch
+        if: github.head_ref != 'dev' && !startsWith(github.head_ref, 'hotfix/')
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          echo "::error::PR to main must come from 'dev' or 'hotfix/*' branches."
+          echo "Current source branch: $HEAD_REF"
+          exit 1


### PR DESCRIPTION
## 目的

限制 main 分支只能接受来自 `dev` 或 `hotfix/*` 分支的 PR。

## 变更

添加 GitHub Action workflow：
- 监听目标分支为 `main` 的 PR
- 检查 PR 的源分支是否为 `dev` 或 `hotfix/*`
- 如果不是，CI 检查失败，阻止合并

## 工作流

```
feature/xxx --squash PR--> dev --merge PR--> main
hotfix/*    ---------------merge PR-------> main
```

## 关联

配合今天修改的分支保护规则：
- dev: 只允许 squash merge
- main: 只允许 merge commit



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mihari-proxy/mihari/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

