### PR TITLE
fix: 允许在 main 上手动部署 GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - "site/**"
       - ".github/workflows/pages.yml"
+  workflow_dispatch:
 
 concurrency:
   group: pages
@@ -32,7 +33,7 @@ jobs:
 
   deploy:
     needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/scripts/release/tests/test_release_workflow.py
+++ b/scripts/release/tests/test_release_workflow.py
@@ -1321,6 +1321,19 @@ def test_pages_workflow_publishes_site_from_main_only():
     )
 
 
+def test_pages_workflow_allows_manual_deploy_from_main():
+    document = yaml.safe_load(PAGES_WORKFLOW.read_text(encoding="utf-8"))
+    triggers = document[True]
+    assert "workflow_dispatch" in triggers
+    assert triggers["push"]["branches"] == ["main"]
+
+    deploy = document["jobs"]["deploy"]
+    assert deploy["if"] == (
+        "github.ref == 'refs/heads/main' && "
+        "(github.event_name == 'push' || github.event_name == 'workflow_dispatch')"
+    )
+
+
 def test_branch_governance_keeps_feature_work_off_main_and_dev_without_promising_review_rules():
     agents = AGENTS.read_text(encoding="utf-8")
     contributing = CONTRIBUTING.read_text(encoding="utf-8")


### PR DESCRIPTION
## 变更内容

`https://mihari-proxy.github.io/mihari/` 目前 404。站点文件已经在 `main`，Pages 也已开通，但 `pages.yml` 的 deploy 只在 `push` 到 `main` 时运行，而这个仓库的 `main` 上不会产生任何 `on: push` 的 Actions run。同时 workflow 没有 `workflow_dispatch`，无法手动补发。

本次补上 `workflow_dispatch`，并允许在 `main` 上手动部署。本 PR 的 CI 仍只 build、不 deploy。

合并后在 `main` 上执行一次：

```
gh workflow run pages.yml --ref main
```

## 类型

- [ ] feat: 新功能
- [x] fix: Bug 修复
- [ ] refactor: 重构
- [ ] docs: 文档
- [ ] test: 测试
- [ ] chore: 构建/工具

## 检查清单

- [ ] `go test -race ./...` 通过（本次只改 workflow / Python 契约测试，未改 Go）
- [ ] `go vet ./...` 通过（未改 Go）
- [ ] `gofmt -l cmd internal` 无输出（未改 Go）
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] 未修改 `CHANGELOG.md`（`chore/release-*` 正式发版收口，或恢复成与 `main` 一致除外）
- [ ] 若修改了 `internal/control/protocol` 的契约、CLI 输出/退出码或跨平台行为，已在 PR 描述中说明影响

## 验证

- RED：`test_pages_workflow_allows_manual_deploy_from_main` 因缺少 `workflow_dispatch` 失败
- GREEN：`python -m pytest scripts/release/tests/test_release_workflow.py -q` → 78 passed
- `python -m pytest scripts/site/test_site.py -q` 一并通过

## 其他

`main` 上 `push` 不触发 Actions 是独立问题，本次不修。即使修好，`workflow_dispatch` 仍应保留为官网发布的兜底入口。

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mihari-proxy/mihari/pull/190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

