### PR TITLE
fix: 切回 main 时 prerelease 不再误判为 ahead

### DIFF
--- a/internal/tui/pages/system/model_test.go
+++ b/internal/tui/pages/system/model_test.go
@@ -1799,17 +1799,17 @@ func TestSystemMihariVersionCheckRendersAvailable(t *testing.T) {
 
 func TestSystemMihariUpdateRendersAheadState(t *testing.T) {
 	model := New(nil, nil)
-	model.SetSelfUpdater(&fakeSelfUpdater{}, "v0.9.0-dev.3", "mihari", func() bool { return true })
+	model.SetSelfUpdater(&fakeSelfUpdater{}, "v0.9.0", "mihari", func() bool { return true })
 	model.selfCheckGeneration = 3
 	updated, _ := model.Update(selfCheckResultMsg{
 		generation: 3,
 		result: update.CheckResult{
-			Current: "v0.9.0-dev.3", Latest: "v0.8.2", Available: false, Ahead: true, Channel: update.ChannelMain,
+			Current: "v0.9.0", Latest: "v0.8.2", Available: false, Ahead: true, Channel: update.ChannelMain,
 		},
 	})
 	model = updated.(*Model)
 	view := model.View()
-	want := "v0.9.0-dev.3 · " + fmt.Sprintf(ui.UpdateMihariAhead, update.ChannelMain, "v0.8.2")
+	want := "v0.9.0 · " + fmt.Sprintf(ui.UpdateMihariAhead, update.ChannelMain, "v0.8.2")
 	if !strings.Contains(view, want) {
 		t.Fatalf("ahead view missing %q:\n%s", want, view)
 	}
@@ -1820,12 +1820,12 @@ func TestSystemMihariUpdateRendersAheadState(t *testing.T) {
 
 func TestSystemMihariAheadEnterDoesNotOfferUpdate(t *testing.T) {
 	model := New(nil, nil)
-	model.SetSelfUpdater(&fakeSelfUpdater{}, "v0.9.0-dev.3", "mihari", func() bool { return true })
+	model.SetSelfUpdater(&fakeSelfUpdater{}, "v0.9.0", "mihari", func() bool { return true })
 	model.selfCheckGeneration = 3
 	updated, _ := model.Update(selfCheckResultMsg{
 		generation: 3,
 		result: update.CheckResult{
-			Current: "v0.9.0-dev.3", Latest: "v0.8.2", Available: false, Ahead: true, Channel: update.ChannelMain,
+			Current: "v0.9.0", Latest: "v0.8.2", Available: false, Ahead: true, Channel: update.ChannelMain,
 		},
 	})
 	model = updated.(*Model)
@@ -1842,15 +1842,44 @@ func TestSystemMihariAheadEnterDoesNotOfferUpdate(t *testing.T) {
 
 func TestSystemMihariSkipUpdateKeepsAhead(t *testing.T) {
 	model := New(nil, nil)
-	model.SetSelfUpdater(&fakeSelfUpdater{}, "v0.9.0-dev.3", "mihari", func() bool { return true })
+	model.SetSelfUpdater(&fakeSelfUpdater{}, "v0.9.0", "mihari", func() bool { return true })
 	updated, _ := model.Update(selfUpdateResultMsg{
 		result: update.Result{Version: "v0.8.2", Updated: false, Ahead: true, Channel: update.ChannelMain},
 	})
 	model = updated.(*Model)
 	view := model.View()
-	want := "v0.9.0-dev.3 · " + fmt.Sprintf(ui.UpdateMihariAhead, update.ChannelMain, "v0.8.2")
+	want := "v0.9.0 · " + fmt.Sprintf(ui.UpdateMihariAhead, update.ChannelMain, "v0.8.2")
 	if !strings.Contains(view, want) {
 		t.Fatalf("skip ahead view missing %q:\n%s", want, view)
+	}
+}
+
+func TestSystemMihariPrereleaseOnMainOffersOfficialUpdate(t *testing.T) {
+	model := New(nil, nil)
+	model.SetSelfUpdater(&fakeSelfUpdater{}, "v0.9.0-dev.8", "mihari", func() bool { return true })
+	model.selfCheckGeneration = 3
+	updated, _ := model.Update(selfCheckResultMsg{
+		generation: 3,
+		result: update.CheckResult{
+			Current: "v0.9.0-dev.8", Latest: "v0.8.2", Available: true, Ahead: false, Channel: update.ChannelMain,
+		},
+	})
+	model = updated.(*Model)
+	view := model.View()
+	if !strings.Contains(view, "v0.9.0-dev.8 · v0.8.2 "+ui.UpdateMihariAvailable) {
+		t.Fatalf("available view:\n%s", view)
+	}
+	if strings.Contains(view, fmt.Sprintf(ui.UpdateMihariAhead, update.ChannelMain, "v0.8.2")) {
+		t.Fatalf("prerelease on main must not render ahead:\n%s", view)
+	}
+	model.focusID = rowMihariUpdate
+	_, command := model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if command == nil {
+		t.Fatal("available prerelease did not offer confirmation")
+	}
+	intent, ok := command().(ui.ActionIntentMsg)
+	if !ok || intent.Action != ui.ActionUpdateMihari || !strings.Contains(intent.Object, "v0.9.0-dev.8") || !strings.Contains(intent.Object, "v0.8.2") {
+		t.Fatalf("intent=%#v", intent)
 	}
 }
 

--- a/internal/tui/pages/system/model_test.go
+++ b/internal/tui/pages/system/model_test.go
@@ -1883,6 +1883,35 @@ func TestSystemMihariPrereleaseOnMainOffersOfficialUpdate(t *testing.T) {
 	}
 }
 
+func TestSystemMihariOfficialOnDevOffersPrereleaseUpdate(t *testing.T) {
+	model := New(nil, nil)
+	model.SetSelfUpdater(&fakeSelfUpdater{}, "v0.8.2", "mihari", func() bool { return true })
+	model.selfCheckGeneration = 3
+	updated, _ := model.Update(selfCheckResultMsg{
+		generation: 3,
+		result: update.CheckResult{
+			Current: "v0.8.2", Latest: "v0.9.0-dev.8", Available: true, Ahead: false, Channel: update.ChannelDev,
+		},
+	})
+	model = updated.(*Model)
+	view := model.View()
+	if !strings.Contains(view, "v0.8.2 · v0.9.0-dev.8 "+ui.UpdateMihariAvailable) {
+		t.Fatalf("available view:\n%s", view)
+	}
+	if strings.Contains(view, fmt.Sprintf(ui.UpdateMihariAhead, update.ChannelDev, "v0.9.0-dev.8")) {
+		t.Fatalf("official on dev must not render ahead:\n%s", view)
+	}
+	model.focusID = rowMihariUpdate
+	_, command := model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if command == nil {
+		t.Fatal("available official did not offer confirmation")
+	}
+	intent, ok := command().(ui.ActionIntentMsg)
+	if !ok || intent.Action != ui.ActionUpdateMihari || !strings.Contains(intent.Object, "v0.8.2") || !strings.Contains(intent.Object, "v0.9.0-dev.8") {
+		t.Fatalf("intent=%#v", intent)
+	}
+}
+
 func TestSystemMihariVersionCheckRendersUpToDate(t *testing.T) {
 	model := New(nil, nil)
 	model.SetSelfUpdater(&fakeSelfUpdater{}, "v0.3.1", "mihari", func() bool { return true })
@@ -2718,6 +2747,38 @@ func TestSystemMihariChannelEnterConfirmsSwitchWithoutElevation(t *testing.T) {
 	}
 	runSelfCheckCmd(t, checkCmd)
 	if updater.checkCalls != 1 || updater.lastChannel != update.ChannelDev {
+		t.Fatalf("checkCalls=%d lastChannel=%q", updater.checkCalls, updater.lastChannel)
+	}
+}
+
+func TestSystemMihariChannelEnterSwitchesDevToMain(t *testing.T) {
+	model, updater, saved := mihariChannelModel(t, update.ChannelDev)
+	model.SetSelfUpdater(updater, "v0.9.0-dev.8", "mihari", func() bool { return false })
+	model.focusID = rowMihariChannel
+	_, command := model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if command == nil {
+		t.Fatal("expected confirmation")
+	}
+	intent, ok := command().(ui.ActionIntentMsg)
+	if !ok || intent.Action != ui.ActionSwitchMihariChannel || intent.Execute == nil || intent.Capability != "" {
+		t.Fatalf("intent=%#v", intent)
+	}
+	if intent.Title != ui.SwitchMihariChannelTitle+" to "+update.ChannelMain {
+		t.Fatalf("title=%q", intent.Title)
+	}
+	if intent.Impact != ui.SwitchMihariChannelToMainImpact || intent.Rollback != ui.SwitchMihariChannelRollback {
+		t.Fatalf("copy=%#v", intent)
+	}
+
+	updated, _ := model.Update(ui.ActionPendingMsg{Page: ui.PageSystem, Action: ui.ActionSwitchMihariChannel})
+	model = updated.(*Model)
+	result := intent.Execute()
+	_, checkCmd := model.Update(result)
+	if saved.channel != update.ChannelMain {
+		t.Fatalf("saved=%q", saved.channel)
+	}
+	runSelfCheckCmd(t, checkCmd)
+	if updater.checkCalls != 1 || updater.lastChannel != update.ChannelMain {
 		t.Fatalf("checkCalls=%d lastChannel=%q", updater.checkCalls, updater.lastChannel)
 	}
 }

--- a/internal/tui/ui/strings.go
+++ b/internal/tui/ui/strings.go
@@ -343,7 +343,7 @@ const (
 	SwitchCoreChannelRollback       = "The previous valid core remains if installation fails."
 	SwitchMihariChannelTitle        = "Switch Mihari channel"
 	SwitchMihariChannelToDevImpact  = "This TUI will track prerelease builds, which may be unstable. The running binary is not replaced now. If the current build is the same series or a newer official release, the next check may show ahead."
-	SwitchMihariChannelToMainImpact = "This TUI will track the official latest release. The running binary is not replaced now. If the current build is a canonical prerelease, the next check may show ahead."
+	SwitchMihariChannelToMainImpact = "This TUI will track the official latest release. The running binary is not replaced now. If the current build is a canonical prerelease, the next check will offer the official latest."
 	SwitchMihariChannelRollback     = "The running binary is not changed."
 )
 

--- a/internal/update/channel.go
+++ b/internal/update/channel.go
@@ -87,14 +87,20 @@ func classifyUpdate(current, latest string) (available, ahead bool) {
 		return false, false
 	}
 	normalized := strings.TrimSpace(current)
-	if _, ok := parseCanonicalTag(normalized); !ok {
+	currentTag, ok := parseCanonicalTag(normalized)
+	if !ok {
 		if normalized == "" || strings.HasPrefix(strings.ToLower(normalized), "v") {
 			return true, false
 		}
 		normalized = "v" + normalized
-		if _, ok := parseCanonicalTag(normalized); !ok {
+		currentTag, ok = parseCanonicalTag(normalized)
+		if !ok {
 			return true, false
 		}
+	}
+	latestTag, latestOK := parseCanonicalTag(latest)
+	if currentTag.isDev && latestOK && !latestTag.isDev {
+		return true, false
 	}
 	cmp, ok := compareCanonicalTags(latest, normalized)
 	if !ok {

--- a/internal/update/channel_test.go
+++ b/internal/update/channel_test.go
@@ -78,10 +78,12 @@ func TestClassifyUpdate(t *testing.T) {
 	}{
 		{name: "same tag strips v", current: "0.8.2", latest: "v0.8.2", available: false, ahead: false},
 		{name: "newer latest", current: "v0.8.2", latest: "v0.9.0-dev.3", available: true, ahead: false},
-		{name: "dev ahead of main", current: "v0.9.0-dev.3", latest: "v0.8.2", available: false, ahead: true},
+		{name: "prerelease current offers official latest", current: "v0.9.0-dev.8", latest: "v0.8.2", available: true, ahead: false},
+		{name: "unprefixed prerelease current offers official latest", current: "0.9.0-dev.3", latest: "v0.8.2", available: true, ahead: false},
+		{name: "newer official ahead of older official", current: "v0.9.0", latest: "v0.8.2", available: false, ahead: true},
 		{name: "stable ahead of same-series dev", current: "v0.9.0", latest: "v0.9.0-dev.3", available: false, ahead: true},
+		{name: "newer prerelease ahead of older prerelease", current: "v0.9.0-dev.8", latest: "v0.9.0-dev.3", available: false, ahead: true},
 		{name: "dirty current is available not ahead", current: "dev", latest: "v0.8.2", available: true, ahead: false},
-		{name: "unprefixed current dev is ahead of main", current: "0.9.0-dev.3", latest: "v0.8.2", available: false, ahead: true},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/update/channel_test.go
+++ b/internal/update/channel_test.go
@@ -77,8 +77,8 @@ func TestClassifyUpdate(t *testing.T) {
 		ahead     bool
 	}{
 		{name: "same tag strips v", current: "0.8.2", latest: "v0.8.2", available: false, ahead: false},
-		{name: "newer latest", current: "v0.8.2", latest: "v0.9.0-dev.3", available: true, ahead: false},
-		{name: "prerelease current offers official latest", current: "v0.9.0-dev.8", latest: "v0.8.2", available: true, ahead: false},
+		{name: "dev to main offers official latest", current: "v0.9.0-dev.8", latest: "v0.8.2", available: true, ahead: false},
+		{name: "main to dev offers prerelease latest", current: "v0.8.2", latest: "v0.9.0-dev.8", available: true, ahead: false},
 		{name: "unprefixed prerelease current offers official latest", current: "0.9.0-dev.3", latest: "v0.8.2", available: true, ahead: false},
 		{name: "newer official ahead of older official", current: "v0.9.0", latest: "v0.8.2", available: false, ahead: true},
 		{name: "stable ahead of same-series dev", current: "v0.9.0", latest: "v0.9.0-dev.3", available: false, ahead: true},

--- a/internal/update/self_test.go
+++ b/internal/update/self_test.go
@@ -637,12 +637,29 @@ func TestSelfUpdateSkipsAheadVersion(t *testing.T) {
 		checksumBody: fixtureSHA256Hex(payload) + "  mihari-linux-amd64\n",
 		binaryBody:   payload,
 	})
-	result, err := env.updater.Update(context.Background(), env.binaryPath, "v0.9.0-dev.3", ChannelMain)
+	result, err := env.updater.Update(context.Background(), env.binaryPath, "v0.9.0", ChannelMain)
 	if err != nil || result.Updated || !result.Ahead || result.Version != "v0.8.2" || result.Channel != ChannelMain {
 		t.Fatalf("result=%#v err=%v", result, err)
 	}
 	if env.checksumReqs != 0 || env.binaryReqs != 0 {
 		t.Fatalf("checksum=%d binary=%d, want 0", env.checksumReqs, env.binaryReqs)
+	}
+}
+
+func TestSelfUpdateInstallsOfficialWhenCurrentIsPrerelease(t *testing.T) {
+	payload := []byte("official-binary")
+	env := startSelfUpdateEnv(t, selfUpdateServerConfig{
+		tag:          "v0.8.2",
+		checksumBody: fixtureSHA256Hex(payload) + "  mihari-linux-amd64\n",
+		binaryBody:   payload,
+	})
+	result, err := env.updater.Update(context.Background(), env.binaryPath, "v0.9.0-dev.8", ChannelMain)
+	if err != nil || !result.Updated || result.Ahead || result.Version != "v0.8.2" || result.Channel != ChannelMain {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+	got, readErr := os.ReadFile(env.binaryPath)
+	if readErr != nil || string(got) != string(payload) {
+		t.Fatalf("binary=%q err=%v", got, readErr)
 	}
 }
 
@@ -657,6 +674,7 @@ func TestSelfUpdaterCheckReportsAvailability(t *testing.T) {
 		{name: "new release", current: "v1.0.0", latest: "v1.1.0", available: true},
 		{name: "same release", current: "v1.0.0", latest: "v1.0.0"},
 		{name: "ahead of latest", current: "v2.0.0", latest: "v1.0.0", ahead: true},
+		{name: "prerelease current on main", current: "v0.9.0-dev.8", latest: "v0.8.2", available: true},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/update/self_test.go
+++ b/internal/update/self_test.go
@@ -663,6 +663,23 @@ func TestSelfUpdateInstallsOfficialWhenCurrentIsPrerelease(t *testing.T) {
 	}
 }
 
+func TestSelfUpdateInstallsPrereleaseWhenCurrentIsOfficial(t *testing.T) {
+	payload := []byte("prerelease-binary")
+	env := startSelfUpdateEnv(t, selfUpdateServerConfig{
+		tag:          "v0.9.0-dev.8",
+		checksumBody: fixtureSHA256Hex(payload) + "  mihari-linux-amd64\n",
+		binaryBody:   payload,
+	})
+	result, err := env.updater.Update(context.Background(), env.binaryPath, "v0.8.2", ChannelDev)
+	if err != nil || !result.Updated || result.Ahead || result.Version != "v0.9.0-dev.8" || result.Channel != ChannelDev {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+	got, readErr := os.ReadFile(env.binaryPath)
+	if readErr != nil || string(got) != string(payload) {
+		t.Fatalf("binary=%q err=%v", got, readErr)
+	}
+}
+
 func TestSelfUpdaterCheckReportsAvailability(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -690,6 +707,53 @@ func TestSelfUpdaterCheckReportsAvailability(t *testing.T) {
 			}
 			if path != "/repos/mihari-proxy/mihari/releases/latest" {
 				t.Fatalf("path=%q", path)
+			}
+		})
+	}
+}
+
+func TestSelfUpdaterCheckCrossChannelAvailability(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  string
+		latest   string
+		channel  string
+		wantPath string
+	}{
+		{
+			name:     "dev to main",
+			current:  "v0.9.0-dev.8",
+			latest:   "v0.8.2",
+			channel:  ChannelMain,
+			wantPath: "/repos/mihari-proxy/mihari/releases/latest",
+		},
+		{
+			name:     "main to dev",
+			current:  "v0.8.2",
+			latest:   "v0.9.0-dev.8",
+			channel:  ChannelDev,
+			wantPath: "/repos/mihari-proxy/mihari/releases",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var path string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				path = r.URL.Path
+				release := Release{TagName: test.latest, Assets: []Asset{{Name: "mihari-linux-amd64"}}}
+				if test.channel == ChannelDev {
+					_ = json.NewEncoder(w).Encode([]Release{release})
+					return
+				}
+				_ = json.NewEncoder(w).Encode(release)
+			}))
+			defer server.Close()
+			result, err := (SelfUpdater{HTTPClient: server.Client(), APIBase: server.URL}).Check(context.Background(), test.current, test.channel)
+			if err != nil || result.Current != test.current || result.Latest != test.latest || !result.Available || result.Ahead || result.Channel != test.channel {
+				t.Fatalf("result=%#v err=%v", result, err)
+			}
+			if path != test.wantPath {
+				t.Fatalf("path=%q want=%q", path, test.wantPath)
 			}
 		})
 	}


### PR DESCRIPTION
## 变更内容

切到 `main` 后，当前二进制若是 `vX.Y.Z-dev.N`，不再因为版本号大于正式 latest 而被判成 `ahead`。`classifyUpdate` 把「prerelease 当前版本 vs 正式 latest」视为可安装官方版本，Update Mihari 可以装回 `/releases/latest`（例如 `v0.8.2`）。

真正更新的官方版本（例如 `v0.9.0` vs `v0.8.2`）以及 `dev` 通道上较新的 prerelease，仍保持 `ahead`。

## 类型

- [ ] feat: 新功能
- [x] fix: Bug 修复
- [ ] refactor: 重构
- [ ] docs: 文档
- [ ] test: 测试
- [ ] chore: 构建/工具

## 检查清单

- [x] `go test -race ./...` 通过
- [x] `go vet ./...` 通过
- [x] `gofmt -l cmd internal` 无输出
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] 若修改了 `internal/control/protocol` 的契约、CLI 输出/退出码或跨平台行为，已在 PR 描述中说明影响

未改协议、退出码或跨平台边界。TUI 切到 `main` 的确认文案改为：当前是 prerelease 时，下次检查会提供正式 latest，而不是显示 ahead。

## 相关 Issues

Fixes #140
Related #125

## 其他

复现：`v0.9.0-dev.8` + 通道 `main` + 正式 latest `v0.8.2`。修复前显示 `ahead of main v0.8.2` 且无法安装；修复后显示 `v0.8.2 available` 并可确认更新。

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mihari-proxy/mihari/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

