### PR TITLE
ci: 允许 main 向 dev 的同步 PR 通过来源检查

### DIFF
--- a/.github/workflows/pr-source-check.yml
+++ b/.github/workflows/pr-source-check.yml
@@ -5,17 +5,20 @@ permissions:
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   check-source:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR source branch
-        if: github.head_ref != 'dev' && !startsWith(github.head_ref, 'hotfix/')
+        if: github.base_ref == 'main' && github.head_ref != 'dev' && !startsWith(github.head_ref, 'hotfix/')
         env:
           HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
           echo "::error::PR to main must come from 'dev' or 'hotfix/*' branches."
+          echo "PRs from main may target dev (sync)."
           echo "Current source branch: $HEAD_REF"
+          echo "Current base branch: $BASE_REF"
           exit 1

--- a/scripts/release/tests/test_release_workflow.py
+++ b/scripts/release/tests/test_release_workflow.py
@@ -19,6 +19,9 @@ PAGES_WORKFLOW = Path(__file__).resolve().parents[3] / ".github" / "workflows" /
 CHANGELOG_CHECK_WORKFLOW = (
     Path(__file__).resolve().parents[3] / ".github" / "workflows" / "changelog-check.yml"
 )
+PR_SOURCE_CHECK_WORKFLOW = (
+    Path(__file__).resolve().parents[3] / ".github" / "workflows" / "pr-source-check.yml"
+)
 AGENTS = Path(__file__).resolve().parents[3] / "AGENTS.md"
 CONTRIBUTING = Path(__file__).resolve().parents[3] / ".github" / "CONTRIBUTING.md"
 CONTRIBUTING_ZH_CN = Path(__file__).resolve().parents[3] / ".github" / "CONTRIBUTING.zh-CN.md"
@@ -1609,6 +1612,24 @@ def test_changelog_check_workflow_gates_feature_prs_into_dev():
     assert "--head-ref \"${HEAD_REF}\"" in policy["run"] or '--head-ref "${HEAD_REF}"' in policy["run"]
     assert "origin/main" in workflow
     assert "CHANGELOG.md" in workflow
+
+
+def test_pr_source_check_allows_main_to_dev_sync_and_restricts_main_intake():
+    document = yaml.safe_load(PR_SOURCE_CHECK_WORKFLOW.read_text(encoding="utf-8"))
+    assert document[True]["pull_request"]["branches"] == ["main", "dev"]
+    assert document["permissions"] == {"contents": "read"}
+
+    step = document["jobs"]["check-source"]["steps"][0]
+    condition = " ".join(str(step.get("if", "")).split())
+    assert "github.base_ref == 'main'" in condition
+    assert "github.head_ref != 'dev'" in condition
+    assert "hotfix/" in condition
+    assert "github.head_ref != 'main'" not in condition
+
+    run = step["run"]
+    assert "PR to main must come from 'dev' or 'hotfix/*'" in run
+    assert "${{ github.head_ref }}" not in run
+    assert step["env"]["HEAD_REF"] == "${{ github.head_ref }}"
 
 
 def test_dev_release_does_not_require_changelog_gate():


### PR DESCRIPTION
## 变更内容

`pr-source-check.yml` 现在同时监听指向 `main` 和 `dev` 的 PR：

- 合进 **main**：来源仍必须是 `dev` 或 `hotfix/*`
- 合进 **dev**：允许 `main` 作为来源（官方 `main → dev` 同步），`feat/*` / `chore/*` 等日常 PR 也不拦

失败条件改为 `github.base_ref == ''main''` 时才检查 head。这样不会再把 `main → dev` 同步误判成非法晋级。

合进 **main** 仍禁止 `chore/promote-*` 这类非 `dev`/`hotfix/*` 分支。

## 类型

- [x] chore: 构建/工具

## 检查清单

- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] 未修改 `CHANGELOG.md`
- [x] 未修改协议 / CLI

## 相关 Issues

配合 #186 的 `main → dev` 同步与后续 `dev → main` 晋级。

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mihari-proxy/mihari/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

