### PR TITLE
fix: 修复 PowerShell 5.1 解析 GitHub Releases JSON

### DIFF
--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -114,7 +114,14 @@ function Resolve-DevTag {
       if ($resp) { $resp.Close() }
     }
     $releases = @()
-    try { $releases = @($body | ConvertFrom-Json) } catch { $releases = @() }
+    try {
+      # PS 5.1 flattens a top-level JSON array into one object. Wrapping
+      # preserves per-release tag_name / draft on nested GitHub payloads.
+      $parsed = ConvertFrom-Json -InputObject ('{"items":' + $body + '}')
+      if ($null -ne $parsed.items) { $releases = @($parsed.items) }
+    } catch {
+      try { $releases = @($body | ConvertFrom-Json) } catch { $releases = @() }
+    }
     foreach ($rel in $releases) {
       if ($rel.draft) { continue }
       $tag = [string]$rel.tag_name
@@ -124,12 +131,13 @@ function Resolve-DevTag {
       if (-not $best -or (Compare-Canonical $tag $best) -gt 0) { $best = $tag }
     }
     if (-not $best) {
-      foreach ($obj in [regex]::Matches([string]$body, '\{[^{}]*\}')) {
-        $chunk = $obj.Value
-        if ($chunk -match '"draft"\s*:\s*true') { continue }
-        $tagMatch = [regex]::Match($chunk, '"tag_name"\s*:\s*"([^"]*)"')
-        if (-not $tagMatch.Success) { continue }
-        $tag = $tagMatch.Groups[1].Value
+      $tagHits = [regex]::Matches([string]$body, '"tag_name"\s*:\s*"([^"]*)"')
+      for ($i = 0; $i -lt $tagHits.Count; $i++) {
+        $tag = $tagHits[$i].Groups[1].Value
+        $start = $tagHits[$i].Index
+        $end = if ($i + 1 -lt $tagHits.Count) { $tagHits[$i + 1].Index } else { $body.Length }
+        $slice = $body.Substring($start, $end - $start)
+        if ($slice -match '"draft"\s*:\s*true') { continue }
         if (-not (Test-CanonicalDev $tag)) { continue }
         if (-not $best -or (Compare-Canonical $tag $best) -gt 0) { $best = $tag }
       }

--- a/scripts/install/test_install_channel.py
+++ b/scripts/install/test_install_channel.py
@@ -21,6 +21,22 @@ COMPACT_RELEASES = (
     '{"tag_name":"v0.9.0-dev"},{"tag_name":"v0.9.0-dev.1","draft":true},'
     f'{{"tag_name":"{CANONICAL_DEV}"}}]'
 )
+# GitHub list JSON nests author/assets objects. PS 5.1 ConvertFrom-Json flattens
+# arrays, and a \{[^{}]*\} fallback only matches those inner objects.
+NESTED_GITHUB_RELEASES = json.dumps(
+    [
+        {"tag_name": "v0.8.0-dev.99", "draft": False, "assets": [{"name": "x"}]},
+        {"tag_name": "v0.9.0", "draft": False, "author": {"login": "bot"}},
+        {"tag_name": "v0.9.0-dev", "draft": False},
+        {"tag_name": "v0.9.0-dev.1", "draft": True, "assets": [{"name": "y"}]},
+        {
+            "tag_name": CANONICAL_DEV,
+            "draft": False,
+            "assets": [{"name": "mihari-windows-amd64.exe", "id": 1}],
+        },
+    ],
+    separators=(",", ":"),
+)
 
 
 def posix_shell() -> str | None:
@@ -337,6 +353,16 @@ def test_script1_ps1_channel_args_and_env(tmp_path: Path, github_server: GitHubL
     got = parse_test_output(colon.stdout)
     assert got.get("CHANNEL") == "main"
     assert "/releases/latest/download/" in got.get("URL", "")
+
+
+@requires_ps
+def test_script1_ps1_nested_github_json_picks_canonical_dev(tmp_path: Path, github_server: GitHubListServer):
+    github_server.default_body = NESTED_GITHUB_RELEASES.encode()
+    api = f"http://127.0.0.1:{github_server.server_address[1]}"
+    result = run_install_ps1(tmp_path, ["-Channel", "dev"], {"MIHARI_GITHUB_API": api})
+    assert result.returncode == 0, result.stderr + result.stdout
+    got = parse_test_output(result.stdout)
+    assert f"/releases/download/{CANONICAL_DEV}/mihari-windows-" in got.get("URL", "")
 
 
 @requires_ps


### PR DESCRIPTION
## Summary
Windows ``install.ps1`` ``Resolve-DevTag`` 在 PowerShell 5.1 下无法从真实 GitHub Releases 列表里选出 canonical ``vX.Y.Z-dev.N``，表现为 ``no canonical mihari dev release``。

PS 5.1 会把顶层 JSON 数组压成一个对象；GitHub 列表项又带嵌套 ``assets``/``author``。此前用 ``\{[^{}]*\}`` 的 draft 回退只能匹配到内层对象，选不到 ``tag_name``。

## Fix
- 把响应包成 ``{"items": ...}`` 再 ``ConvertFrom-Json``，保留每个 release 的 ``tag_name`` / ``draft``
- 正则回退改为按 ``tag_name`` 切片，并跳过 ``draft: true``
- 测试使用带嵌套 assets/author 的 GitHub 形 JSON

## Workaround until merge
```powershell
$env:MIHARI_VERSION = 'v0.9.0-dev.8'
$env:MIHARI_CHANNEL = 'dev'
irm https://raw.githubusercontent.com/mihari-proxy/mihari/dev/scripts/install/install.ps1 | iex
```
或改用 AList：
```powershell
& ([scriptblock]::Create((irm https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.ps1))) -Channel dev
```

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mihari-proxy/mihari/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

