### PR TITLE
chore: 将 main 上的 GitHub Pages 热修同步回 dev

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - "site/**"
       - ".github/workflows/pages.yml"
+  workflow_dispatch:
 
 concurrency:
   group: pages
@@ -32,7 +33,7 @@ jobs:
 
   deploy:
     needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/scripts/release/tests/test_release_workflow.py
+++ b/scripts/release/tests/test_release_workflow.py
@@ -1321,6 +1321,19 @@ def test_pages_workflow_publishes_site_from_main_only():
     )
 
 
+def test_pages_workflow_allows_manual_deploy_from_main():
+    document = yaml.safe_load(PAGES_WORKFLOW.read_text(encoding="utf-8"))
+    triggers = document[True]
+    assert "workflow_dispatch" in triggers
+    assert triggers["push"]["branches"] == ["main"]
+
+    deploy = document["jobs"]["deploy"]
+    assert deploy["if"] == (
+        "github.ref == 'refs/heads/main' && "
+        "(github.event_name == 'push' || github.event_name == 'workflow_dispatch')"
+    )
+
+
 def test_branch_governance_keeps_feature_work_off_main_and_dev_without_promising_review_rules():
     agents = AGENTS.read_text(encoding="utf-8")
     contributing = CONTRIBUTING.read_text(encoding="utf-8")


### PR DESCRIPTION
## 变更内容

`main` 在 #189 之后多了 2 个尚未回到 `dev` 的提交（#190：允许在 main 上手动部署 GitHub Pages）。按流程做 `main → dev` 同步。

同步内容：

- `4a9435e` fix: 允许在 main 上手动部署 GitHub Pages
- `f778f5e` Merge pull request #190 from mihari-proxy/hotfix/pages-manual-deploy

`origin/dev` 是 `origin/main` 的祖先，无反向提交。

**必须用 merge commit 合并，不要 squash。** 若 squash，`main` 上的 commit SHA 不会进入 `dev` 历史，随后的 `dev → main` 晋级 PR 仍会被判定 out-of-date（#186 / #188 已踩过）。

## 类型

- [x] chore: 构建/工具

## 检查清单

- [x] 同步 PR 使用 merge commit（不要 squash）
- [x] 未改 `CHANGELOG.md`（与 `main` 一致）
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [ ] `go test -race ./...` 通过（由 CI 覆盖；本次仅为 workflow / 测试脚本，已在 #190 合入 `main`）
- [ ] `go vet ./...` 通过（同上）
- [ ] `gofmt -l cmd internal` 无输出（本次未改 Go 源码）

## 相关 Issues

同步 #190。


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mihari-proxy/mihari/pull/192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

