### PR TITLE
chore: 将 main 上的 CI workflow 修复同步回 dev

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   check:
     name: Validate changelog ownership
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches: [main, dev, master]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   lint:

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,5 +1,6 @@
 name: DCO
 
+# Job id `check` is a required status on main and dev.
 on:
   pull_request:
   # Only run on branch pushes. Tag pushes have a zero SHA for event.before, which
@@ -13,6 +14,7 @@ permissions:
 
 jobs:
   check:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## 变更内容

`main` 在 v0.9.0 晋级后有 3 个尚未回到 `dev` 的 CI 修复（#173：重新登记已删除的 Actions workflow）。按流程做 `main → dev` 同步，**使用 merge commit，不要 squash**。

若 squash，`main` 上的 commit SHA 不会进入 `dev` 历史，随后的 `dev → main` 晋级 PR 仍会被判定 out-of-date。

合入后立刻开 `dev → main` 晋级 PR（head 必须是 `dev`），以满足 `pr-source-check`。

## 类型

- [x] chore: 构建/工具

## 检查清单

- [x] 同步 PR 使用 merge commit（不要 squash）
- [x] 未改 `CHANGELOG.md`
- [x] 提交包含 `Signed-off-by`（DCO 签名）

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mihari-proxy/mihari/pull/186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

