### PR TITLE
ci: 正式发版前校验 CHANGELOG 已收口

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -33,7 +33,7 @@ CGO_ENABLED=0 go build -buildvcs=false -trimpath -ldflags "-s -w -X github.com/m
 
 Release builds must use both `-buildvcs=false` and `-trimpath`. The former prevents Go from writing different VCS/module metadata to the same commit before and after tag creation, while the latter removes local build paths; version identity is injected only via `buildinfo.Version` above.
 
-The all-in-one release inputs are fixed in `scripts/release/release-inputs.lock.json` within the repository. The release workflow only consumes this file and does not query mihomo's latest release or GeoIP's mutable branches during release. When upstream inputs need updating, maintainers should run in a separate release-prep PR:
+The all-in-one release inputs are fixed in `scripts/release/release-inputs.lock.json` within the repository. The release workflow only consumes this file and does not query mihomo's latest release or GeoIP's mutable branches during release. When upstream inputs need updating, maintainers should run it in the official human `chore/release-*` PR (the same PR that closes `CHANGELOG.md`):
 
 ```sh
 go run ./scripts/tools/resolve-release-inputs --channel stable --out scripts/release/release-inputs.lock.json
@@ -185,7 +185,7 @@ main ──sync PR──> dev
 
 Regular features and fixes are merged from `feat/*` or `fix/*` branches via PR into `dev`, then promoted to `main` via a promotion PR after integration verification in dev. Emergency fixes are created from `main` as `hotfix/*`, merged via PR into `main`, and then a sync PR must merge `main` back to `dev`. Regular PRs use squash merge; `dev → main` promotions and `main → dev` syncs use merge commits to preserve release history and avoid re-displaying already-released commits. Do not push directly to `main` or `dev`.
 
-Feature PRs targeting `dev` must not modify `CHANGELOG.md`. The changelog is written only by official `chore/release-*` release-prep PRs (closing entries into `## [vX.Y.Z]`) or copied back by a `main → dev` sync. CI rejects other `CHANGELOG.md` edits; restoring the file so it matches `main` is allowed.
+Feature PRs targeting `dev` must not modify `CHANGELOG.md`. The changelog is written only by a human `chore/release-*` PR (closing entries into `## [vX.Y.Z]`) or copied back by a `main → dev` sync. `release.yml` / `release-dev.yml` do not modify or commit `CHANGELOG.md`. CI rejects other `CHANGELOG.md` edits; restoring the file so it matches `main` is allowed.
 
 Before `dev` was created and protected, Issue #115's bootstrap changes used a one-time main PR; this is not an exception to direct push or direct commit to `main`. After merging, the normal flow above was restored.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -185,6 +185,8 @@ main ──sync PR──> dev
 
 Regular features and fixes are merged from `feat/*` or `fix/*` branches via PR into `dev`, then promoted to `main` via a promotion PR after integration verification in dev. Emergency fixes are created from `main` as `hotfix/*`, merged via PR into `main`, and then a sync PR must merge `main` back to `dev`. Regular PRs use squash merge; `dev → main` promotions and `main → dev` syncs use merge commits to preserve release history and avoid re-displaying already-released commits. Do not push directly to `main` or `dev`.
 
+Feature PRs targeting `dev` must not modify `CHANGELOG.md`. The changelog is written only by official `chore/release-*` release-prep PRs (closing entries into `## [vX.Y.Z]`) or copied back by a `main → dev` sync. CI rejects other `CHANGELOG.md` edits; restoring the file so it matches `main` is allowed.
+
 Before `dev` was created and protected, Issue #115's bootstrap changes used a one-time main PR; this is not an exception to direct push or direct commit to `main`. After merging, the normal flow above was restored.
 
 1. **Create a branch**

--- a/.github/CONTRIBUTING.zh-CN.md
+++ b/.github/CONTRIBUTING.zh-CN.md
@@ -185,6 +185,8 @@ main ──同步 PR──> dev
 
 普通功能和修复从 `feat/*` 或 `fix/*` 分支通过 PR 合并到 `dev`，在 dev 集成验证后再通过晋级 PR 进入 `main`。紧急修复从 `main` 创建 `hotfix/*`，通过 PR 合并到 `main`，随后必须用同步 PR 将 `main` 合并回 `dev`。普通 PR 使用 squash merge；`dev → main` 晋级和 `main → dev` 同步使用 merge commit，以保留发布历史和避免重复显示已发布提交。不得直接推送 `main` 或 `dev`。
 
+指向 `dev` 的功能 PR 不得修改 `CHANGELOG.md`。CHANGELOG 只由正式发版的 `chore/release-*` PR 写入（把条目收口到 `## [vX.Y.Z]`），或随 `main → dev` 同步回到 `dev`。CI 会拒绝其它对 `CHANGELOG.md` 的改动；若只是把 `dev` 上的文件恢复成与 `main` 一致，则允许。
+
 在 `dev` 创建并受保护前，Issue #115 的 bootstrap 变更使用一次性 main PR；这不是直接推送或直接提交 `main` 的例外。合并后恢复上述常规流。
 
 1. **创建分支**

--- a/.github/CONTRIBUTING.zh-CN.md
+++ b/.github/CONTRIBUTING.zh-CN.md
@@ -33,7 +33,7 @@ CGO_ENABLED=0 go build -buildvcs=false -trimpath -ldflags "-s -w -X github.com/m
 
 发布构建必须同时使用 `-buildvcs=false -trimpath`。前者避免同一 commit 在创建 tag 前后被 Go 写入不同的 VCS/module 元数据，后者去除本机构建路径；版本身份仍只由上面的 `buildinfo.Version` 注入。
 
-all-in-one 发布输入固定在仓库内的 `scripts/release/release-inputs.lock.json`。发布 workflow 只消费该文件，不在发版时查询 mihomo 的 latest release 或 GeoIP 的可变分支。需要更新上游输入时，维护者应在独立的 release-prep PR 中运行：
+all-in-one 发布输入固定在仓库内的 `scripts/release/release-inputs.lock.json`。发布 workflow 只消费该文件，不在发版时查询 mihomo 的 latest release 或 GeoIP 的可变分支。需要更新上游输入时，维护者应在正式发版的人工 PR `chore/release-*` 中运行（与收口 `CHANGELOG.md` 同一类 PR）：
 
 ```sh
 go run ./scripts/tools/resolve-release-inputs --channel stable --out scripts/release/release-inputs.lock.json
@@ -185,7 +185,7 @@ main ──同步 PR──> dev
 
 普通功能和修复从 `feat/*` 或 `fix/*` 分支通过 PR 合并到 `dev`，在 dev 集成验证后再通过晋级 PR 进入 `main`。紧急修复从 `main` 创建 `hotfix/*`，通过 PR 合并到 `main`，随后必须用同步 PR 将 `main` 合并回 `dev`。普通 PR 使用 squash merge；`dev → main` 晋级和 `main → dev` 同步使用 merge commit，以保留发布历史和避免重复显示已发布提交。不得直接推送 `main` 或 `dev`。
 
-指向 `dev` 的功能 PR 不得修改 `CHANGELOG.md`。CHANGELOG 只由正式发版的 `chore/release-*` PR 写入（把条目收口到 `## [vX.Y.Z]`），或随 `main → dev` 同步回到 `dev`。CI 会拒绝其它对 `CHANGELOG.md` 的改动；若只是把 `dev` 上的文件恢复成与 `main` 一致，则允许。
+指向 `dev` 的功能 PR 不得修改 `CHANGELOG.md`。CHANGELOG 只由人工 PR `chore/release-*` 写入（把条目收口到 `## [vX.Y.Z]`），或随 `main → dev` 同步回到 `dev`。`release.yml` / `release-dev.yml` 不会修改或提交 `CHANGELOG.md`。CI 会拒绝其它对 `CHANGELOG.md` 的改动；若只是把 `dev` 上的文件恢复成与 `main` 一致，则允许。
 
 在 `dev` 创建并受保护前，Issue #115 的 bootstrap 变更使用一次性 main PR；这不是直接推送或直接提交 `main` 的例外。合并后恢复上述常规流。
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,7 @@
 - [ ] `go vet ./...` 通过
 - [ ] `gofmt -l cmd internal` 无输出
 - [ ] 提交包含 `Signed-off-by`（DCO 签名）
+- [ ] 未修改 `CHANGELOG.md`（`chore/release-*` 正式发版收口，或恢复成与 `main` 一致除外）
 - [ ] 若修改了 `internal/control/protocol` 的契约、CLI 输出/退出码或跨平台行为，已在 PR 描述中说明影响
 
 ## 相关 Issues

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,48 @@
+name: changelog check
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [dev]
+
+jobs:
+  check:
+    name: Validate changelog ownership
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Fetch main for changelog comparison
+        run: git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Validate changelog ownership
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if git diff --quiet "origin/${BASE_REF}...HEAD" -- CHANGELOG.md; then
+            CHANGELOG_CHANGED=false
+          else
+            status=$?
+            [ "${status}" -eq 1 ] || { echo "::error::unable to diff CHANGELOG.md against the PR base"; exit "${status}"; }
+            CHANGELOG_CHANGED=true
+          fi
+          if git diff --quiet origin/main HEAD -- CHANGELOG.md; then
+            HEAD_MATCHES_MAIN=true
+          else
+            status=$?
+            [ "${status}" -eq 1 ] || { echo "::error::unable to compare CHANGELOG.md with main"; exit "${status}"; }
+            HEAD_MATCHES_MAIN=false
+          fi
+          python scripts/release/changelog_branch_policy.py \
+            --head-ref "${HEAD_REF}" \
+            --changelog-changed "${CHANGELOG_CHANGED}" \
+            --head-matches-main "${HEAD_MATCHES_MAIN}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Test release safety policies
         env:
           PYTHONPATH: ${{ github.workspace }}/scripts/release
-        run: python -m pytest scripts/release/tests/test_release_policy.py scripts/release/tests/test_github_release_policy.py scripts/release/tests/test_release_workflow.py scripts/release/tests/test_alist_client.py scripts/release/tests/test_alist_index.py scripts/release/tests/test_release_alist.py scripts/release/tests/test_retract_alist.py scripts/release/tests/test_regenerate_index.py scripts/release/tests/test_alist_channel_guard.py -q
+        run: python -m pytest scripts/release/tests/test_release_policy.py scripts/release/tests/test_github_release_policy.py scripts/release/tests/test_changelog_policy.py scripts/release/tests/test_release_workflow.py scripts/release/tests/test_alist_client.py scripts/release/tests/test_alist_index.py scripts/release/tests/test_release_alist.py scripts/release/tests/test_retract_alist.py scripts/release/tests/test_regenerate_index.py scripts/release/tests/test_alist_channel_guard.py -q
       - name: Test
         run: go test -count=1 ./...
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Test release safety policies
         env:
           PYTHONPATH: ${{ github.workspace }}/scripts/release
-        run: python -m pytest scripts/release/tests/test_release_policy.py scripts/release/tests/test_github_release_policy.py scripts/release/tests/test_changelog_policy.py scripts/release/tests/test_release_workflow.py scripts/release/tests/test_alist_client.py scripts/release/tests/test_alist_index.py scripts/release/tests/test_release_alist.py scripts/release/tests/test_retract_alist.py scripts/release/tests/test_regenerate_index.py scripts/release/tests/test_alist_channel_guard.py -q
+        run: python -m pytest scripts/release/tests/test_release_policy.py scripts/release/tests/test_github_release_policy.py scripts/release/tests/test_changelog_policy.py scripts/release/tests/test_changelog_branch_policy.py scripts/release/tests/test_release_workflow.py scripts/release/tests/test_alist_client.py scripts/release/tests/test_alist_index.py scripts/release/tests/test_release_alist.py scripts/release/tests/test_retract_alist.py scripts/release/tests/test_regenerate_index.py scripts/release/tests/test_alist_channel_guard.py -q
       - name: Test
         run: go test -count=1 ./...
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,13 @@ jobs:
           echo "sha=${SHA}" >> "${GITHUB_OUTPUT}"
           echo "should_release=true" >> "${GITHUB_OUTPUT}"
 
+      - name: Validate stable changelog
+        if: steps.gate.outputs.should_resolve == 'true'
+        run: |
+          python scripts/release/changelog_policy.py \
+            --changelog CHANGELOG.md \
+            --version "${VERSION}"
+
   build:
     name: build ${{ matrix.goos }}/${{ matrix.goarch }}
     needs: resolve
@@ -218,6 +225,12 @@ jobs:
             echo "::error::version rejected at final gate"
             exit 1
           fi
+
+      - name: Validate stable changelog
+        run: |
+          python scripts/release/changelog_policy.py \
+            --changelog CHANGELOG.md \
+            --version "${VERSION}"
 
       - name: Download artifacts
         uses: actions/download-artifact@v8

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - 本文件适用于整个仓库。子目录若新增 `AGENTS.md`，以离目标文件最近的规则为补充或覆盖。
 - 开始任何开发之前先阅读 `.github/CONTRIBUTING.md`；修改代码前再阅读 `README.md`、相关包代码与测试；涉及架构边界时同时阅读 `docs/superpowers/specs/2026-08-03-mihari-architecture-design.md`。
 - 禁止在 `main` 或 `dev` 分支上直接修改或提交。任何变更都必须在独立分支中完成，验证通过并经用户确认后再通过 PR 合并。
+- 指向 `dev` 的功能 PR 不得修改 `CHANGELOG.md`。CHANGELOG 只由正式发版的 `chore/release-*` PR 收口，或随 `main → dev` 同步回来。
 - `dev` 创建并受保护前，Issue #115 的 bootstrap 变更仅可通过一次性 main PR 落地；该例外不允许直接修改或提交 `main`。
 - 保留用户已有的未提交修改，不覆盖、不清理、不顺手重构无关代码。
 - 只做当前任务要求的变更。发现邻近问题时记录并说明，除非它直接阻塞当前任务，否则不要扩大范围。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,7 @@ $env:GOOS = 'darwin';  $env:GOARCH = 'arm64'; go build -o bin/mihari-darwin-arm6
 - 平台代码与构建标签配对，通用代码可在三个目标 OS 编译，且保持 CGO-free。
 - 修改过的 Go 文件已格式化，相关测试、race 检查和 vet 已按风险执行。
 - README、命令帮助或架构文档在用户可见行为变化时同步更新。
+- 指向 `dev` 的功能 PR 未修改 `CHANGELOG.md`（仅 `chore/release-*`、`main → dev` 同步，或恢复成与 `main` 一致时例外）。
 - `git diff` 中不含无关文件、临时产物或对用户既有修改的覆盖。
 
 ## 9. Commit 规范

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,34 +6,7 @@
 
 ### Added
 
-- 增加 Mihari 应用通道 main/dev（安装脚本、CLI、TUI；#125）。
-- 为 prerelease 通道增加独立 AList index（`/mihari-release/mihari-dev`）与 `retract-dev` 撤回入口（#126）。
-
-### Changed
-
-- 正式版 `release.yml` 在构建与发布前校验 CHANGELOG 已收口到目标版本节；dev 预发布不校验。
-
 ### Fixed
-
-- 兼容当前 AList `/api/fs/list` 不再返回分页字段的响应，避免发版脚本拒绝合法目录 listing。
-- 把 AList 对缺失目录返回的 `object not found` 视为不存在，而不是发版检查失败。
-
-## [v0.9.0] - 2026-08-24
-
-### Added
-
-- 增加受保护的 `dev` 集成分支与 canonical `vX.Y.Z-dev.N` GitHub prerelease 流程：固定源 commit SHA，构建六个平台并校验精确 14 个 assets，且不改变 stable `/releases/latest`（#120）。
-
-### Changed
-
-- Stable 发布改为固定 `main` commit SHA，并加固 stable AList 发布/撤回事务、索引恢复与通道隔离（#120）。
-
-### Fixed
-
-- Windows TUN 冲突探测避免把本实例的 mihomo 进程识别为外部冲突（#114）。
-- 修复 dev prerelease Create Release 的 `make_latest` 参数类型，并在创建失败时保留 GitHub API 响应与错误输出。
-- 修复同一 commit 在创建 release tag 前后因 Go VCS/module 元数据变化而产生不同二进制的问题；发布构建改用 `-buildvcs=false -trimpath`。
-- all-in-one 构建改为消费已审核的不可变 mihomo/GeoIP 输入 lock，避免发版重试期间上游 latest/ref 漂移并导致 asset checksum 冲突。
 
 ## [v0.8.2] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - 增加 Mihari 应用通道 main/dev（安装脚本、CLI、TUI；#125）。
 - 为 prerelease 通道增加独立 AList index（`/mihari-release/mihari-dev`）与 `retract-dev` 撤回入口（#126）。
 
+### Changed
+
+- 正式版 `release.yml` 在构建与发布前校验 CHANGELOG 已收口到目标版本节；dev 预发布不校验。
+
 ### Fixed
 
 - 兼容当前 AList `/api/fs/list` 不再返回分页字段的响应，避免发版脚本拒绝合法目录 listing。

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -37,7 +37,7 @@ Dev 发布固定 `refs/heads/dev` 来源并校验 canonical `vX.Y.Z-dev.N` 版�
 
 ### 1. 通过晋级 PR 合并到 main
 
-将已经通过 dev 集成验证的 release-prep 变更通过 `dev → main` 晋级 PR 合并；不要直接推送或提交 `main`。
+功能 PR 合进 `dev` 时不得修改 `CHANGELOG.md`。正式发版前从 `dev` 拉 `chore/release-vX.Y.Z`，只在该 PR 里把 CHANGELOG 收口，合进 `dev` 后再走 `dev → main` 晋级 PR；不要直接推送或提交 `main`。
 
 ```bash
 git checkout main
@@ -50,7 +50,7 @@ git pull origin main
 
 ### 3. 记录精确 main commit
 
-确认 CHANGELOG 与 release input lock 已随晋级 PR 进入 `main`。CHANGELOG 必须把 `[Unreleased]` 收口为 `## [vX.Y.Z] - YYYY-MM-DD`：该节至少一条条目，且是 Unreleased 后的第一个版本节；Unreleased 下不得再留 bullet。`release.yml` 会在构建前和发布前读取同一 SHA 上的 `CHANGELOG.md`，不满足则 fail closed。记录远端 `main` 当前精确的 40 位小写 commit SHA：
+确认 CHANGELOG 与 release input lock 已随 `chore/release-*` 与晋级 PR 进入 `main`。CHANGELOG 必须把 `[Unreleased]` 收口为 `## [vX.Y.Z] - YYYY-MM-DD`：该节至少一条条目，且是 Unreleased 后的第一个版本节；Unreleased 下不得再留 bullet。`release.yml` 会在构建前和发布前读取同一 SHA 上的 `CHANGELOG.md`，不满足则 fail closed。记录远端 `main` 当前精确的 40 位小写 commit SHA：
 
 ```bash
 git rev-parse origin/main
@@ -175,7 +175,7 @@ Get-FileHash mihari-windows-amd64.exe -Algorithm SHA256
 
 ### Dev 手动发布
 
-`release-dev.yml` 不校验 CHANGELOG。预发布把用户可见条目继续记在 `[Unreleased]`，正式版晋级前再收口。
+`release-dev.yml` 不校验 CHANGELOG。指向 `dev` 的功能 PR 不得修改 `CHANGELOG.md`；CHANGELOG 只在正式发版的 `chore/release-*` 中收口。
 
 从 GitHub Actions 选择 `release-dev` workflow 和受保护的 `dev` ref，填写符合 canonical `vX.Y.Z-dev.N` 格式的版本（各数字段不允许前导零）。workflow 先创建或复用 GitHub dev tag、prerelease 并上传精确 14 个 assets；GitHub 最终验收成功后，若 `ALIST_URL` 存在则写入独立 AList 根目录 `/mihari-release/mihari-dev` 及其 `index.txt`。`v0.9.0-dev.2` 已按 GitHub-only 路径发布并完成公开资产验收。不回溯该历史版本是首次真实 dispatch 的人工操作规则：workflow 不会因历史 GitHub-only 版本自动拒绝；空的 dev AList 根上重跑会创建通道并写入该版本。请从本变更后的下一个 `vX.Y.Z-dev.N` 开始写入 AList。
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -50,7 +50,7 @@ git pull origin main
 
 ### 3. 记录精确 main commit
 
-确认 CHANGELOG 与 release input lock 已随晋级 PR 进入 `main`，记录远端 `main` 当前精确的 40 位小写 commit SHA：
+确认 CHANGELOG 与 release input lock 已随晋级 PR 进入 `main`。CHANGELOG 必须把 `[Unreleased]` 收口为 `## [vX.Y.Z] - YYYY-MM-DD`：该节至少一条条目，且是 Unreleased 后的第一个版本节；Unreleased 下不得再留 bullet。`release.yml` 会在构建前和发布前读取同一 SHA 上的 `CHANGELOG.md`，不满足则 fail closed。记录远端 `main` 当前精确的 40 位小写 commit SHA：
 
 ```bash
 git rev-parse origin/main
@@ -175,6 +175,8 @@ Get-FileHash mihari-windows-amd64.exe -Algorithm SHA256
 
 ### Dev 手动发布
 
+`release-dev.yml` 不校验 CHANGELOG。预发布把用户可见条目继续记在 `[Unreleased]`，正式版晋级前再收口。
+
 从 GitHub Actions 选择 `release-dev` workflow 和受保护的 `dev` ref，填写符合 canonical `vX.Y.Z-dev.N` 格式的版本（各数字段不允许前导零）。workflow 先创建或复用 GitHub dev tag、prerelease 并上传精确 14 个 assets；GitHub 最终验收成功后，若 `ALIST_URL` 存在则写入独立 AList 根目录 `/mihari-release/mihari-dev` 及其 `index.txt`。`v0.9.0-dev.2` 已按 GitHub-only 路径发布并完成公开资产验收。不回溯该历史版本是首次真实 dispatch 的人工操作规则：workflow 不会因历史 GitHub-only 版本自动拒绝；空的 dev AList 根上重跑会创建通道并写入该版本。请从本变更后的下一个 `vX.Y.Z-dev.N` 开始写入 AList。
 
 AList 是否启用只由 `ALIST_URL` 决定：URL 缺失时 skip AList，GitHub prerelease 仍成功；URL 存在但 `ALIST_USERNAME` 或 `ALIST_PASSWORD` 任一缺失时，客户端 fail closed，workflow 失败。dev 发布与 `retract-dev.yml` 共用 job 级并发组 `mihari-dev-alist`。公开 dev index 为 `https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari-dev/index.txt`。dev 根目录不上传 `install-aio-remote.sh` / `.ps1`；稳定安装入口仍使用 `/mihari-release/mihari/index.txt`，不会指向 dev。
@@ -216,7 +218,7 @@ dev 撤回使用并发组 `mihari-dev-alist`，不得修改稳定目录、稳定
 - [ ] 所有测试通过 (`go test -race ./...`)
 - [ ] 代码格式正确 (`gofmt -l .`)
 - [ ] 静态分析通过 (`go vet ./...`)
-- [ ] [CHANGELOG.md](../CHANGELOG.md) 已更新
-- [ ] 标签版本号与 CHANGELOG.md 一致
+- [ ] [CHANGELOG.md](../CHANGELOG.md) 已将 `[Unreleased]` 收口到目标版本节，且 Unreleased 无残留条目；`release.yml` 会 fail closed 校验
+- [ ] 标签版本号与 CHANGELOG.md 中的版本节一致
 - [ ] `go.mod` 仍钉死 Go 1.26.5，发布构建仍使用 `-buildvcs=false -trimpath`
 - [ ] `scripts/release/release-inputs.lock.json` 已在 release-prep PR 中更新（如需）并审核 diff；release workflow 未动态解析 latest/ref

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -7,7 +7,7 @@
 | 工作流 | 触发条件 | 运行内容 |
 |--------|----------|----------|
 | **CI** | 推送到 `main`、`dev`、`master` 分支<br>Pull Request | ✅ 代码格式检查 (`gofmt`)<br>✅ 静态分析 (`go vet`)<br>✅ 单元测试 (`go test ./...` + `-race`)<br>✅ 交叉编译验证（6 平台） |
-| **Release** | 主路径：从 `main` 执行 `workflow_dispatch`（必填 `version` + `commit_sha`）<br>兼容入口：推送 `v*` 标签 | ✅ 版本闸门（拒绝 `-` 预发布后缀）<br>✅ 6 平台构建 + 版本号注入<br>✅ 打包 6 个 all-in-one 整合包<br>✅ 生成 SHA256 校验和（全量 + aio 专用）<br>✅ 创建 GitHub Release<br>✅ `ALIST_URL` 存在时上传整合包到 AList 网盘 |
+| **Release** | 主路径：从 `main` 执行 `workflow_dispatch`（必填 `version` + `commit_sha`）<br>兼容入口：推送 `v*` 标签 | ✅ 校验仓库内已收口的 CHANGELOG（不改文件、不创建 commit）<br>✅ 版本闸门（拒绝 `-` 预发布后缀）<br>✅ 6 平台构建 + 版本号注入<br>✅ 打包 6 个 all-in-one 整合包<br>✅ 生成 SHA256 校验和（全量 + aio 专用）<br>✅ 创建 GitHub Release<br>✅ `ALIST_URL` 存在时上传整合包到 AList 网盘 |
 | **Retract** | 从 `main` 执行 `workflow_dispatch`（必填 `version` + `confirm`） | ✅ 彻底撤回致命错误版本（GitHub release + AList 目录 + index 重建） |
 | **DCO** | 推送到任何分支<br>Pull Request | ✅ 校验每个提交的 `Signed-off-by` 签名 |
 
@@ -35,28 +35,36 @@ Dev 发布固定 `refs/heads/dev` 来源并校验 canonical `vX.Y.Z-dev.N` 版�
 
 ## 发版流程
 
-### 1. 通过晋级 PR 合并到 main
+`release.yml` **不会修改 `CHANGELOG.md`，也不会创建 `chore/release-*` commit**。它只读取晋级后那个精确 SHA 上已经存在的 changelog，校验通过才打 tag、构建和上传。GitHub Release 页面的 What's Changed 由 `generate_release_notes` 生成，不会回写仓库。
 
-功能 PR 合进 `dev` 时不得修改 `CHANGELOG.md`。正式发版前从 `dev` 拉 `chore/release-vX.Y.Z`，只在该 PR 里把 CHANGELOG 收口，合进 `dev` 后再走 `dev → main` 晋级 PR；不要直接推送或提交 `main`。
+功能 PR 合进 `dev` 时不得修改 `CHANGELOG.md`。
+
+### 1. 人手收口 CHANGELOG
+
+这是人工 PR，不是 workflow 产物。从 `dev` 拉分支 `chore/release-vX.Y.Z`，把 `[Unreleased]` 收口为 `## [vX.Y.Z] - YYYY-MM-DD`：该节至少一条条目，且是 Unreleased 后的第一个版本节；Unreleased 下不得再留 bullet。按需在同一 PR 里审核并更新 `scripts/release/release-inputs.lock.json`。将这个 PR 合进 `dev`。
+
+### 2. 通过晋级 PR 合并到 main
+
+将已经通过 `dev` 集成验证、且包含上一步 CHANGELOG 收口的提交，通过 `dev → main` 晋级 PR 合并；不要直接推送或提交 `main`。
 
 ```bash
 git checkout main
 git pull origin main
 ```
 
-### 2. 验证 CI 通过
+### 3. 验证 CI 通过
 
-推送代码到 `main` 后，CI 工作流会自动运行。在 GitHub Actions 页面确认所有检查通过后再继续。
+推送到 `main` 后，CI 工作流会自动运行。在 GitHub Actions 页面确认所有检查通过后再继续。
 
-### 3. 记录精确 main commit
+### 4. 记录精确 main commit
 
-确认 CHANGELOG 与 release input lock 已随 `chore/release-*` 与晋级 PR 进入 `main`。CHANGELOG 必须把 `[Unreleased]` 收口为 `## [vX.Y.Z] - YYYY-MM-DD`：该节至少一条条目，且是 Unreleased 后的第一个版本节；Unreleased 下不得再留 bullet。`release.yml` 会在构建前和发布前读取同一 SHA 上的 `CHANGELOG.md`，不满足则 fail closed。记录远端 `main` 当前精确的 40 位小写 commit SHA：
+确认 CHANGELOG 与 release input lock 已随 `chore/release-*` 与晋级 PR 进入 `main`。`release.yml` 会在构建前和发布前读取同一 SHA 上的 `CHANGELOG.md`，不满足则 fail closed。记录远端 `main` 当前精确的 40 位小写 commit SHA：
 
 ```bash
 git rev-parse origin/main
 ```
 
-### 4. 从 GitHub Actions 触发 stable release
+### 5. 从 GitHub Actions 触发 stable release
 
 在 GitHub Actions 选择 `release` workflow，ref 选择 `main`，执行 `workflow_dispatch`：
 
@@ -65,16 +73,17 @@ git rev-parse origin/main
 
 `release.yml` 会自行创建或验证 canonical stable tag。不要把本地创建并推送 tag 作为当前稳定发版操作。
 
-### 5. 自动发布与验收
+### 6. 自动发布与验收
 
 手动 dispatch 后，GitHub Actions Release 工作流会自动：
 
-1. 版本闸门校验（build / release 各一层，拒绝 `-` 预发布后缀）；
-2. 使用 Go 1.26.5 交叉编译 linux / darwin / windows（各 amd64 + arm64），以 `-buildvcs=false -trimpath` 构建并注入版本号（`-X .../buildinfo.Version=<version>`）；
-3. 只从仓库内已审核的 `scripts/release/release-inputs.lock.json` 读取精确 mihomo 与 GeoIP 输入，打包 6 个 all-in-one 整合包；
-4. 生成 SHA256 校验和（全量 `SHA256SUMS.txt` + aio 专用 `AIO_SHA256SUMS.txt`）；
-5. 创建 GitHub Release 并上传全部产物；
-6. `ALIST_URL` 存在时进入 AList mutation，上传整合包到网盘版本目录、更新 `index.txt`、追加离线安装命令到 release notes；只有 `ALIST_URL` 缺失时才走 GitHub-only skip，不阻塞 GitHub 发布。URL 已存在但 `ALIST_USERNAME` 或 `ALIST_PASSWORD` 任一缺失时，客户端必须 fail closed，workflow 失败且不得静默跳过。
+1. 校验仓库内 CHANGELOG 已收口到本次 `version`（只读，不改文件、不创建 commit）；
+2. 版本闸门校验（build / release 各一层，拒绝 `-` 预发布后缀）；
+3. 使用 Go 1.26.5 交叉编译 linux / darwin / windows（各 amd64 + arm64），以 `-buildvcs=false -trimpath` 构建并注入版本号（`-X .../buildinfo.Version=<version>`）；
+4. 只从仓库内已审核的 `scripts/release/release-inputs.lock.json` 读取精确 mihomo 与 GeoIP 输入，打包 6 个 all-in-one 整合包；
+5. 生成 SHA256 校验和（全量 `SHA256SUMS.txt` + aio 专用 `AIO_SHA256SUMS.txt`）；
+6. 创建 GitHub Release 并上传全部产物；
+7. `ALIST_URL` 存在时进入 AList mutation，上传整合包到网盘版本目录、更新 `index.txt`、追加离线安装命令到 release notes；只有 `ALIST_URL` 缺失时才走 GitHub-only skip，不阻塞 GitHub 发布。URL 已存在但 `ALIST_USERNAME` 或 `ALIST_PASSWORD` 任一缺失时，客户端必须 fail closed，workflow 失败且不得静默跳过。
 
 ## 可复现构建输入
 
@@ -167,7 +176,7 @@ Get-FileHash mihari-windows-amd64.exe -Algorithm SHA256
 - `version`：如 `v0.3.0`，必须匹配上述 canonical stable 格式，不接受前导零或预发布后缀；
 - `commit_sha`：必填的 **40 位十六进制**提交 SHA。workflow 会将该 SHA 与 checkout 后的源代码核对，身份不一致时 fail closed。
 
-这是当前稳定发版的主路径：release-prep 先经 `dev → main` 晋级 PR，随后以 `main` ref、canonical `version` 和精确 40 位 `main` `commit_sha` dispatch。workflow 会核对 checkout 后的 `main` 与输入 SHA，身份不一致即 fail closed。稳定发布和 AList 写入均须通过 CI、版本闸门及维护者审批；审批前不得执行生产分发写操作。
+这是当前稳定发版的主路径：先用人工 PR `chore/release-vX.Y.Z` 收口 CHANGELOG 并合进 `dev`，再经 `dev → main` 晋级 PR，随后以 `main` ref、canonical `version` 和精确 40 位 `main` `commit_sha` dispatch。`release.yml` 不会修改 `CHANGELOG.md`、不会创建 `chore/release-*` commit。workflow 会核对 checkout 后的 `main` 与输入 SHA，身份不一致即 fail closed。稳定发布和 AList 写入均须通过 CI、版本闸门及维护者审批；审批前不得执行生产分发写操作。
 
 兼容入口仍接受 `v*` tag push：它会将 lightweight 或 annotated tag 最终 peel 到 commit，并要求该 commit 可从可信 `main` 到达。它用于兼容既有自动化，不作为当前人工 runbook。无论入口为何，workflow 都在发布前后重新读取并 peel stable tag；该复核不是原子操作，因此还依赖已 active、覆盖 `refs/tags/v*` 的 tag ruleset 禁止删除、更新和 non-fast-forward。
 
@@ -175,7 +184,7 @@ Get-FileHash mihari-windows-amd64.exe -Algorithm SHA256
 
 ### Dev 手动发布
 
-`release-dev.yml` 不校验 CHANGELOG。指向 `dev` 的功能 PR 不得修改 `CHANGELOG.md`；CHANGELOG 只在正式发版的 `chore/release-*` 中收口。
+`release-dev.yml` 不校验 CHANGELOG，也不会改 `CHANGELOG.md`。指向 `dev` 的功能 PR 不得修改 `CHANGELOG.md`；CHANGELOG 只由人工 PR `chore/release-*` 在正式发版前收口。
 
 从 GitHub Actions 选择 `release-dev` workflow 和受保护的 `dev` ref，填写符合 canonical `vX.Y.Z-dev.N` 格式的版本（各数字段不允许前导零）。workflow 先创建或复用 GitHub dev tag、prerelease 并上传精确 14 个 assets；GitHub 最终验收成功后，若 `ALIST_URL` 存在则写入独立 AList 根目录 `/mihari-release/mihari-dev` 及其 `index.txt`。`v0.9.0-dev.2` 已按 GitHub-only 路径发布并完成公开资产验收。不回溯该历史版本是首次真实 dispatch 的人工操作规则：workflow 不会因历史 GitHub-only 版本自动拒绝；空的 dev AList 根上重跑会创建通道并写入该版本。请从本变更后的下一个 `vX.Y.Z-dev.N` 开始写入 AList。
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -91,7 +91,7 @@ git rev-parse origin/main
 
 all-in-one 的外部输入固定在仓库内的 `scripts/release/release-inputs.lock.json`。lock 记录精确的 mihomo release、六个平台 asset ID/URL/大小/SHA-256，以及 GeoIP commit、不可变 URL 和 SHA-256。构建阶段只读取 lock，**不会**解析 mihomo latest release 或 GeoIP 的可变 `release` ref，也不会在 workflow 中自动更新 lock。
 
-维护者只应在独立的 release-prep PR 中更新它：
+维护者只应在人工 PR `chore/release-*` 中更新它（与收口 CHANGELOG 同一类 PR；release workflow 不会提交 lock）：
 
 ```bash
 go run ./scripts/tools/resolve-release-inputs --channel stable --out scripts/release/release-inputs.lock.json
@@ -230,4 +230,4 @@ dev 撤回使用并发组 `mihari-dev-alist`，不得修改稳定目录、稳定
 - [ ] [CHANGELOG.md](../CHANGELOG.md) 已将 `[Unreleased]` 收口到目标版本节，且 Unreleased 无残留条目；`release.yml` 会 fail closed 校验
 - [ ] 标签版本号与 CHANGELOG.md 中的版本节一致
 - [ ] `go.mod` 仍钉死 Go 1.26.5，发布构建仍使用 `-buildvcs=false -trimpath`
-- [ ] `scripts/release/release-inputs.lock.json` 已在 release-prep PR 中更新（如需）并审核 diff；release workflow 未动态解析 latest/ref
+- [ ] `scripts/release/release-inputs.lock.json` 已在人工 `chore/release-*` PR 中更新（如需）并审核 diff；release workflow 未动态解析 latest/ref，也不会提交 lock

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -85,7 +85,7 @@ curl -fsSL https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/insta
 
 `scripts/tools/build-all-in-one` 不解析滚动 tag、latest release 或 GeoIP 可变分支。它要求显式传入仓库内已审核的 `scripts/release/release-inputs.lock.json`，并只下载 lock 中精确记录且有 SHA-256 的六个平台 mihomo 资产和两份 GeoIP 数据。当前 checked-in lock 使用 **stable** 内核；预置通道由 lock 的 `mihomo.channel` 决定，而不是由 bundler 在发版时动态选择。
 
-维护者只在独立的 release-prep PR 中更新 lock：
+维护者只在正式发版的人工 PR `chore/release-*` 中更新 lock（与收口 CHANGELOG 同一类 PR；不是 workflow 提交）：
 
 ```sh
 go run ./scripts/tools/resolve-release-inputs --channel stable --out scripts/release/release-inputs.lock.json

--- a/scripts/release/changelog_branch_policy.py
+++ b/scripts/release/changelog_branch_policy.py
@@ -1,0 +1,63 @@
+"""Validate that PRs into dev do not edit CHANGELOG.md outside official release-prep."""
+
+import argparse
+import sys
+
+
+class ChangelogBranchPolicyError(ValueError):
+    """Raised when a PR into dev is not allowed to change CHANGELOG.md."""
+
+
+def validate_dev_changelog_change(
+    *,
+    head_ref: str,
+    changelog_changed: bool,
+    head_matches_main: bool,
+) -> None:
+    """Allow unchanged files, main sync, official release-prep, or restore-to-main."""
+    if not isinstance(head_ref, str) or not isinstance(changelog_changed, bool) or not isinstance(
+        head_matches_main, bool
+    ):
+        raise ChangelogBranchPolicyError("invalid changelog branch input")
+    if "\n" in head_ref or "\r" in head_ref:
+        raise ChangelogBranchPolicyError("invalid changelog branch input")
+    if not changelog_changed:
+        return
+    if head_ref == "main" or head_ref.startswith("chore/release-") or head_matches_main:
+        return
+    raise ChangelogBranchPolicyError("feature PRs targeting dev must not modify CHANGELOG.md")
+
+
+def _parse_bool(value: str) -> bool:
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    raise ChangelogBranchPolicyError("invalid changelog branch input")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--head-ref", required=True)
+    parser.add_argument("--changelog-changed", required=True)
+    parser.add_argument("--head-matches-main", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the branch changelog gate without echoing untrusted inputs."""
+    arguments = _parser().parse_args(argv)
+    try:
+        validate_dev_changelog_change(
+            head_ref=arguments.head_ref,
+            changelog_changed=_parse_bool(arguments.changelog_changed),
+            head_matches_main=_parse_bool(arguments.head_matches_main),
+        )
+    except ChangelogBranchPolicyError as error:
+        print(f"changelog branch policy validation failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/changelog_policy.py
+++ b/scripts/release/changelog_policy.py
@@ -1,0 +1,114 @@
+"""Validate that a stable release changelog has closed Unreleased into the version section."""
+
+import argparse
+import datetime
+from pathlib import Path
+import re
+import sys
+
+
+_MAX_CHANGELOG_BYTES = 1_048_576
+_STABLE_VERSION_PATTERN = re.compile(
+    r"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$"
+)
+_H2_PATTERN = re.compile(r"^##[ \t]+(.+?)[ \t]*$")
+_UNRELEASED_HEADING = re.compile(r"^\[Unreleased\]$")
+_VERSION_HEADING = re.compile(
+    r"^\[(v(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))\]"
+    r"[ \t]+-[ \t]+(\d{4}-\d{2}-\d{2})$"
+)
+_BULLET_PATTERN = re.compile(r"^[ \t]*[-*+][ \t]+\S")
+
+
+class ChangelogPolicyError(ValueError):
+    """Raised when CHANGELOG.md cannot be used for a stable release."""
+
+
+def validate_stable_changelog(text: str, version: str) -> None:
+    """Require a closed Unreleased section and a matching first stable version section."""
+    if not isinstance(text, str) or not isinstance(version, str):
+        raise ChangelogPolicyError("invalid changelog input")
+    if _STABLE_VERSION_PATTERN.fullmatch(version) is None:
+        raise ChangelogPolicyError("version must match the required stable format")
+
+    lines = text.splitlines()
+    headings: list[tuple[int, str]] = []
+    for index, line in enumerate(lines):
+        match = _H2_PATTERN.fullmatch(line)
+        if match is not None:
+            headings.append((index, match.group(1)))
+
+    if not headings or _UNRELEASED_HEADING.fullmatch(headings[0][1]) is None:
+        raise ChangelogPolicyError("changelog is missing the Unreleased section")
+
+    version_headings: list[tuple[int, str]] = []
+    for position, (index, heading) in enumerate(headings[1:], start=1):
+        parsed = _VERSION_HEADING.fullmatch(heading)
+        if parsed is None:
+            raise ChangelogPolicyError("stable version heading is invalid")
+        section_version, date_text = parsed.group(1), parsed.group(2)
+        try:
+            year, month, day = (int(part) for part in date_text.split("-"))
+            datetime.date(year, month, day)
+        except ValueError as error:
+            raise ChangelogPolicyError("stable version heading date is invalid") from error
+        version_headings.append((index, section_version))
+        next_index = headings[position + 1][0] if position + 1 < len(headings) else len(lines)
+        body = lines[index + 1 : next_index]
+        if section_version == version and not any(_BULLET_PATTERN.match(item) for item in body):
+            raise ChangelogPolicyError("stable version section has no entries")
+
+    unreleased_end = headings[1][0] if len(headings) > 1 else len(lines)
+    unreleased_body = lines[headings[0][0] + 1 : unreleased_end]
+    if any(_BULLET_PATTERN.match(item) for item in unreleased_body):
+        raise ChangelogPolicyError("Unreleased section still contains changelog entries")
+
+    if not version_headings:
+        raise ChangelogPolicyError("changelog is missing the required stable version section")
+
+    seen: set[str] = set()
+    for _, section_version in version_headings:
+        if section_version in seen:
+            raise ChangelogPolicyError("changelog contains a duplicate version heading")
+        seen.add(section_version)
+
+    if version not in seen:
+        raise ChangelogPolicyError("changelog is missing the required stable version section")
+    if version_headings[0][1] != version:
+        raise ChangelogPolicyError("stable version section is not the first version after Unreleased")
+
+
+def _read_changelog(path_value: str) -> str:
+    path = Path(path_value)
+    try:
+        with path.open("rb") as source:
+            data = source.read(_MAX_CHANGELOG_BYTES + 1)
+        if len(data) > _MAX_CHANGELOG_BYTES:
+            raise ChangelogPolicyError("changelog exceeds the allowed size")
+        return data.decode("utf-8-sig")
+    except ChangelogPolicyError:
+        raise
+    except (OSError, UnicodeDecodeError) as error:
+        raise ChangelogPolicyError("invalid changelog input") from error
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--changelog", required=True)
+    parser.add_argument("--version", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the changelog gate and return a process status without exposing inputs."""
+    arguments = _parser().parse_args(argv)
+    try:
+        validate_stable_changelog(_read_changelog(arguments.changelog), arguments.version)
+    except ChangelogPolicyError as error:
+        print(f"changelog policy validation failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/tests/test_changelog_branch_policy.py
+++ b/scripts/release/tests/test_changelog_branch_policy.py
@@ -1,0 +1,95 @@
+"""PRs into dev must not edit CHANGELOG.md except official release-prep or main sync."""
+
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from changelog_branch_policy import ChangelogBranchPolicyError, validate_dev_changelog_change
+
+
+SCRIPT = Path(__file__).parent.parent / "changelog_branch_policy.py"
+SECRET_REF = "feat/secret-changelog-ref"
+
+
+def run_policy(*arguments):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *arguments],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
+def test_allows_prs_that_do_not_touch_changelog():
+    validate_dev_changelog_change(
+        head_ref="feat/channel",
+        changelog_changed=False,
+        head_matches_main=False,
+    )
+
+
+def test_allows_main_to_dev_sync_even_when_changelog_changed():
+    validate_dev_changelog_change(
+        head_ref="main",
+        changelog_changed=True,
+        head_matches_main=True,
+    )
+
+
+def test_allows_official_release_prep_branch():
+    validate_dev_changelog_change(
+        head_ref="chore/release-v0.9.0",
+        changelog_changed=True,
+        head_matches_main=False,
+    )
+
+
+def test_allows_restoring_changelog_to_match_main():
+    validate_dev_changelog_change(
+        head_ref="fix/restore-changelog",
+        changelog_changed=True,
+        head_matches_main=True,
+    )
+
+
+def test_rejects_feature_pr_changelog_edits_that_do_not_match_main():
+    with pytest.raises(ChangelogBranchPolicyError, match="CHANGELOG"):
+        validate_dev_changelog_change(
+            head_ref="feat/channel",
+            changelog_changed=True,
+            head_matches_main=False,
+        )
+
+
+def test_cli_rejects_feature_changelog_edit_without_echoing_the_ref():
+    result = run_policy(
+        "--head-ref",
+        SECRET_REF,
+        "--changelog-changed",
+        "true",
+        "--head-matches-main",
+        "false",
+    )
+
+    assert result.returncode == 1
+    assert "Traceback" not in result.stderr
+    assert SECRET_REF not in result.stderr
+    assert SECRET_REF not in result.stdout
+    assert result.stderr.startswith("changelog branch policy validation failed:")
+
+
+def test_cli_accepts_unchanged_changelog():
+    result = run_policy(
+        "--head-ref",
+        SECRET_REF,
+        "--changelog-changed",
+        "false",
+        "--head-matches-main",
+        "false",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert result.stderr == ""

--- a/scripts/release/tests/test_changelog_policy.py
+++ b/scripts/release/tests/test_changelog_policy.py
@@ -1,0 +1,161 @@
+"""Stable changelog gate: official releases must close Unreleased into the version section."""
+
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from changelog_policy import ChangelogPolicyError, validate_stable_changelog
+
+
+SCRIPT = Path(__file__).parent.parent / "changelog_policy.py"
+VERSION = "v0.9.0"
+SECRET = "secret-changelog-body"
+
+
+def valid_changelog(version=VERSION, *, unreleased="", body="- fix a user-visible bug."):
+    return (
+        "# Changelog\n"
+        "\n"
+        "## [Unreleased]\n"
+        "\n"
+        "### Added\n"
+        "\n"
+        f"{unreleased}"
+        "### Fixed\n"
+        "\n"
+        f"## [{version}] - 2026-08-26\n"
+        "\n"
+        "### Fixed\n"
+        "\n"
+        f"{body}\n"
+        "\n"
+        "## [v0.8.2] - 2026-08-18\n"
+        "\n"
+        "### Fixed\n"
+        "\n"
+        "- older stable fix.\n"
+    )
+
+
+def run_policy(*arguments):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *arguments],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
+def test_accepts_closed_unreleased_and_matching_version_section():
+    validate_stable_changelog(valid_changelog(), VERSION)
+
+
+def test_accepts_crlf_and_blank_unreleased_categories():
+    validate_stable_changelog(valid_changelog().replace("\n", "\r\n"), VERSION)
+
+
+def test_rejects_dev_version_argument():
+    with pytest.raises(ChangelogPolicyError, match="stable format"):
+        validate_stable_changelog(valid_changelog(), "v0.9.0-dev.1")
+
+
+def test_rejects_missing_unreleased_section():
+    text = valid_changelog().replace("## [Unreleased]\n\n### Added\n\n### Fixed\n\n", "")
+    with pytest.raises(ChangelogPolicyError, match="Unreleased"):
+        validate_stable_changelog(text, VERSION)
+
+
+def test_rejects_unreleased_leftover_bullet():
+    with pytest.raises(ChangelogPolicyError, match="Unreleased"):
+        validate_stable_changelog(
+            valid_changelog(unreleased="- leftover channel note.\n\n"),
+            VERSION,
+        )
+
+
+def test_rejects_missing_required_version_section():
+    with pytest.raises(ChangelogPolicyError, match="version section"):
+        validate_stable_changelog(valid_changelog(version="v0.9.1"), VERSION)
+
+
+def test_rejects_version_section_that_is_not_first_after_unreleased():
+    text = (
+        "# Changelog\n"
+        "\n"
+        "## [Unreleased]\n"
+        "\n"
+        "## [v0.8.2] - 2026-08-18\n"
+        "\n"
+        "- older fix.\n"
+        "\n"
+        "## [v0.9.0] - 2026-08-26\n"
+        "\n"
+        "- too late.\n"
+    )
+    with pytest.raises(ChangelogPolicyError, match="first version"):
+        validate_stable_changelog(text, VERSION)
+
+
+def test_rejects_version_section_without_entries():
+    with pytest.raises(ChangelogPolicyError, match="no entries"):
+        validate_stable_changelog(valid_changelog(body=""), VERSION)
+
+
+def test_rejects_duplicate_version_heading():
+    text = valid_changelog() + "\n## [v0.9.0] - 2026-08-27\n\n- duplicate.\n"
+    with pytest.raises(ChangelogPolicyError, match="duplicate"):
+        validate_stable_changelog(text, VERSION)
+
+
+def test_rejects_version_heading_without_date():
+    text = valid_changelog().replace("## [v0.9.0] - 2026-08-26", "## [v0.9.0]")
+    with pytest.raises(ChangelogPolicyError, match="heading"):
+        validate_stable_changelog(text, VERSION)
+
+
+def test_rejects_invalid_version_date():
+    text = valid_changelog().replace("2026-08-26", "2026-13-40")
+    with pytest.raises(ChangelogPolicyError, match="date"):
+        validate_stable_changelog(text, VERSION)
+
+
+def test_cli_accepts_a_closed_changelog(tmp_path):
+    path = tmp_path / "CHANGELOG.md"
+    path.write_text(valid_changelog(), encoding="utf-8")
+
+    result = run_policy("--changelog", str(path), "--version", VERSION)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_cli_rejects_leftover_unreleased_without_echoing_inputs(tmp_path):
+    path = tmp_path / "CHANGELOG.md"
+    path.write_text(
+        valid_changelog(unreleased=f"- {SECRET}\n\n"),
+        encoding="utf-8",
+    )
+
+    result = run_policy("--changelog", str(path), "--version", VERSION)
+
+    assert result.returncode == 1
+    assert "Traceback" not in result.stderr
+    assert SECRET not in result.stderr
+    assert SECRET not in result.stdout
+    assert VERSION not in result.stderr
+    assert result.stderr.startswith("changelog policy validation failed:")
+
+
+def test_cli_rejects_oversized_changelog_without_echoing_it(tmp_path):
+    path = tmp_path / "CHANGELOG.md"
+    path.write_bytes(b"# Changelog\n" + b"x" * (1_048_576))
+
+    result = run_policy("--changelog", str(path), "--version", VERSION)
+
+    assert result.returncode == 1
+    assert "Traceback" not in result.stderr
+    assert "xxxx" not in result.stderr
+    assert VERSION not in result.stderr

--- a/scripts/release/tests/test_release_workflow.py
+++ b/scripts/release/tests/test_release_workflow.py
@@ -21,6 +21,7 @@ CHANGELOG_CHECK_WORKFLOW = (
 AGENTS = Path(__file__).resolve().parents[3] / "AGENTS.md"
 CONTRIBUTING = Path(__file__).resolve().parents[3] / ".github" / "CONTRIBUTING.md"
 CONTRIBUTING_ZH_CN = Path(__file__).resolve().parents[3] / ".github" / "CONTRIBUTING.zh-CN.md"
+PR_TEMPLATE = Path(__file__).resolve().parents[3] / ".github" / "PULL_REQUEST_TEMPLATE.md"
 RELEASE_DOCUMENT = Path(__file__).resolve().parents[3] / "docs" / "RELEASE.md"
 DISTRIBUTION_DOCUMENT = Path(__file__).resolve().parents[3] / "docs" / "distribution.md"
 DESIGN_DOCUMENT = (
@@ -1282,10 +1283,16 @@ def test_ci_runs_release_safety_suite_from_pinned_requirements_on_all_integratio
 
 def test_branch_governance_keeps_feature_work_off_main_and_dev_without_promising_review_rules():
     agents = AGENTS.read_text(encoding="utf-8")
+    contributing = CONTRIBUTING.read_text(encoding="utf-8")
     contributing_zh_cn = CONTRIBUTING_ZH_CN.read_text(encoding="utf-8")
+    pr_template = PR_TEMPLATE.read_text(encoding="utf-8")
     normalized_agents = agents.replace("`", "")
 
     assert "功能 PR 不得修改 CHANGELOG.md" in normalized_agents
+    assert "CHANGELOG.md" in agents[agents.index("## 8. 变更检查清单") : agents.index("## 9. Commit 规范")]
+    assert "must not modify `CHANGELOG.md`" in contributing
+    assert "CHANGELOG.md" in pr_template
+    assert "chore/release-" in pr_template
     assert "main 或 dev 分支上直接修改或提交" in normalized_agents
     assert "一次性 main PR" in normalized_agents
     assert "main 或 dev 分支创建 commit" in normalized_agents

--- a/scripts/release/tests/test_release_workflow.py
+++ b/scripts/release/tests/test_release_workflow.py
@@ -31,6 +31,7 @@ DESIGN_DOCUMENT = (
 RELEASE_SAFETY_TESTS = (
     "scripts/release/tests/test_release_policy.py "
     "scripts/release/tests/test_github_release_policy.py "
+    "scripts/release/tests/test_changelog_policy.py "
     "scripts/release/tests/test_release_workflow.py "
     "scripts/release/tests/test_alist_client.py "
     "scripts/release/tests/test_alist_index.py "
@@ -1502,6 +1503,68 @@ def test_release_document_uses_main_dispatch_as_the_stable_runbook():
     assert "不要把本地创建并推送 tag 作为当前稳定发版操作" in runbook
     assert "兼容入口仍接受 `v*` tag push" in stable_dispatch
     assert "不作为当前人工 runbook" in stable_dispatch
+
+
+def test_stable_release_validates_changelog_before_build_and_publish():
+    workflow = STABLE_WORKFLOW.read_text(encoding="utf-8")
+    document = yaml.safe_load(workflow)
+    resolve_steps = document["jobs"]["resolve"]["steps"]
+    release_steps = document["jobs"]["release"]["steps"]
+
+    resolve_source = next(
+        index for index, step in enumerate(resolve_steps) if step.get("name") == "Resolve immutable source commit"
+    )
+    resolve_changelog = next(
+        index for index, step in enumerate(resolve_steps) if step.get("name") == "Validate stable changelog"
+    )
+    release_gate = next(
+        index for index, step in enumerate(release_steps) if step.get("name") == "Version gate (final)"
+    )
+    release_changelog = next(
+        index for index, step in enumerate(release_steps) if step.get("name") == "Validate stable changelog"
+    )
+    release_tag = next(
+        index
+        for index, step in enumerate(release_steps)
+        if step.get("name") == "Create or verify current stable tag"
+    )
+
+    assert resolve_source < resolve_changelog
+    assert release_gate < release_changelog < release_tag
+    assert resolve_steps[resolve_changelog]["if"] == "steps.gate.outputs.should_resolve == 'true'"
+    for step in (resolve_steps[resolve_changelog], release_steps[release_changelog]):
+        run = step["run"]
+        assert "scripts/release/changelog_policy.py" in run
+        assert "--changelog CHANGELOG.md" in run
+        assert '--version "${VERSION}"' in run
+        assert "echo" not in run
+        assert "${VERSION}" not in run.replace('"${VERSION}"', "")
+
+
+def test_dev_release_does_not_require_changelog_gate():
+    dev_release = WORKFLOW.read_text(encoding="utf-8")
+    retract_dev = RETRACT_DEV_WORKFLOW.read_text(encoding="utf-8")
+    retract_stable = STABLE_RETRACT_WORKFLOW.read_text(encoding="utf-8")
+
+    for document in (dev_release, retract_dev, retract_stable):
+        assert "changelog_policy.py" not in document
+        assert "Validate stable changelog" not in document
+
+
+def test_release_document_requires_changelog_gate_for_stable_only():
+    release = RELEASE_DOCUMENT.read_text(encoding="utf-8")
+    runbook = _markdown_section(release, "## 发版流程")
+    stable_dispatch = _markdown_section(release, "## 手动触发发布")
+    checklist = _markdown_section(release, "## CI/CD 检查项")
+    dev_dispatch = stable_dispatch[stable_dispatch.index("### Dev 手动发布") :]
+
+    assert "CHANGELOG" in runbook
+    assert "Unreleased" in runbook
+    assert "fail closed" in runbook.lower() or "fail-closed" in runbook.lower() or "fail closed" in checklist.lower()
+    assert "`release.yml`" in checklist or "release.yml" in checklist
+    assert "CHANGELOG" in checklist
+    assert "dev" in dev_dispatch.lower()
+    assert "不要求" in dev_dispatch or "不必" in dev_dispatch or "不校验 CHANGELOG" in dev_dispatch
 
 
 def test_release_documents_scope_existing_asset_preflight_to_dev():

--- a/scripts/release/tests/test_release_workflow.py
+++ b/scripts/release/tests/test_release_workflow.py
@@ -1291,6 +1291,8 @@ def test_branch_governance_keeps_feature_work_off_main_and_dev_without_promising
     assert "功能 PR 不得修改 CHANGELOG.md" in normalized_agents
     assert "CHANGELOG.md" in agents[agents.index("## 8. 变更检查清单") : agents.index("## 9. Commit 规范")]
     assert "must not modify `CHANGELOG.md`" in contributing
+    assert "do not modify or commit `CHANGELOG.md`" in contributing
+    assert "不会修改或提交 `CHANGELOG.md`" in contributing_zh_cn
     assert "CHANGELOG.md" in pr_template
     assert "chore/release-" in pr_template
     assert "main 或 dev 分支上直接修改或提交" in normalized_agents

--- a/scripts/release/tests/test_release_workflow.py
+++ b/scripts/release/tests/test_release_workflow.py
@@ -15,6 +15,9 @@ RETRACT_DEV_WORKFLOW = Path(__file__).resolve().parents[3] / ".github" / "workfl
 STABLE_WORKFLOW = Path(__file__).resolve().parents[3] / ".github" / "workflows" / "release.yml"
 STABLE_RETRACT_WORKFLOW = Path(__file__).resolve().parents[3] / ".github" / "workflows" / "retract.yml"
 CI_WORKFLOW = Path(__file__).resolve().parents[3] / ".github" / "workflows" / "ci.yml"
+CHANGELOG_CHECK_WORKFLOW = (
+    Path(__file__).resolve().parents[3] / ".github" / "workflows" / "changelog-check.yml"
+)
 AGENTS = Path(__file__).resolve().parents[3] / "AGENTS.md"
 CONTRIBUTING = Path(__file__).resolve().parents[3] / ".github" / "CONTRIBUTING.md"
 CONTRIBUTING_ZH_CN = Path(__file__).resolve().parents[3] / ".github" / "CONTRIBUTING.zh-CN.md"
@@ -32,6 +35,7 @@ RELEASE_SAFETY_TESTS = (
     "scripts/release/tests/test_release_policy.py "
     "scripts/release/tests/test_github_release_policy.py "
     "scripts/release/tests/test_changelog_policy.py "
+    "scripts/release/tests/test_changelog_branch_policy.py "
     "scripts/release/tests/test_release_workflow.py "
     "scripts/release/tests/test_alist_client.py "
     "scripts/release/tests/test_alist_index.py "
@@ -1281,9 +1285,12 @@ def test_branch_governance_keeps_feature_work_off_main_and_dev_without_promising
     contributing_zh_cn = CONTRIBUTING_ZH_CN.read_text(encoding="utf-8")
     normalized_agents = agents.replace("`", "")
 
+    assert "功能 PR 不得修改 CHANGELOG.md" in normalized_agents
     assert "main 或 dev 分支上直接修改或提交" in normalized_agents
     assert "一次性 main PR" in normalized_agents
     assert "main 或 dev 分支创建 commit" in normalized_agents
+    assert "指向 `dev` 的功能 PR 不得修改 `CHANGELOG.md`" in contributing_zh_cn
+    assert "chore/release-*" in contributing_zh_cn
     assert "feat/*、fix/* ──PR──> dev ──晋级 PR──> main" in contributing_zh_cn
     assert "hotfix/*（从 main） ──PR──> main" in contributing_zh_cn
     assert "main ──同步 PR──> dev" in contributing_zh_cn
@@ -1541,6 +1548,23 @@ def test_stable_release_validates_changelog_before_build_and_publish():
         assert "${VERSION}" not in run.replace('"${VERSION}"', "")
 
 
+def test_changelog_check_workflow_gates_feature_prs_into_dev():
+    workflow = CHANGELOG_CHECK_WORKFLOW.read_text(encoding="utf-8")
+    document = yaml.safe_load(workflow)
+    job = document["jobs"]["check"]
+    policy = next(step for step in job["steps"] if step.get("name") == "Validate changelog ownership")
+
+    assert document[True]["pull_request"]["branches"] == ["dev"]
+    assert document["permissions"] == {"contents": "read"}
+    assert "changelog_branch_policy.py" in policy["run"]
+    assert policy["env"]["HEAD_REF"] == "${{ github.head_ref }}"
+    assert "${{ github.head_ref }}" not in policy["run"]
+    assert 'echo "${HEAD_REF}"' not in policy["run"]
+    assert "--head-ref \"${HEAD_REF}\"" in policy["run"] or '--head-ref "${HEAD_REF}"' in policy["run"]
+    assert "origin/main" in workflow
+    assert "CHANGELOG.md" in workflow
+
+
 def test_dev_release_does_not_require_changelog_gate():
     dev_release = WORKFLOW.read_text(encoding="utf-8")
     retract_dev = RETRACT_DEV_WORKFLOW.read_text(encoding="utf-8")
@@ -1565,6 +1589,8 @@ def test_release_document_requires_changelog_gate_for_stable_only():
     assert "CHANGELOG" in checklist
     assert "dev" in dev_dispatch.lower()
     assert "不要求" in dev_dispatch or "不必" in dev_dispatch or "不校验 CHANGELOG" in dev_dispatch
+    assert "不得修改" in release
+    assert "chore/release-" in release
 
 
 def test_release_documents_scope_existing_asset_preflight_to_dev():

--- a/scripts/release/tests/test_release_workflow.py
+++ b/scripts/release/tests/test_release_workflow.py
@@ -1598,6 +1598,10 @@ def test_release_document_requires_changelog_gate_for_stable_only():
     assert "不要求" in dev_dispatch or "不必" in dev_dispatch or "不校验 CHANGELOG" in dev_dispatch
     assert "不得修改" in release
     assert "chore/release-" in release
+    assert "### 1. 人手收口 CHANGELOG" in runbook
+    assert "人工 PR" in runbook
+    assert "不会修改 `CHANGELOG.md`" in runbook
+    assert "不会创建 `chore/release" in runbook
 
 
 def test_release_documents_scope_existing_asset_preflight_to_dev():


### PR DESCRIPTION
## 变更内容

1. 正式版 `release.yml` 在构建前和发布前 fail closed 读取同一 SHA 上的 `CHANGELOG.md`（Unreleased 必须清空，目标版本节必须存在且有条目）。dev 预发布不校验。
2. 指向 `dev` 的功能 PR 不得修改 `CHANGELOG.md`。CI workflow `changelog-check` 只允许：
   - 文件未改
   - 源分支是 `main`（同步）
   - 源分支是 `chore/release-*`（正式发版收口）
   - HEAD 的 CHANGELOG 与 `origin/main` 逐字节一致（把 `dev` 上误写的内容恢复回去）
3. 撤销 `dev` 上提前写入的 `[v0.9.0]` / Unreleased 条目，使 `CHANGELOG.md` 与 `main` 一致（停在 `v0.8.2`）。这些内容来自 #123、#124、#128、#129、#130、#137，应等到 `chore/release-v0.9.0` 再写。

## 类型

- [x] ci: 构建/发版流程
- [x] test: 测试
- [x] docs: 文档

## 检查清单

- [x] `python -m pytest` release-safety 套件 316 passed
- [x] 提交包含 `Signed-off-by`（DCO 签名）