### PR TITLE
feat: 增加安全文件日志基础

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Mihari 是面向 Windows、Linux 和 macOS 的 mihomo 本地管理器。它使�
 
 - daemon 是持久化状态与 mihomo 生命周期的唯一所有者和写入者。
 - CLI、TUI 及其他本地客户端只通过 `internal/control/client` 和版本化本地控制协议访问 daemon，不直接修改 daemon 管理的业务文件。
-- **窄例外**：TUI 仅可通过 `internal/logging` 向固定 `mihari-tui.log*` 序列追加/轮转；不得扩展为 settings、订阅、token、面板或其他业务状态写入。settings 与业务状态仍只有 daemon/Manager 可写。
+- **窄例外**：TUI 仅可通过 `internal/logging` 确保共享日志目录存在，并向固定 `mihari-tui.log*` 序列追加/轮转；不得扩展为 settings、订阅、token、面板或其他业务状态写入。settings 与业务状态仍只有 daemon/Manager 可写。
 - 本地控制 API 使用 Windows named pipe 或 Unix domain socket，不得退化为 TCP 监听。
 - mihomo controller 仅绑定 loopback；浏览器不得获得 controller 地址或 secret。
 - 所有 Web 面板的 REST、WebSocket 与写操作必须经过 Mihari Web gateway 和统一 mutation coordinator；未知写操作默认拒绝。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,8 @@ Mihari 是面向 Windows、Linux 和 macOS 的 mihomo 本地管理器。它使�
 以下约束视为架构不变量：
 
 - daemon 是持久化状态与 mihomo 生命周期的唯一所有者和写入者。
-- CLI、未来 TUI 及其他本地客户端只通过 `internal/control/client` 和版本化本地控制协议访问 daemon，不直接修改 daemon 管理的文件。
+- CLI、TUI 及其他本地客户端只通过 `internal/control/client` 和版本化本地控制协议访问 daemon，不直接修改 daemon 管理的业务文件。
+- **窄例外**：TUI 仅可通过 `internal/logging` 向固定 `mihari-tui.log*` 序列追加/轮转；不得扩展为 settings、订阅、token、面板或其他业务状态写入。settings 与业务状态仍只有 daemon/Manager 可写。
 - 本地控制 API 使用 Windows named pipe 或 Unix domain socket，不得退化为 TCP 监听。
 - mihomo controller 仅绑定 loopback；浏览器不得获得 controller 地址或 secret。
 - 所有 Web 面板的 REST、WebSocket 与写操作必须经过 Mihari Web gateway 和统一 mutation coordinator；未知写操作默认拒绝。

--- a/README.md
+++ b/README.md
@@ -156,6 +156,20 @@ All release binaries are CGO-free.
 
 Settings, control token, runtime config, core binary, subscriptions, GeoIP, panel assets, logs, and staging all live under the data root.
 
+## File logs
+
+Mihari writes newline-delimited JSON (JSONL) to three files under the data root:
+
+| Source | Path |
+| --- | --- |
+| Mihari daemon | `logs/mihari-daemon.log` |
+| TUI (shared by all TUI instances) | `logs/mihari-tui.log` |
+| Captured mihomo output | `logs/mihomo.log` |
+
+The default file-log level is `info`, each active file rotates at 10 MiB, and three files (the active file plus up to two archives) are retained. Captured mihomo stdout is recorded as `INFO` and stderr as `WARN`; these capture levels do not infer the severity encoded in mihomo's own message text.
+
+Redaction is best effort only. Treat all log files as sensitive material and share them only after reviewing their contents. This release does not yet provide a logging configuration UI or log export.
+
 ## Development
 
 ```console

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Mihari writes newline-delimited JSON (JSONL) to three files under the data root:
 | TUI (shared by all TUI instances) | `logs/mihari-tui.log` |
 | Captured mihomo output | `logs/mihomo.log` |
 
-The default file-log level is `info`, each active file rotates at 10 MiB, and three files (the active file plus up to two archives) are retained. Captured mihomo stdout is recorded as `INFO` and stderr as `WARN`; these capture levels do not infer the severity encoded in mihomo's own message text.
+Daemon and captured-mihomo file logs use the default `info` level, rotate each active file at 10 MiB, and retain three files (the active file plus up to two archives). The TUI starts with its bootstrap configuration—`debug`, 100 MiB, and 10 files—so it can log before daemon settings are available; it remains on this bootstrap configuration until a later control-plane synchronization. Captured mihomo stdout is recorded as `INFO` and stderr as `WARN`; these capture levels do not infer the severity encoded in mihomo's own message text.
 
 Redaction is best effort only. Treat all log files as sensitive material and share them only after reviewing their contents. This release does not yet provide a logging configuration UI or log export.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -166,7 +166,7 @@ Mihari 会在数据根目录下写入三个 JSONL（每行一个 JSON 对象）�
 | TUI（所有 TUI 实例共享） | `logs/mihari-tui.log` |
 | 捕获的 mihomo 输出 | `logs/mihomo.log` |
 
-默认文件日志级别为 `info`，每个活跃文件到 10 MiB 时轮转，并保留三份文件（活跃文件加最多两份归档）。捕获的 mihomo stdout 记为 `INFO`，stderr 记为 `WARN`；这些捕获级别不代表 mihomo 行内文本本身的严重程度。
+守护进程与捕获的 mihomo 文件日志默认级别为 `info`，每个活跃文件到 10 MiB 时轮转，并保留三份文件（活跃文件加最多两份归档）。TUI 启动时使用 bootstrap 配置——级别 `debug`、100 MiB、10 份文件——以便在守护进程设置可用前也能记录日志；在后续控制面同步前会保持该 bootstrap 配置。捕获的 mihomo stdout 记为 `INFO`，stderr 记为 `WARN`；这些捕获级别不代表 mihomo 行内文本本身的严重程度。
 
 脱敏仅为尽力而为，仍应将所有日志文件按敏感资料处理，并在分享前审阅内容。本版本尚未提供日志配置 UI 或日志导出。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -156,6 +156,20 @@ mihari sysproxy enable
 
 设置、控制令牌、运行时配置、核心二进制、订阅、GeoIP、面板资产、日志与暂存都在数据根目录下。
 
+## 文件日志
+
+Mihari 会在数据根目录下写入三个 JSONL（每行一个 JSON 对象）文件：
+
+| 来源 | 路径 |
+| --- | --- |
+| Mihari 守护进程 | `logs/mihari-daemon.log` |
+| TUI（所有 TUI 实例共享） | `logs/mihari-tui.log` |
+| 捕获的 mihomo 输出 | `logs/mihomo.log` |
+
+默认文件日志级别为 `info`，每个活跃文件到 10 MiB 时轮转，并保留三份文件（活跃文件加最多两份归档）。捕获的 mihomo stdout 记为 `INFO`，stderr 记为 `WARN`；这些捕获级别不代表 mihomo 行内文本本身的严重程度。
+
+脱敏仅为尽力而为，仍应将所有日志文件按敏感资料处理，并在分享前审阅内容。本版本尚未提供日志配置 UI 或日志导出。
+
 ## 开发
 
 ```console

--- a/cmd/mihari/main.go
+++ b/cmd/mihari/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -141,7 +142,9 @@ func main() {
 				BinaryPath:     executable,
 				Elevated:       elevate.IsElevated,
 				Relaunch: func() error {
-					return platform.Relaunch(executable, tuiRelaunchArgs(executable), os.Environ())
+					return relaunchWithLocalRootCleanup(func() error {
+						return platform.Relaunch(executable, tuiRelaunchArgs(executable), os.Environ())
+					})
 				},
 				Input:  os.Stdin,
 				Output: os.Stdout,
@@ -156,6 +159,13 @@ func main() {
 
 func tuiRelaunchArgs(binary string) []string {
 	return []string{binary}
+}
+
+func relaunchWithLocalRootCleanup(relaunch func() error) error {
+	if err := closeCachedLocalRoot(); err != nil {
+		return fmt.Errorf("close Mihari data root before relaunch: %w", err)
+	}
+	return relaunch()
 }
 
 func isInteractiveTerminal(input, output *os.File) bool {

--- a/cmd/mihari/main.go
+++ b/cmd/mihari/main.go
@@ -2,9 +2,14 @@ package main
 
 import (
 	"context"
+	"errors"
+	"io"
+	"log/slog"
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
+	"sync"
 
 	"github.com/mihari-proxy/mihari/internal/app"
 	"github.com/mihari-proxy/mihari/internal/buildinfo"
@@ -16,33 +21,73 @@ import (
 	"github.com/mihari-proxy/mihari/internal/control/transport"
 	"github.com/mihari-proxy/mihari/internal/daemon"
 	"github.com/mihari-proxy/mihari/internal/elevate"
+	"github.com/mihari-proxy/mihari/internal/logging"
+	"github.com/mihari-proxy/mihari/internal/panel"
 	"github.com/mihari-proxy/mihari/internal/platform"
 	"github.com/mihari-proxy/mihari/internal/service"
+	"github.com/mihari-proxy/mihari/internal/subscription"
 	"github.com/mihari-proxy/mihari/internal/tui"
 	"github.com/mihari-proxy/mihari/internal/update"
 )
+
+var (
+	localRootOnce   sync.Once
+	localRootCached processLocalRoot
+	localRootErr    error
+
+	defaultAbsolutePaths = func() (platform.Paths, error) {
+		return platform.DefaultPaths().Absolute()
+	}
+	newPrivateFS = platform.NewPrivateFS
+	absPath      = filepath.Abs
+
+	afterDaemonLoggingOpen func(*slog.Logger)
+)
+
+type processLocalRoot struct {
+	Paths platform.Paths
+	FS    *platform.PrivateFS
+	Token string
+}
+
+type daemonRunDeps struct {
+	Paths         platform.Paths
+	PrivateFS     *platform.PrivateFS
+	Token         string
+	Version       string
+	Endpoint      string
+	Ready         chan<- struct{}
+	ServiceStatus func() (string, error)
+}
+
+type daemonLoggingResources struct {
+	StdoutCapture io.Closer
+	StderrCapture io.Closer
+	MihomoRuntime io.Closer
+	DaemonRuntime io.Closer
+	PrivateFS     io.Closer
+}
 
 func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
 	endpoint := transport.DefaultEndpoint()
-	token, setupError := credential.LoadOrCreate(transport.DefaultCredentialPath())
-	localClient := controlclient.New(endpoint, token)
+	localClient := controlclient.New(endpoint, "")
 	var serviceManager *service.Manager
 	ready := make(chan struct{})
 	runDaemonBody := func(ctx context.Context) error {
-		paths := platform.DefaultPaths()
-		if err := paths.EnsureDirs(); err != nil {
-			return protocol.APIError{Code: protocol.CodeDataFailure, Message: "create mihari data directories"}
-		}
-		sidecar := filepath.Join(paths.Bin, "core-channel")
-		settings, created, err := config.LoadOrCreateWithSidecar(paths.Settings, sidecar)
+		root, err := prepareLocalRoot()
 		if err != nil {
 			return err
 		}
-		assembly, err := app.BuildRuntimeWithOptions(paths, settings, buildinfo.Version, os.Stdout, os.Stderr, app.RuntimeBuildOptions{
-			InitialSetupRequired: created, SettingsPath: paths.Settings,
+		return runDaemonWith(ctx, daemonRunDeps{
+			Paths:     root.Paths,
+			PrivateFS: root.FS,
+			Token:     root.Token,
+			Version:   buildinfo.Version,
+			Endpoint:  endpoint,
+			Ready:     ready,
 			ServiceStatus: func() (string, error) {
 				if serviceManager == nil {
 					return string(service.StatusUnknown), nil
@@ -50,23 +95,6 @@ func main() {
 				kind, err := serviceManager.Status()
 				return string(kind), err
 			},
-		})
-		if err != nil {
-			return daemon.Run(ctx, daemon.Options{
-				Endpoint: endpoint,
-				Token:    token,
-				Version:  buildinfo.Version,
-				Ready:    ready,
-				Store:    app.NewDegradedStore(buildinfo.Version, err),
-			})
-		}
-		return daemon.Run(ctx, daemon.Options{
-			Endpoint: endpoint,
-			Token:    token,
-			Version:  buildinfo.Version,
-			Ready:    ready,
-			Store:    assembly.Store,
-			Runtime:  assembly.Manager,
 		})
 	}
 	// When SCM launches ImagePath `mihari.exe daemon`, the process is non-interactive.
@@ -92,8 +120,15 @@ func main() {
 		ServiceController:  serviceManager,
 		SelfUpdater:        selfUpdater,
 		OpenBrowser:        platform.OpenBrowser,
-		SetupError:         setupError,
 		Interactive:        isInteractiveTerminal(os.Stdin, os.Stdout),
+		PrepareLocalRoot: func() error {
+			root, err := prepareLocalRoot()
+			if err != nil {
+				return err
+			}
+			localClient.SetToken(root.Token)
+			return nil
+		},
 		RunTUI: func(ctx context.Context) error {
 			if executableError != nil {
 				return protocol.APIError{Code: protocol.CodeInternal, Message: "resolve Mihari executable path"}
@@ -114,7 +149,9 @@ func main() {
 		},
 		RunDaemon: runDaemon,
 	}
-	os.Exit(cli.Execute(ctx, os.Args[1:], os.Stdout, os.Stderr, dependencies))
+	code := cli.Execute(ctx, os.Args[1:], os.Stdout, os.Stderr, dependencies)
+	_ = closeCachedLocalRoot()
+	os.Exit(code)
 }
 
 func tuiRelaunchArgs(binary string) []string {
@@ -128,4 +165,232 @@ func isInteractiveTerminal(input, output *os.File) bool {
 	}
 	outputInfo, err := output.Stat()
 	return err == nil && outputInfo.Mode()&os.ModeCharDevice != 0
+}
+
+func prepareLocalRoot() (processLocalRoot, error) {
+	localRootOnce.Do(func() {
+		localRootCached, localRootErr = doPrepareLocalRoot()
+	})
+	return localRootCached, localRootErr
+}
+
+func doPrepareLocalRoot() (processLocalRoot, error) {
+	absolutePaths, err := defaultAbsolutePaths()
+	if err != nil {
+		return processLocalRoot{}, protocol.APIError{Code: protocol.CodeDataFailure, Message: "resolve Mihari data root"}
+	}
+	processFS, fsErr := newPrivateFS(absolutePaths.Root)
+	credPath, err := resolveCredentialPath(absolutePaths)
+	if err != nil {
+		return processLocalRoot{Paths: absolutePaths, FS: processFS}, protocol.APIError{Code: protocol.CodeDataFailure, Message: "resolve Mihari control credential"}
+	}
+	token, err := loadProcessToken(credPath, absolutePaths.Root, fsErr == nil)
+	if err != nil {
+		return processLocalRoot{Paths: absolutePaths, FS: processFS}, err
+	}
+	return processLocalRoot{Paths: absolutePaths, FS: processFS, Token: token}, nil
+}
+
+func resolveCredentialPath(absolutePaths platform.Paths) (string, error) {
+	value := os.Getenv("MIHARI_CONTROL_CREDENTIAL")
+	if value == "" {
+		return absolutePaths.ControlToken, nil
+	}
+	abs, err := absPath(value)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(abs), nil
+}
+
+func loadProcessToken(credPath, root string, fsOK bool) (string, error) {
+	if fsOK || !isInsideRoot(credPath, root) {
+		token, err := credential.LoadOrCreate(credPath)
+		if err == nil {
+			return token, nil
+		}
+		var apiError protocol.APIError
+		if errors.As(err, &apiError) {
+			if apiError.Code == "" {
+				apiError.Code = protocol.CodeDataFailure
+			}
+			return "", apiError
+		}
+		return "", protocol.APIError{Code: protocol.CodeDataFailure, Message: "local control setup failed"}
+	}
+	token, err := credential.Load(credPath)
+	if err != nil {
+		return "", nil
+	}
+	return token, nil
+}
+
+func isInsideRoot(path, root string) bool {
+	rel, err := filepath.Rel(filepath.Clean(root), filepath.Clean(path))
+	if err != nil {
+		return false
+	}
+	if rel == "." {
+		return true
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
+}
+
+func closeCachedLocalRoot() error {
+	if localRootCached.FS == nil {
+		return nil
+	}
+	return localRootCached.FS.Close()
+}
+
+func resetProcessLocalRoot() {
+	if localRootCached.FS != nil {
+		_ = localRootCached.FS.Close()
+	}
+	localRootOnce = sync.Once{}
+	localRootCached = processLocalRoot{}
+	localRootErr = nil
+	defaultAbsolutePaths = func() (platform.Paths, error) {
+		return platform.DefaultPaths().Absolute()
+	}
+	newPrivateFS = platform.NewPrivateFS
+	absPath = filepath.Abs
+	afterDaemonLoggingOpen = nil
+}
+
+func (r *daemonLoggingResources) Close() error {
+	if r == nil {
+		return nil
+	}
+	var errs []error
+	for _, closer := range []io.Closer{r.StdoutCapture, r.StderrCapture, r.MihomoRuntime, r.DaemonRuntime, r.PrivateFS} {
+		if closer == nil {
+			continue
+		}
+		errs = append(errs, closer.Close())
+	}
+	return errors.Join(errs...)
+}
+
+func runDaemonWith(ctx context.Context, deps daemonRunDeps) (resultErr error) {
+	if deps.PrivateFS == nil {
+		return protocol.APIError{Code: protocol.CodeDataFailure, Message: "create mihari data directories"}
+	}
+	resources := &daemonLoggingResources{PrivateFS: deps.PrivateFS}
+	var closeOnce sync.Once
+	closeResources := func() error {
+		var closeErr error
+		closeOnce.Do(func() {
+			closeErr = resources.Close()
+		})
+		return closeErr
+	}
+	defer func() {
+		resultErr = errors.Join(resultErr, closeResources())
+	}()
+
+	if err := deps.Paths.EnsureDirs(); err != nil {
+		return protocol.APIError{Code: protocol.CodeDataFailure, Message: "create mihari data directories"}
+	}
+	sidecar := filepath.Join(deps.Paths.Bin, "core-channel")
+	settings, created, err := config.LoadOrCreateWithSidecar(deps.Paths.Settings, sidecar)
+	if err != nil {
+		return err
+	}
+	if err := deps.PrivateFS.EnsureDir(deps.Paths.LogDir); err != nil {
+		return err
+	}
+
+	redactor := logging.NewRedactor()
+	redactor.ReplaceExact(collectLogSecrets(deps.Paths, deps.Token, settings))
+	reporter := logging.NewFailureReporter(os.Stderr, redactor, nil)
+	cfg := logging.DefaultConfig()
+
+	daemonRT, err := logging.Open(ctx, logging.RuntimeOptions{
+		BasePath:  deps.Paths.DaemonLog,
+		Component: "daemon",
+		Config:    cfg,
+		PrivateFS: deps.PrivateFS,
+		Redactor:  redactor,
+		Reporter:  reporter,
+	})
+	if err != nil {
+		return err
+	}
+	resources.DaemonRuntime = daemonRT
+
+	mihomoRT, err := logging.Open(ctx, logging.RuntimeOptions{
+		BasePath:  deps.Paths.MihomoLog,
+		Component: "mihomo",
+		Config:    cfg,
+		PrivateFS: deps.PrivateFS,
+		Redactor:  redactor,
+		Reporter:  reporter,
+	})
+	if err != nil {
+		return err
+	}
+	resources.MihomoRuntime = mihomoRT
+
+	stdoutCapture := logging.NewLineCaptureWriter(mihomoRT.Logger(), slog.LevelInfo, "stdout")
+	stderrCapture := logging.NewLineCaptureWriter(mihomoRT.Logger(), slog.LevelWarn, "stderr")
+	resources.StdoutCapture = stdoutCapture
+	resources.StderrCapture = stderrCapture
+	if afterDaemonLoggingOpen != nil {
+		afterDaemonLoggingOpen(daemonRT.Logger())
+	}
+
+	assembly, err := app.BuildRuntimeWithOptions(deps.Paths, settings, deps.Version, io.Discard, io.Discard, app.RuntimeBuildOptions{
+		InitialSetupRequired: created,
+		SettingsPath:         deps.Paths.Settings,
+		ServiceStatus:        deps.ServiceStatus,
+		MihomoStdout:         stdoutCapture,
+		MihomoStderr:         stderrCapture,
+		OnBackgroundError: func(component string, bgErr error) {
+			if bgErr == nil {
+				return
+			}
+			daemonRT.Logger().Error(bgErr.Error(), slog.String("component", component))
+		},
+	})
+	if err != nil {
+		return daemon.Run(ctx, daemon.Options{
+			Endpoint: deps.Endpoint,
+			Token:    deps.Token,
+			Version:  deps.Version,
+			Ready:    deps.Ready,
+			Store:    app.NewDegradedStore(deps.Version, err),
+		})
+	}
+	return daemon.Run(ctx, daemon.Options{
+		Endpoint: deps.Endpoint,
+		Token:    deps.Token,
+		Version:  deps.Version,
+		Ready:    deps.Ready,
+		Store:    assembly.Store,
+		Runtime:  assembly.Manager,
+	})
+}
+
+func collectLogSecrets(paths platform.Paths, token string, settings config.Settings) []string {
+	secrets := make([]string, 0, 8)
+	if token != "" {
+		secrets = append(secrets, token)
+	}
+	if settings.ControllerSecret != "" {
+		secrets = append(secrets, settings.ControllerSecret)
+	}
+	if cred, err := panel.LoadOrCreateCredential(paths.WebCredential); err == nil && cred != "" {
+		secrets = append(secrets, cred)
+	}
+	catalog, err := subscription.LoadOrCreate(paths.SubscriptionCatalog)
+	if err != nil {
+		return secrets
+	}
+	for _, profile := range catalog.Profiles {
+		if profile.URL != "" {
+			secrets = append(secrets, profile.URL)
+		}
+	}
+	return secrets
 }

--- a/cmd/mihari/main.go
+++ b/cmd/mihari/main.go
@@ -180,29 +180,24 @@ func main() {
 }
 
 func openTUILogging(ctx context.Context, paths platform.Paths, token string, fs *platform.PrivateFS) (tui.LoggingResources, error) {
-	resources := tui.LoggingResources{PrivateFS: fs}
-	resources.Health = &resources
+	redactor := logging.NewRedactor(token)
 	if fs == nil {
-		resources.Redactor = logging.NewRedactor(token)
-		return resources, errors.New("TUI logging private fs is unavailable")
+		return tui.NewLoggingResources(nil, redactor, nil), errors.New("TUI logging private fs is unavailable")
 	}
 	if err := fs.EnsureDir(paths.LogDir); err != nil {
-		resources.Redactor = logging.NewRedactor(token)
-		return resources, err
+		return tui.NewLoggingResources(nil, redactor, fs), err
 	}
-	resources.Redactor = logging.NewRedactor(token)
 	runtime, err := logging.Open(ctx, logging.RuntimeOptions{
 		BasePath:  paths.TUILog,
 		Component: "tui",
 		Config:    logging.BootstrapConfig(),
 		PrivateFS: fs,
-		Redactor:  resources.Redactor,
+		Redactor:  redactor,
 	})
 	if err != nil {
-		return resources, err
+		return tui.NewLoggingResources(nil, redactor, fs), err
 	}
-	resources.Runtime = runtime
-	return resources, nil
+	return tui.NewLoggingResources(runtime, redactor, fs), nil
 }
 
 func tuiRelaunchArgs(binary string) []string {

--- a/cmd/mihari/main.go
+++ b/cmd/mihari/main.go
@@ -148,6 +148,10 @@ func main() {
 			if executableError != nil {
 				return protocol.APIError{Code: protocol.CodeInternal, Message: "resolve Mihari executable path"}
 			}
+			root, err := prepareLocalRoot()
+			if err != nil {
+				return err
+			}
 			return tui.Run(ctx, tui.Options{
 				Client:         localClient,
 				Service:        serviceManager,
@@ -160,8 +164,12 @@ func main() {
 						return platform.Relaunch(executable, tuiRelaunchArgs(executable), os.Environ())
 					})
 				},
-				Input:  os.Stdin,
-				Output: os.Stdout,
+				Input:       os.Stdin,
+				Output:      os.Stdout,
+				ErrorOutput: os.Stderr,
+				OpenLogging: func(ctx context.Context) (tui.LoggingResources, error) {
+					return openTUILogging(ctx, root.Paths, root.Token, root.FS)
+				},
 			})
 		},
 		RunDaemon: runDaemon,
@@ -169,6 +177,32 @@ func main() {
 	code := cli.Execute(ctx, os.Args[1:], os.Stdout, os.Stderr, dependencies)
 	_ = closeCachedLocalRoot()
 	os.Exit(code)
+}
+
+func openTUILogging(ctx context.Context, paths platform.Paths, token string, fs *platform.PrivateFS) (tui.LoggingResources, error) {
+	resources := tui.LoggingResources{PrivateFS: fs}
+	resources.Health = &resources
+	if fs == nil {
+		resources.Redactor = logging.NewRedactor(token)
+		return resources, errors.New("TUI logging private fs is unavailable")
+	}
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		resources.Redactor = logging.NewRedactor(token)
+		return resources, err
+	}
+	resources.Redactor = logging.NewRedactor(token)
+	runtime, err := logging.Open(ctx, logging.RuntimeOptions{
+		BasePath:  paths.TUILog,
+		Component: "tui",
+		Config:    logging.BootstrapConfig(),
+		PrivateFS: fs,
+		Redactor:  resources.Redactor,
+	})
+	if err != nil {
+		return resources, err
+	}
+	resources.Runtime = runtime
+	return resources, nil
 }
 
 func tuiRelaunchArgs(binary string) []string {

--- a/cmd/mihari/main.go
+++ b/cmd/mihari/main.go
@@ -168,7 +168,7 @@ func main() {
 				Output:      os.Stdout,
 				ErrorOutput: os.Stderr,
 				OpenLogging: func(ctx context.Context) (tui.LoggingResources, error) {
-					return openTUILogging(ctx, root.Paths, root.Token, root.FS)
+					return openTUILogging(ctx, root.Paths, root.Token, root.FS, os.Stderr)
 				},
 			})
 		},
@@ -179,7 +179,7 @@ func main() {
 	os.Exit(code)
 }
 
-func openTUILogging(ctx context.Context, paths platform.Paths, token string, fs *platform.PrivateFS) (tui.LoggingResources, error) {
+func openTUILogging(ctx context.Context, paths platform.Paths, token string, fs *platform.PrivateFS, errorOutput io.Writer) (tui.LoggingResources, error) {
 	redactor := logging.NewRedactor(token)
 	if fs == nil {
 		return tui.NewLoggingResources(nil, redactor, nil), errors.New("TUI logging private fs is unavailable")
@@ -193,6 +193,7 @@ func openTUILogging(ctx context.Context, paths platform.Paths, token string, fs 
 		Config:    logging.BootstrapConfig(),
 		PrivateFS: fs,
 		Redactor:  redactor,
+		Reporter:  logging.NewFailureReporter(errorOutput, redactor, nil),
 	})
 	if err != nil {
 		return tui.NewLoggingResources(nil, redactor, fs), err

--- a/cmd/mihari/main.go
+++ b/cmd/mihari/main.go
@@ -69,6 +69,27 @@ type daemonLoggingResources struct {
 	PrivateFS     io.Closer
 }
 
+type daemonLoggingRuntime struct {
+	Closer io.Closer
+	Logger *slog.Logger
+}
+
+var (
+	newDaemonResources = func(privateFS io.Closer) *daemonLoggingResources {
+		return &daemonLoggingResources{PrivateFS: privateFS}
+	}
+	openDaemonRuntime = func(ctx context.Context, options logging.RuntimeOptions) (daemonLoggingRuntime, error) {
+		runtime, err := logging.Open(ctx, options)
+		if err != nil {
+			return daemonLoggingRuntime{}, err
+		}
+		return daemonLoggingRuntime{Closer: runtime, Logger: runtime.Logger()}, nil
+	}
+	newDaemonCapture   = logging.NewLineCaptureWriter
+	buildDaemonRuntime = app.BuildRuntimeWithOptions
+	runDaemon          = daemon.Run
+)
+
 func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
@@ -122,14 +143,7 @@ func main() {
 		SelfUpdater:        selfUpdater,
 		OpenBrowser:        platform.OpenBrowser,
 		Interactive:        isInteractiveTerminal(os.Stdin, os.Stdout),
-		PrepareLocalRoot: func() error {
-			root, err := prepareLocalRoot()
-			if err != nil {
-				return err
-			}
-			localClient.SetToken(root.Token)
-			return nil
-		},
+		PrepareLocalRoot:   prepareLocalRootForClient(localClient),
 		RunTUI: func(ctx context.Context) error {
 			if executableError != nil {
 				return protocol.APIError{Code: protocol.CodeInternal, Message: "resolve Mihari executable path"}
@@ -159,6 +173,17 @@ func main() {
 
 func tuiRelaunchArgs(binary string) []string {
 	return []string{binary}
+}
+
+func prepareLocalRootForClient(localClient *controlclient.Client) func() error {
+	return func() error {
+		root, err := prepareLocalRoot()
+		if err != nil {
+			return err
+		}
+		localClient.SetToken(root.Token)
+		return nil
+	}
 }
 
 func relaunchWithLocalRootCleanup(relaunch func() error) error {
@@ -286,7 +311,7 @@ func runDaemonWith(ctx context.Context, deps daemonRunDeps) (resultErr error) {
 	if deps.PrivateFS == nil {
 		return protocol.APIError{Code: protocol.CodeDataFailure, Message: "create mihari data directories"}
 	}
-	resources := &daemonLoggingResources{PrivateFS: deps.PrivateFS}
+	resources := newDaemonResources(deps.PrivateFS)
 	var closeOnce sync.Once
 	closeResources := func() error {
 		var closeErr error
@@ -316,7 +341,7 @@ func runDaemonWith(ctx context.Context, deps daemonRunDeps) (resultErr error) {
 	reporter := logging.NewFailureReporter(os.Stderr, redactor, nil)
 	cfg := logging.DefaultConfig()
 
-	daemonRT, err := logging.Open(ctx, logging.RuntimeOptions{
+	daemonRT, err := openDaemonRuntime(ctx, logging.RuntimeOptions{
 		BasePath:  deps.Paths.DaemonLog,
 		Component: "daemon",
 		Config:    cfg,
@@ -327,9 +352,9 @@ func runDaemonWith(ctx context.Context, deps daemonRunDeps) (resultErr error) {
 	if err != nil {
 		return err
 	}
-	resources.DaemonRuntime = daemonRT
+	resources.DaemonRuntime = daemonRT.Closer
 
-	mihomoRT, err := logging.Open(ctx, logging.RuntimeOptions{
+	mihomoRT, err := openDaemonRuntime(ctx, logging.RuntimeOptions{
 		BasePath:  deps.Paths.MihomoLog,
 		Component: "mihomo",
 		Config:    cfg,
@@ -340,17 +365,17 @@ func runDaemonWith(ctx context.Context, deps daemonRunDeps) (resultErr error) {
 	if err != nil {
 		return err
 	}
-	resources.MihomoRuntime = mihomoRT
+	resources.MihomoRuntime = mihomoRT.Closer
 
-	stdoutCapture := logging.NewLineCaptureWriter(mihomoRT.Logger(), slog.LevelInfo, "stdout")
-	stderrCapture := logging.NewLineCaptureWriter(mihomoRT.Logger(), slog.LevelWarn, "stderr")
+	stdoutCapture := newDaemonCapture(mihomoRT.Logger, slog.LevelInfo, "stdout")
+	stderrCapture := newDaemonCapture(mihomoRT.Logger, slog.LevelWarn, "stderr")
 	resources.StdoutCapture = stdoutCapture
 	resources.StderrCapture = stderrCapture
 	if afterDaemonLoggingOpen != nil {
-		afterDaemonLoggingOpen(daemonRT.Logger())
+		afterDaemonLoggingOpen(daemonRT.Logger)
 	}
 
-	assembly, err := app.BuildRuntimeWithOptions(deps.Paths, settings, deps.Version, io.Discard, io.Discard, app.RuntimeBuildOptions{
+	assembly, err := buildDaemonRuntime(deps.Paths, settings, deps.Version, io.Discard, io.Discard, app.RuntimeBuildOptions{
 		InitialSetupRequired: created,
 		SettingsPath:         deps.Paths.Settings,
 		ServiceStatus:        deps.ServiceStatus,
@@ -360,11 +385,11 @@ func runDaemonWith(ctx context.Context, deps daemonRunDeps) (resultErr error) {
 			if bgErr == nil {
 				return
 			}
-			daemonRT.Logger().Error(bgErr.Error(), slog.String("component", component))
+			daemonRT.Logger.Error(bgErr.Error(), slog.String("component", component))
 		},
 	})
 	if err != nil {
-		return daemon.Run(ctx, daemon.Options{
+		return runDaemon(ctx, daemon.Options{
 			Endpoint: deps.Endpoint,
 			Token:    deps.Token,
 			Version:  deps.Version,
@@ -372,7 +397,7 @@ func runDaemonWith(ctx context.Context, deps daemonRunDeps) (resultErr error) {
 			Store:    app.NewDegradedStore(deps.Version, err),
 		})
 	}
-	return daemon.Run(ctx, daemon.Options{
+	return runDaemon(ctx, daemon.Options{
 		Endpoint: deps.Endpoint,
 		Token:    deps.Token,
 		Version:  deps.Version,

--- a/cmd/mihari/main_test.go
+++ b/cmd/mihari/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -40,7 +41,7 @@ func TestOpenTUILogging_UsesInjectedPaths(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resources, err := openTUILogging(context.Background(), paths, "tui-control-token", fs)
+	resources, err := openTUILogging(context.Background(), paths, "tui-control-token", fs, io.Discard)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,9 +71,48 @@ func TestOpenTUILogging_UsesInjectedPaths(t *testing.T) {
 	}
 }
 
+func TestOpenTUILogging_RuntimeFailuresAreReported(t *testing.T) {
+	paths := absoluteTempPaths(t)
+	fs, err := platform.NewPrivateFS(paths.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var errorOutput bytes.Buffer
+	resources, err := openTUILogging(context.Background(), paths, "tui-control-token", fs, &errorOutput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = resources.Close() })
+	held, err := platform.OpenAdvisoryLock(fs, paths.TUILog+".lock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = held.Close() })
+	if err := held.Lock(context.Background(), platform.LockExclusive); err != nil {
+		t.Fatal(err)
+	}
+
+	for range 2 {
+		resources.Runtime.Logger().Info("runtime write failed",
+			slog.String("token", "tui-control-token"),
+			slog.String("path", paths.TUILog),
+		)
+	}
+	if err := held.Unlock(); err != nil {
+		t.Fatal(err)
+	}
+	warnings := errorOutput.String()
+	if got, want := warnings, "logging: dropped: lock wait exceeded\n"; got != want {
+		t.Fatalf("runtime warnings=%q want=%q", got, want)
+	}
+	if strings.Contains(warnings, "tui-control-token") || strings.Contains(warnings, paths.Root) || strings.Contains(warnings, paths.TUILog) {
+		t.Fatalf("runtime warning leaked secret or path: %q", warnings)
+	}
+}
+
 func TestOpenTUILogging_NilPrivateFSDoesNotCreateRoot(t *testing.T) {
 	paths := absoluteTempPaths(t)
-	resources, err := openTUILogging(context.Background(), paths, "tui-control-token", nil)
+	resources, err := openTUILogging(context.Background(), paths, "tui-control-token", nil, io.Discard)
 	if err == nil {
 		t.Fatal("nil PrivateFS did not report bootstrap failure")
 	}
@@ -95,7 +135,7 @@ func TestOpenTUILogging_CanceledContextRetainsPartialResources(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	resources, err := openTUILogging(ctx, paths, "tui-control-token", fs)
+	resources, err := openTUILogging(ctx, paths, "tui-control-token", fs, io.Discard)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("err=%v want context cancellation", err)
 	}
@@ -116,7 +156,7 @@ func TestOpenTUILogging_EnsureDirFailureRetainsPartialResources(t *testing.T) {
 	if err := fs.Close(); err != nil {
 		t.Fatal(err)
 	}
-	resources, err := openTUILogging(context.Background(), paths, "tui-control-token", fs)
+	resources, err := openTUILogging(context.Background(), paths, "tui-control-token", fs, io.Discard)
 	if err == nil {
 		t.Fatal("closed PrivateFS did not report EnsureDir failure")
 	}
@@ -471,7 +511,7 @@ func TestPrepareLocalRoot_RelativeDataRoot(t *testing.T) {
 	if root.Paths.DaemonLog != filepath.Join(wantRoot, "logs", "mihari-daemon.log") {
 		t.Fatalf("daemon log=%q", root.Paths.DaemonLog)
 	}
-	resources, err := openTUILogging(context.Background(), root.Paths, root.Token, root.FS)
+	resources, err := openTUILogging(context.Background(), root.Paths, root.Token, root.FS, io.Discard)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -603,7 +643,7 @@ func TestPrepareLocalRoot_ExplicitOutOfRootCredentialCreatesTUILog(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	resources, err := openTUILogging(context.Background(), root.Paths, root.Token, root.FS)
+	resources, err := openTUILogging(context.Background(), root.Paths, root.Token, root.FS, io.Discard)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/mihari/main_test.go
+++ b/cmd/mihari/main_test.go
@@ -100,6 +100,30 @@ func TestOpenTUILogging_CanceledContextRetainsPartialResources(t *testing.T) {
 	}
 }
 
+func TestOpenTUILogging_EnsureDirFailureRetainsPartialResources(t *testing.T) {
+	paths := absoluteTempPaths(t)
+	fs, err := platform.NewPrivateFS(paths.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fs.Close(); err != nil {
+		t.Fatal(err)
+	}
+	resources, err := openTUILogging(context.Background(), paths, "tui-control-token", fs)
+	if err == nil {
+		t.Fatal("closed PrivateFS did not report EnsureDir failure")
+	}
+	if resources.PrivateFS != fs || resources.Redactor == nil || resources.Runtime != nil {
+		t.Fatalf("resources=%+v", resources)
+	}
+	if resources.Health == nil || resources.Health.Available() {
+		t.Fatal("EnsureDir failure health was not unavailable")
+	}
+	if closeErr := resources.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+}
+
 func TestInteractiveTerminal_RejectsRedirectedStreams(t *testing.T) {
 	input, err := os.CreateTemp(t.TempDir(), "input")
 	if err != nil {

--- a/cmd/mihari/main_test.go
+++ b/cmd/mihari/main_test.go
@@ -427,6 +427,27 @@ func TestRunDaemon_CatalogLoadFailureStillOpensLogger(t *testing.T) {
 	}
 }
 
+func TestCollectLogSecretsReadsExistingBusinessSecrets(t *testing.T) {
+	paths := absoluteTempPaths(t)
+	settings := config.Defaults()
+	settings.ControllerSecret = "controller-secret"
+	webCredential := strings.Repeat("f", 64)
+	catalogURL := "https://provider.example/sub?token=catalog-secret"
+	if err := os.MkdirAll(filepath.Dir(paths.WebCredential), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.WebCredential, []byte(webCredential+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeCatalog(t, paths, catalogURL)
+
+	got := collectLogSecrets(paths, "control-token", settings)
+	want := []string{"control-token", "controller-secret", webCredential, catalogURL}
+	if !slices.Equal(got, want) {
+		t.Fatalf("secrets=%q want=%q", got, want)
+	}
+}
+
 func TestRunDaemon_NilPrivateFSReturnsDataFailure(t *testing.T) {
 	paths := platform.NewPaths(filepath.Join(t.TempDir(), "data"))
 	err := runDaemonWith(context.Background(), daemonRunDeps{
@@ -715,7 +736,7 @@ func TestPrepareLocalRoot_StatusUsesLoadedToken(t *testing.T) {
 	}
 }
 
-func TestPrepareLocalRoot_ExplicitCredentialTokenPropagatesToClientDaemonAndTUI(t *testing.T) {
+func TestPrepareLocalRoot_ExplicitCredentialTokenPropagatesToClientAndDaemon(t *testing.T) {
 	for _, test := range []struct {
 		name       string
 		credential func(t *testing.T, cwd string) string
@@ -774,11 +795,7 @@ func TestPrepareLocalRoot_ExplicitCredentialTokenPropagatesToClientDaemonAndTUI(
 			if err := prepareLocalRootForClient(localClient)(); err != nil {
 				t.Fatal(err)
 			}
-			tuiOptions := tui.Options{Client: localClient}
-			if tuiOptions.Client != localClient {
-				t.Fatal("TUI did not receive the prepared local client")
-			}
-			if _, err := tuiOptions.Client.Status(context.Background()); err != nil {
+			if _, err := localClient.Status(context.Background()); err != nil {
 				t.Fatal(err)
 			}
 

--- a/cmd/mihari/main_test.go
+++ b/cmd/mihari/main_test.go
@@ -1,9 +1,26 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/mihari-proxy/mihari/internal/cli"
+	"github.com/mihari-proxy/mihari/internal/config"
+	controlclient "github.com/mihari-proxy/mihari/internal/control/client"
+	"github.com/mihari-proxy/mihari/internal/control/protocol"
+	transporttest "github.com/mihari-proxy/mihari/internal/control/transport/testutil"
+	"github.com/mihari-proxy/mihari/internal/platform"
 )
 
 func TestTUIRelaunchArgsStartsDefaultTUI(t *testing.T) {
@@ -27,4 +44,530 @@ func TestInteractiveTerminal_RejectsRedirectedStreams(t *testing.T) {
 	if isInteractiveTerminal(input, output) {
 		t.Fatal("regular files must not be treated as an interactive terminal")
 	}
+}
+
+func TestDaemonLoggingResources_CloseOrderJoinsErrors(t *testing.T) {
+	var order []string
+	resources := &daemonLoggingResources{
+		StdoutCapture: orderCloser{name: "stdout", order: &order, err: errors.New("stdout close")},
+		StderrCapture: orderCloser{name: "stderr", order: &order, err: errors.New("stderr close")},
+		MihomoRuntime: orderCloser{name: "mihomo", order: &order, err: errors.New("mihomo close")},
+		DaemonRuntime: orderCloser{name: "daemon", order: &order, err: errors.New("daemon close")},
+		PrivateFS:     orderCloser{name: "fs", order: &order, err: errors.New("fs close")},
+	}
+	err := resources.Close()
+	wantOrder := []string{"stdout", "stderr", "mihomo", "daemon", "fs"}
+	if !slices.Equal(order, wantOrder) {
+		t.Fatalf("order=%q want=%q", order, wantOrder)
+	}
+	if err == nil {
+		t.Fatal("expected joined close errors")
+	}
+	for _, part := range []string{"stdout close", "stderr close", "mihomo close", "daemon close", "fs close"} {
+		if !strings.Contains(err.Error(), part) {
+			t.Fatalf("joined error %q missing %q", err, part)
+		}
+	}
+}
+
+func TestRunDaemon_LoggingOpensBeforeBuildRuntime(t *testing.T) {
+	paths := absoluteTempPaths(t)
+	fs, err := platform.NewPrivateFS(paths.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := "exact-control-token-value"
+	secret := strings.Repeat("c", 64)
+	catalogURL := "https://provider.example/sub?token=catalog-secret-value"
+	settings, holder := occupiedControllerSettings(t, secret)
+	t.Cleanup(func() { _ = holder.Close() })
+	writeSettings(t, paths, settings)
+	writeCatalog(t, paths, catalogURL)
+
+	afterDaemonLoggingOpen = func(logger *slog.Logger) {
+		logger.Info("probe " + token + " " + secret + " " + catalogURL)
+	}
+	t.Cleanup(func() { afterDaemonLoggingOpen = nil })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ready := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- runDaemonWith(ctx, daemonRunDeps{
+			Paths:     paths,
+			PrivateFS: fs,
+			Token:     token,
+			Version:   "test",
+			Endpoint:  transporttest.Endpoint(t),
+			Ready:     ready,
+		})
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("runDaemonWith did not stop")
+		}
+	})
+	select {
+	case <-ready:
+	case <-time.After(5 * time.Second):
+		t.Fatal("degraded daemon did not become ready")
+	}
+	daemonLog := readFileString(t, paths.DaemonLog)
+	if strings.TrimSpace(daemonLog) == "" {
+		t.Fatal("daemon JSONL missing after Open")
+	}
+	if _, err := os.Stat(paths.MihomoLog); err != nil {
+		t.Fatalf("mihomo log missing: %v", err)
+	}
+	for _, secretValue := range []string{token, secret, catalogURL} {
+		if strings.Contains(daemonLog, secretValue) {
+			t.Fatalf("secret %q leaked: %s", secretValue, daemonLog)
+		}
+	}
+}
+
+func TestRunDaemon_CatalogLoadFailureStillOpensLogger(t *testing.T) {
+	paths := absoluteTempPaths(t)
+	fs, err := platform.NewPrivateFS(paths.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	settings, holder := occupiedControllerSettings(t, strings.Repeat("d", 64))
+	t.Cleanup(func() { _ = holder.Close() })
+	writeSettings(t, paths, settings)
+	if err := os.MkdirAll(filepath.Dir(paths.SubscriptionCatalog), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.SubscriptionCatalog, []byte("not: [valid: catalog"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ready := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- runDaemonWith(ctx, daemonRunDeps{
+			Paths:     paths,
+			PrivateFS: fs,
+			Token:     "catalog-fail-token",
+			Version:   "test",
+			Endpoint:  transporttest.Endpoint(t),
+			Ready:     ready,
+		})
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("runDaemonWith did not stop")
+		}
+	})
+	select {
+	case <-ready:
+	case <-time.After(5 * time.Second):
+		t.Fatal("degraded daemon did not become ready after catalog failure")
+	}
+	if _, err := os.Stat(paths.DaemonLog); err != nil {
+		t.Fatalf("catalog failure returned before Open: %v", err)
+	}
+	if _, err := os.Stat(paths.MihomoLog); err != nil {
+		t.Fatalf("mihomo log missing: %v", err)
+	}
+}
+
+func TestRunDaemon_NilPrivateFSReturnsDataFailure(t *testing.T) {
+	paths := platform.NewPaths(filepath.Join(t.TempDir(), "data"))
+	err := runDaemonWith(context.Background(), daemonRunDeps{
+		Paths:    paths,
+		Token:    "token-value",
+		Version:  "test",
+		Endpoint: transporttest.Endpoint(t),
+	})
+	var apiError protocol.APIError
+	if !errors.As(err, &apiError) || apiError.Code != protocol.CodeDataFailure {
+		t.Fatalf("err=%v", err)
+	}
+	if _, statErr := os.Stat(paths.Settings); !os.IsNotExist(statErr) {
+		t.Fatalf("nil fs performed settings IO: %v", statErr)
+	}
+	if _, statErr := os.Stat(paths.Root); !os.IsNotExist(statErr) {
+		t.Fatalf("nil fs performed directory IO: %v", statErr)
+	}
+}
+
+func TestResolveCredentialPath_RelativeAndAbsolute(t *testing.T) {
+	resetProcessLocalRootForTest(t)
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	paths, err := platform.NewPaths(filepath.Join(cwd, "data")).Absolute()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("MIHARI_CONTROL_CREDENTIAL", "")
+	got, err := resolveCredentialPath(paths)
+	if err != nil || got != paths.ControlToken {
+		t.Fatalf("default path=%q err=%v want=%q", got, err, paths.ControlToken)
+	}
+
+	t.Setenv("MIHARI_CONTROL_CREDENTIAL", "relative.token")
+	got, err = resolveCredentialPath(paths)
+	wantRelative, absErr := filepath.Abs("relative.token")
+	if absErr != nil {
+		t.Fatal(absErr)
+	}
+	wantRelative = filepath.Clean(wantRelative)
+	if err != nil || got != wantRelative {
+		t.Fatalf("relative path=%q err=%v want=%q", got, err, wantRelative)
+	}
+
+	outside := filepath.Join(t.TempDir(), "outside.token")
+	t.Setenv("MIHARI_CONTROL_CREDENTIAL", outside)
+	got, err = resolveCredentialPath(paths)
+	if err != nil || got != filepath.Clean(outside) {
+		t.Fatalf("absolute path=%q err=%v want=%q", got, err, outside)
+	}
+}
+
+func TestPrepareLocalRoot_RelativeDataRoot(t *testing.T) {
+	resetProcessLocalRootForTest(t)
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	t.Setenv("MIHARI_DATA", "relative-data")
+	t.Setenv("MIHARI_CONTROL_CREDENTIAL", "")
+	root, err := prepareLocalRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantRoot, err := filepath.Abs("relative-data")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantRoot = filepath.Clean(wantRoot)
+	if root.Paths.Root != wantRoot {
+		t.Fatalf("root=%q want=%q", root.Paths.Root, wantRoot)
+	}
+	if root.FS == nil || root.Token == "" {
+		t.Fatalf("fs=%v token empty=%v", root.FS, root.Token == "")
+	}
+	if root.Paths.ControlToken != filepath.Join(wantRoot, "control.token") {
+		t.Fatalf("token path=%q", root.Paths.ControlToken)
+	}
+	if root.Paths.Settings != filepath.Join(wantRoot, "mihari.yaml") {
+		t.Fatalf("settings=%q", root.Paths.Settings)
+	}
+	if root.Paths.DaemonLog != filepath.Join(wantRoot, "logs", "mihari-daemon.log") {
+		t.Fatalf("daemon log=%q", root.Paths.DaemonLog)
+	}
+}
+
+func TestPrepareLocalRoot_UnsetDataUsesHome(t *testing.T) {
+	resetProcessLocalRootForTest(t)
+	home := t.TempDir()
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HOME", home)
+	t.Setenv("MIHARI_DATA", "")
+	t.Setenv("MIHARI_CONTROL_CREDENTIAL", "")
+	root, err := prepareLocalRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(home, ".mihari")
+	if root.Paths.Root != want {
+		t.Fatalf("root=%q want=%q", root.Paths.Root, want)
+	}
+}
+
+func TestPrepareLocalRoot_AbsFailureDoesNoIO(t *testing.T) {
+	resetProcessLocalRootForTest(t)
+	rootDir := filepath.Join(t.TempDir(), "data")
+	t.Setenv("MIHARI_DATA", rootDir)
+	defaultAbsolutePaths = func() (platform.Paths, error) {
+		return platform.Paths{}, errors.New("abs failed")
+	}
+	_, err := prepareLocalRoot()
+	var apiError protocol.APIError
+	if !errors.As(err, &apiError) || apiError.Code != protocol.CodeDataFailure || apiError.Message != "resolve Mihari data root" {
+		t.Fatalf("err=%v", err)
+	}
+	if _, statErr := os.Stat(rootDir); !os.IsNotExist(statErr) {
+		t.Fatalf("data root IO after abs failure: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(rootDir, "control.token")); !os.IsNotExist(statErr) {
+		t.Fatalf("token IO after abs failure: %v", statErr)
+	}
+}
+
+func TestPrepareLocalRoot_NewPrivateFSFailureSkipsInRootCreate(t *testing.T) {
+	resetProcessLocalRootForTest(t)
+	rootDir := filepath.Join(t.TempDir(), "data")
+	t.Setenv("MIHARI_DATA", rootDir)
+	t.Setenv("MIHARI_CONTROL_CREDENTIAL", "")
+	newPrivateFS = func(string) (*platform.PrivateFS, error) {
+		return nil, errors.New("injected fs failure")
+	}
+	root, err := prepareLocalRoot()
+	if err != nil {
+		t.Fatalf("SetupError=%v", err)
+	}
+	if root.FS != nil {
+		t.Fatal("expected nil PrivateFS")
+	}
+	if root.Token != "" {
+		t.Fatalf("token=%q", root.Token)
+	}
+	if _, statErr := os.Stat(rootDir); !os.IsNotExist(statErr) {
+		t.Fatalf("MkdirAll/EnsureDirs created root: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(rootDir, "control.token")); !os.IsNotExist(statErr) {
+		t.Fatalf("LoadOrCreate created token: %v", statErr)
+	}
+}
+
+func TestPrepareLocalRoot_ExplicitInRootCredentialSkipsCreateAfterFSFailure(t *testing.T) {
+	resetProcessLocalRootForTest(t)
+	rootDir := filepath.Join(t.TempDir(), "data")
+	t.Setenv("MIHARI_DATA", rootDir)
+	t.Setenv("MIHARI_CONTROL_CREDENTIAL", filepath.Join(rootDir, "custom.token"))
+	newPrivateFS = func(string) (*platform.PrivateFS, error) {
+		return nil, errors.New("injected fs failure")
+	}
+	root, err := prepareLocalRoot()
+	if err != nil {
+		t.Fatalf("SetupError=%v", err)
+	}
+	if root.FS != nil || root.Token != "" {
+		t.Fatalf("fs=%v token=%q", root.FS, root.Token)
+	}
+	if _, statErr := os.Stat(filepath.Join(rootDir, "custom.token")); !os.IsNotExist(statErr) {
+		t.Fatalf("in-root credential was created: %v", statErr)
+	}
+}
+
+func TestPrepareLocalRoot_ExplicitOutOfRootCredentialCreatesAfterFSFailure(t *testing.T) {
+	resetProcessLocalRootForTest(t)
+	rootDir := filepath.Join(t.TempDir(), "data")
+	outside := filepath.Join(t.TempDir(), "outside.token")
+	t.Setenv("MIHARI_DATA", rootDir)
+	t.Setenv("MIHARI_CONTROL_CREDENTIAL", outside)
+	newPrivateFS = func(string) (*platform.PrivateFS, error) {
+		return nil, errors.New("injected fs failure")
+	}
+	root, err := prepareLocalRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if root.FS != nil {
+		t.Fatal("expected nil PrivateFS")
+	}
+	if root.Token == "" {
+		t.Fatal("expected out-of-root token")
+	}
+	if _, err := os.Stat(outside); err != nil {
+		t.Fatalf("expected LoadOrCreate of outside credential: %v", err)
+	}
+	if _, statErr := os.Stat(rootDir); !os.IsNotExist(statErr) {
+		t.Fatalf("data root created: %v", statErr)
+	}
+}
+
+func TestHelpCreatesNoDataRoot(t *testing.T) {
+	resetProcessLocalRootForTest(t)
+	rootDir := filepath.Join(t.TempDir(), "no-data")
+	t.Setenv("MIHARI_DATA", rootDir)
+	for _, args := range [][]string{{"--help"}, {"help"}, {"daemon", "--help"}, {"self", "version"}} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			resetProcessLocalRootForTest(t)
+			code := cli.Execute(context.Background(), args, io.Discard, io.Discard, productionLikeDependencies(t, nil))
+			if code != cli.ExitOK {
+				t.Fatalf("code=%d", code)
+			}
+			if _, err := os.Stat(rootDir); !os.IsNotExist(err) {
+				t.Fatalf("data root created for %v: %v", args, err)
+			}
+			if localRootCached.FS != nil {
+				t.Fatal("help/version cached a PrivateFS")
+			}
+		})
+	}
+}
+
+func TestPrepareLocalRoot_StatusUsesLoadedToken(t *testing.T) {
+	resetProcessLocalRootForTest(t)
+	rootDir := filepath.Join(t.TempDir(), "data")
+	t.Setenv("MIHARI_DATA", rootDir)
+	t.Setenv("MIHARI_CONTROL_CREDENTIAL", "")
+	token := strings.Repeat("ab", 32)
+	if err := os.MkdirAll(rootDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rootDir, "control.token"), []byte(token+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var sawAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		sawAuth = request.Header.Get("Authorization")
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{"schema":"mihari/v1","protocol_version":"v1","daemon_version":"dev","revision":1,"health":"ok","started_at":"1970-01-01T00:01:40Z"}`))
+	}))
+	t.Cleanup(server.Close)
+	localClient := controlclient.NewHTTP(server.URL, "", server.Client())
+	code := cli.Execute(context.Background(), []string{"status", "--json"}, io.Discard, io.Discard, cli.Dependencies{
+		StatusClient: localClient,
+		PrepareLocalRoot: func() error {
+			root, err := prepareLocalRoot()
+			if err != nil {
+				return err
+			}
+			localClient.SetToken(root.Token)
+			return nil
+		},
+	})
+	if code != cli.ExitOK {
+		t.Fatalf("code=%d", code)
+	}
+	if sawAuth != "Bearer "+token {
+		t.Fatalf("authorization=%q", sawAuth)
+	}
+}
+
+func TestPrepareLocalRoot_InteractiveRunTUIWithNilPrivateFS(t *testing.T) {
+	resetProcessLocalRootForTest(t)
+	rootDir := filepath.Join(t.TempDir(), "data")
+	t.Setenv("MIHARI_DATA", rootDir)
+	newPrivateFS = func(string) (*platform.PrivateFS, error) {
+		return nil, errors.New("injected fs failure")
+	}
+	var called bool
+	var sawFS *platform.PrivateFS
+	code := cli.Execute(context.Background(), []string{}, io.Discard, io.Discard, cli.Dependencies{
+		Interactive: true,
+		PrepareLocalRoot: func() error {
+			root, err := prepareLocalRoot()
+			if err != nil {
+				return err
+			}
+			sawFS = root.FS
+			return nil
+		},
+		RunTUI: func(context.Context) error {
+			called = true
+			return nil
+		},
+	})
+	if code != cli.ExitOK || !called {
+		t.Fatalf("code=%d called=%v", code, called)
+	}
+	if sawFS != nil {
+		t.Fatal("expected RunTUI with PrivateFS=nil")
+	}
+}
+
+type orderCloser struct {
+	name  string
+	order *[]string
+	err   error
+}
+
+func (c orderCloser) Close() error {
+	*c.order = append(*c.order, c.name)
+	return c.err
+}
+
+func resetProcessLocalRootForTest(t *testing.T) {
+	t.Helper()
+	resetProcessLocalRoot()
+	t.Cleanup(func() {
+		if localRootCached.FS != nil {
+			_ = localRootCached.FS.Close()
+		}
+		resetProcessLocalRoot()
+	})
+}
+
+func productionLikeDependencies(t *testing.T, runTUI func(context.Context) error) cli.Dependencies {
+	t.Helper()
+	localClient := controlclient.New("unused", "")
+	return cli.Dependencies{
+		StatusClient: localClient,
+		PrepareLocalRoot: func() error {
+			root, err := prepareLocalRoot()
+			if err != nil {
+				return err
+			}
+			localClient.SetToken(root.Token)
+			return nil
+		},
+		RunTUI: runTUI,
+	}
+}
+
+func absoluteTempPaths(t *testing.T) platform.Paths {
+	t.Helper()
+	paths, err := platform.NewPaths(filepath.Join(t.TempDir(), "data")).Absolute()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return paths
+}
+
+func occupiedControllerSettings(t *testing.T, secret string) (config.Settings, net.Listener) {
+	t.Helper()
+	listeners := make([]net.Listener, 0, 3)
+	addresses := make([]string, 0, 3)
+	for range 3 {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		listeners = append(listeners, listener)
+		addresses = append(addresses, listener.Addr().String())
+	}
+	if err := listeners[0].Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := listeners[2].Close(); err != nil {
+		t.Fatal(err)
+	}
+	settings := config.Defaults()
+	settings.MixedAddr = addresses[0]
+	settings.ControllerAddr = addresses[1]
+	settings.WebAddr = addresses[2]
+	settings.ControllerSecret = secret
+	return settings, listeners[1]
+}
+
+func writeSettings(t *testing.T, paths platform.Paths, settings config.Settings) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(paths.Settings), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.Save(paths.Settings, settings); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeCatalog(t *testing.T, paths platform.Paths, catalogURL string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(paths.SubscriptionCatalog), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	body := "schema: mihari.subscriptions/v1\nglobal-interval: 12h\nprofiles:\n" +
+		"  - id: 0123456789abcdef0123456789abcdef\n    name: probe\n    url: " + catalogURL + "\n    enabled: true\n"
+	if err := os.WriteFile(paths.SubscriptionCatalog, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readFileString(t *testing.T, path string) string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(raw)
 }

--- a/cmd/mihari/main_test.go
+++ b/cmd/mihari/main_test.go
@@ -34,6 +34,72 @@ func TestTUIRelaunchArgsStartsDefaultTUI(t *testing.T) {
 	}
 }
 
+func TestOpenTUILogging_UsesInjectedPaths(t *testing.T) {
+	paths := absoluteTempPaths(t)
+	fs, err := platform.NewPrivateFS(paths.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resources, err := openTUILogging(context.Background(), paths, "tui-control-token", fs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resources.PrivateFS != fs || resources.Redactor == nil || resources.Runtime == nil {
+		t.Fatalf("resources=%+v", resources)
+	}
+	if resources.Health == nil || !resources.Health.Available() {
+		t.Fatal("healthy TUI logger did not report available")
+	}
+	if got := resources.Runtime.Config(); got != logging.BootstrapConfig() {
+		t.Fatalf("bootstrap config=%+v want=%+v", got, logging.BootstrapConfig())
+	}
+	resources.Runtime.Logger().Debug("TUI startup token=tui-control-token")
+	if err := resources.Close(); err != nil {
+		t.Fatal(err)
+	}
+	logged := readFileString(t, paths.TUILog)
+	if strings.Contains(logged, "tui-control-token") || !strings.Contains(logged, "***") {
+		t.Fatalf("TUI log was not redacted: %s", logged)
+	}
+}
+
+func TestOpenTUILogging_NilPrivateFSDoesNotCreateRoot(t *testing.T) {
+	paths := absoluteTempPaths(t)
+	resources, err := openTUILogging(context.Background(), paths, "tui-control-token", nil)
+	if err == nil {
+		t.Fatal("nil PrivateFS did not report bootstrap failure")
+	}
+	if resources.PrivateFS != nil || resources.Redactor == nil {
+		t.Fatalf("resources=%+v", resources)
+	}
+	if resources.Health == nil || resources.Health.Available() {
+		t.Fatal("unavailable logger health was not retained")
+	}
+	if _, statErr := os.Stat(paths.Root); !os.IsNotExist(statErr) {
+		t.Fatalf("nil PrivateFS created data root: %v", statErr)
+	}
+}
+
+func TestOpenTUILogging_CanceledContextRetainsPartialResources(t *testing.T) {
+	paths := absoluteTempPaths(t)
+	fs, err := platform.NewPrivateFS(paths.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	resources, err := openTUILogging(ctx, paths, "tui-control-token", fs)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err=%v want context cancellation", err)
+	}
+	if resources.PrivateFS != fs || resources.Redactor == nil || resources.Runtime != nil {
+		t.Fatalf("resources=%+v", resources)
+	}
+	if closeErr := resources.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+}
+
 func TestInteractiveTerminal_RejectsRedirectedStreams(t *testing.T) {
 	input, err := os.CreateTemp(t.TempDir(), "input")
 	if err != nil {
@@ -374,6 +440,16 @@ func TestPrepareLocalRoot_RelativeDataRoot(t *testing.T) {
 	if root.Paths.DaemonLog != filepath.Join(wantRoot, "logs", "mihari-daemon.log") {
 		t.Fatalf("daemon log=%q", root.Paths.DaemonLog)
 	}
+	resources, err := openTUILogging(context.Background(), root.Paths, root.Token, root.FS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resources.PrivateFS != root.FS || resources.Runtime == nil {
+		t.Fatalf("resources=%+v", resources)
+	}
+	if err := resources.Close(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestPrepareLocalRoot_UnsetDataUsesHome(t *testing.T) {
@@ -483,6 +559,28 @@ func TestPrepareLocalRoot_ExplicitOutOfRootCredentialCreatesAfterFSFailure(t *te
 	}
 	if _, statErr := os.Stat(rootDir); !os.IsNotExist(statErr) {
 		t.Fatalf("data root created: %v", statErr)
+	}
+}
+
+func TestPrepareLocalRoot_ExplicitOutOfRootCredentialCreatesTUILog(t *testing.T) {
+	resetProcessLocalRootForTest(t)
+	rootDir := filepath.Join(t.TempDir(), "data")
+	credentialPath := filepath.Join(t.TempDir(), "credentials", "control.token")
+	t.Setenv("MIHARI_DATA", rootDir)
+	t.Setenv("MIHARI_CONTROL_CREDENTIAL", credentialPath)
+	root, err := prepareLocalRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	resources, err := openTUILogging(context.Background(), root.Paths, root.Token, root.FS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(root.Paths.TUILog); err != nil {
+		t.Fatalf("TUI log=%q: %v", root.Paths.TUILog, err)
+	}
+	if err := resources.Close(); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/cmd/mihari/main_test.go
+++ b/cmd/mihari/main_test.go
@@ -50,11 +50,18 @@ func TestOpenTUILogging_UsesInjectedPaths(t *testing.T) {
 	if resources.Health == nil || !resources.Health.Available() {
 		t.Fatal("healthy TUI logger did not report available")
 	}
+	if _, isResourcePointer := resources.Health.(*tui.LoggingResources); isResourcePointer {
+		t.Fatal("healthy TUI logger health points at a returned-value copy")
+	}
 	if got := resources.Runtime.Config(); got != logging.BootstrapConfig() {
 		t.Fatalf("bootstrap config=%+v want=%+v", got, logging.BootstrapConfig())
 	}
 	resources.Runtime.Logger().Debug("TUI startup token=tui-control-token")
+	copyOfResources := resources
 	if err := resources.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyOfResources.Close(); err != nil {
 		t.Fatal(err)
 	}
 	logged := readFileString(t, paths.TUILog)

--- a/cmd/mihari/main_test.go
+++ b/cmd/mihari/main_test.go
@@ -46,6 +46,31 @@ func TestInteractiveTerminal_RejectsRedirectedStreams(t *testing.T) {
 	}
 }
 
+func TestRelaunchWithLocalRootCleanup_ClosesPrivateFSBeforeRelaunch(t *testing.T) {
+	resetProcessLocalRootForTest(t)
+	paths := absoluteTempPaths(t)
+	fs, err := platform.NewPrivateFS(paths.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	localRootCached = processLocalRoot{Paths: paths, FS: fs}
+
+	called := false
+	err = relaunchWithLocalRootCleanup(func() error {
+		called = true
+		if err := fs.EnsureDir(paths.LogDir); err == nil {
+			t.Fatal("PrivateFS remained open when relaunch began")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Fatal("relaunch callback was not called")
+	}
+}
+
 func TestDaemonLoggingResources_CloseOrderJoinsErrors(t *testing.T) {
 	var order []string
 	resources := &daemonLoggingResources{

--- a/cmd/mihari/main_test.go
+++ b/cmd/mihari/main_test.go
@@ -15,12 +15,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mihari-proxy/mihari/internal/app"
 	"github.com/mihari-proxy/mihari/internal/cli"
 	"github.com/mihari-proxy/mihari/internal/config"
 	controlclient "github.com/mihari-proxy/mihari/internal/control/client"
 	"github.com/mihari-proxy/mihari/internal/control/protocol"
 	transporttest "github.com/mihari-proxy/mihari/internal/control/transport/testutil"
+	"github.com/mihari-proxy/mihari/internal/daemon"
+	"github.com/mihari-proxy/mihari/internal/logging"
 	"github.com/mihari-proxy/mihari/internal/platform"
+	"github.com/mihari-proxy/mihari/internal/tui"
 )
 
 func TestTUIRelaunchArgsStartsDefaultTUI(t *testing.T) {
@@ -95,6 +99,86 @@ func TestDaemonLoggingResources_CloseOrderJoinsErrors(t *testing.T) {
 	}
 }
 
+func TestRunDaemonWith_ClosesResourcesOnceForEveryExit(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		openError string
+		buildErr  error
+		runErr    error
+		wantOrder []string
+	}{
+		{name: "normal", wantOrder: []string{"run", "stdout", "stderr", "mihomo", "daemon", "fs"}},
+		{name: "degraded", buildErr: errors.New("build failed"), wantOrder: []string{"run", "stdout", "stderr", "mihomo", "daemon", "fs"}},
+		{name: "build runtime failure", buildErr: errors.New("build failed"), runErr: errors.New("daemon failed"), wantOrder: []string{"run", "stdout", "stderr", "mihomo", "daemon", "fs"}},
+		{name: "daemon logging open failure", openError: "daemon", wantOrder: []string{"fs"}},
+		{name: "mihomo logging open failure", openError: "mihomo", wantOrder: []string{"daemon", "fs"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			resetDaemonRunSeamsForTest(t)
+			paths := absoluteTempPaths(t)
+			fs, err := platform.NewPrivateFS(paths.Root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = fs.Close() })
+			var order []string
+			closers := map[string]*countingCloser{
+				"stdout": {name: "stdout", order: &order},
+				"stderr": {name: "stderr", order: &order},
+				"mihomo": {name: "mihomo", order: &order},
+				"daemon": {name: "daemon", order: &order},
+				"fs":     {name: "fs", order: &order},
+			}
+			newDaemonResources = func(io.Closer) *daemonLoggingResources {
+				return &daemonLoggingResources{PrivateFS: closers["fs"]}
+			}
+			openDaemonRuntime = func(_ context.Context, options logging.RuntimeOptions) (daemonLoggingRuntime, error) {
+				if options.Component == test.openError {
+					return daemonLoggingRuntime{}, errors.New("open " + options.Component)
+				}
+				return daemonLoggingRuntime{
+					Closer: closers[options.Component],
+					Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+				}, nil
+			}
+			newDaemonCapture = func(_ *slog.Logger, _ slog.Level, stream string) logging.LineCaptureWriter {
+				return &countingCapture{countingCloser: closers[stream]}
+			}
+			buildDaemonRuntime = func(platform.Paths, config.Settings, string, io.Writer, io.Writer, app.RuntimeBuildOptions) (*app.RuntimeAssembly, error) {
+				if test.buildErr != nil {
+					return nil, test.buildErr
+				}
+				return &app.RuntimeAssembly{}, nil
+			}
+			runDaemon = func(context.Context, daemon.Options) error {
+				order = append(order, "run")
+				return test.runErr
+			}
+
+			err = runDaemonWith(context.Background(), daemonRunDeps{Paths: paths, PrivateFS: fs, Token: "token", Version: "test"})
+			if test.openError != "" {
+				if err == nil || !strings.Contains(err.Error(), "open "+test.openError) {
+					t.Fatalf("err=%v want open %s failure", err, test.openError)
+				}
+			} else if !errors.Is(err, test.runErr) {
+				t.Fatalf("err=%v want=%v", err, test.runErr)
+			}
+			if !slices.Equal(order, test.wantOrder) {
+				t.Fatalf("close order=%q want=%q", order, test.wantOrder)
+			}
+			for name, closer := range closers {
+				wantCalls := 0
+				if slices.Contains(test.wantOrder, name) {
+					wantCalls = 1
+				}
+				if closer.calls != wantCalls {
+					t.Fatalf("%s close calls=%d want=%d", name, closer.calls, wantCalls)
+				}
+			}
+		})
+	}
+}
+
 func TestRunDaemon_LoggingOpensBeforeBuildRuntime(t *testing.T) {
 	paths := absoluteTempPaths(t)
 	fs, err := platform.NewPrivateFS(paths.Root)
@@ -116,6 +200,7 @@ func TestRunDaemon_LoggingOpensBeforeBuildRuntime(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	ready := make(chan struct{})
+	endpoint := transporttest.Endpoint(t)
 	done := make(chan error, 1)
 	go func() {
 		done <- runDaemonWith(ctx, daemonRunDeps{
@@ -123,7 +208,7 @@ func TestRunDaemon_LoggingOpensBeforeBuildRuntime(t *testing.T) {
 			PrivateFS: fs,
 			Token:     token,
 			Version:   "test",
-			Endpoint:  transporttest.Endpoint(t),
+			Endpoint:  endpoint,
 			Ready:     ready,
 		})
 	}()
@@ -172,6 +257,7 @@ func TestRunDaemon_CatalogLoadFailureStillOpensLogger(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	ready := make(chan struct{})
+	endpoint := transporttest.Endpoint(t)
 	done := make(chan error, 1)
 	go func() {
 		done <- runDaemonWith(ctx, daemonRunDeps{
@@ -179,7 +265,7 @@ func TestRunDaemon_CatalogLoadFailureStillOpensLogger(t *testing.T) {
 			PrivateFS: fs,
 			Token:     "catalog-fail-token",
 			Version:   "test",
-			Endpoint:  transporttest.Endpoint(t),
+			Endpoint:  endpoint,
 			Ready:     ready,
 		})
 	}()
@@ -460,6 +546,112 @@ func TestPrepareLocalRoot_StatusUsesLoadedToken(t *testing.T) {
 	}
 }
 
+func TestPrepareLocalRoot_ExplicitCredentialTokenPropagatesToClientDaemonAndTUI(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		credential func(t *testing.T, cwd string) string
+	}{
+		{
+			name: "relative credential",
+			credential: func(_ *testing.T, _ string) string {
+				return filepath.Join("credentials", "control.token")
+			},
+		},
+		{
+			name: "absolute credential",
+			credential: func(t *testing.T, _ string) string {
+				return filepath.Join(t.TempDir(), "control.token")
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			resetProcessLocalRootForTest(t)
+			cwd := t.TempDir()
+			t.Chdir(cwd)
+			t.Setenv("MIHARI_DATA", "data")
+			configuredCredential := test.credential(t, cwd)
+			t.Setenv("MIHARI_CONTROL_CREDENTIAL", configuredCredential)
+
+			root, err := prepareLocalRoot()
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantCredential, err := filepath.Abs(configuredCredential)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if root.Token == "" {
+				t.Fatal("explicit credential did not produce a token")
+			}
+			if root.Paths.Root != filepath.Join(cwd, "data") {
+				t.Fatalf("data root=%q", root.Paths.Root)
+			}
+			if filepath.Clean(wantCredential) == root.Paths.ControlToken {
+				t.Fatal("explicit credential unexpectedly used default control token path")
+			}
+			if raw, readErr := os.ReadFile(wantCredential); readErr != nil || strings.TrimSpace(string(raw)) != root.Token {
+				t.Fatalf("credential=%q read=%v token=%q", wantCredential, readErr, root.Token)
+			}
+
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				if got := request.Header.Get("Authorization"); got != "Bearer "+root.Token {
+					t.Fatalf("client bearer=%q", got)
+				}
+				writer.Header().Set("Content-Type", "application/json")
+				_, _ = writer.Write([]byte(`{"schema":"mihari/v1","protocol_version":"v1","daemon_version":"dev","revision":1,"health":"ok","started_at":"1970-01-01T00:01:40Z"}`))
+			}))
+			t.Cleanup(server.Close)
+			localClient := controlclient.NewHTTP(server.URL, "", server.Client())
+			if err := prepareLocalRootForClient(localClient)(); err != nil {
+				t.Fatal(err)
+			}
+			tuiOptions := tui.Options{Client: localClient}
+			if tuiOptions.Client != localClient {
+				t.Fatal("TUI did not receive the prepared local client")
+			}
+			if _, err := tuiOptions.Client.Status(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+
+			settings, holder := occupiedControllerSettings(t, strings.Repeat("e", 64))
+			t.Cleanup(func() { _ = holder.Close() })
+			writeSettings(t, root.Paths, settings)
+			afterDaemonLoggingOpen = func(logger *slog.Logger) {
+				logger.Info("prepared credential " + root.Token)
+			}
+			t.Cleanup(func() { afterDaemonLoggingOpen = nil })
+
+			ctx, cancel := context.WithCancel(context.Background())
+			ready := make(chan struct{})
+			endpoint := transporttest.Endpoint(t)
+			done := make(chan error, 1)
+			go func() {
+				done <- runDaemonWith(ctx, daemonRunDeps{
+					Paths: root.Paths, PrivateFS: root.FS, Token: root.Token,
+					Version: "test", Endpoint: endpoint, Ready: ready,
+				})
+			}()
+			t.Cleanup(func() {
+				cancel()
+				select {
+				case <-done:
+				case <-time.After(5 * time.Second):
+					t.Error("runDaemonWith did not stop")
+				}
+			})
+			select {
+			case <-ready:
+			case <-time.After(5 * time.Second):
+				t.Fatal("degraded daemon did not become ready")
+			}
+			logged := readFileString(t, root.Paths.DaemonLog)
+			if strings.Contains(logged, root.Token) || !strings.Contains(logged, "***") {
+				t.Fatalf("daemon log did not redact explicit credential: %s", logged)
+			}
+		})
+	}
+}
+
 func TestPrepareLocalRoot_InteractiveRunTUIWithNilPrivateFS(t *testing.T) {
 	resetProcessLocalRootForTest(t)
 	rootDir := filepath.Join(t.TempDir(), "data")
@@ -503,6 +695,24 @@ func (c orderCloser) Close() error {
 	return c.err
 }
 
+type countingCloser struct {
+	name  string
+	order *[]string
+	calls int
+}
+
+func (c *countingCloser) Close() error {
+	c.calls++
+	*c.order = append(*c.order, c.name)
+	return nil
+}
+
+type countingCapture struct{ *countingCloser }
+
+func (c *countingCapture) Write(value []byte) (int, error) { return len(value), nil }
+
+func (c *countingCapture) Flush() error { return nil }
+
 func resetProcessLocalRootForTest(t *testing.T) {
 	t.Helper()
 	resetProcessLocalRoot()
@@ -511,6 +721,22 @@ func resetProcessLocalRootForTest(t *testing.T) {
 			_ = localRootCached.FS.Close()
 		}
 		resetProcessLocalRoot()
+	})
+}
+
+func resetDaemonRunSeamsForTest(t *testing.T) {
+	t.Helper()
+	originalResources := newDaemonResources
+	originalOpen := openDaemonRuntime
+	originalCapture := newDaemonCapture
+	originalBuild := buildDaemonRuntime
+	originalRun := runDaemon
+	t.Cleanup(func() {
+		newDaemonResources = originalResources
+		openDaemonRuntime = originalOpen
+		newDaemonCapture = originalCapture
+		buildDaemonRuntime = originalBuild
+		runDaemon = originalRun
 	})
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,7 +78,7 @@ Mihari 围绕一个由守护进程持有的控制面(control plane)设计,由 CL
 - 几乎所有内容都位于该根目录下:设置、控制令牌(`control.token`)、运行时配置、核心二进制、订阅、GeoIP、面板资产、日志与暂存。
 - 文件日志布局:`logs/mihari-daemon.log`、`logs/mihari-tui.log`、`logs/mihomo.log`;默认导出目录为 `logs-export/`(首次默认导出时创建,不由 `EnsureDirs` 预创建)。
 - 日志与默认导出目录经 `PrivateFS` 创建/加固:Unix `0700` 目录/`0600` 文件;Windows 受保护 DACL 只授予数据根 owner 与 LocalSystem。跨进程协调使用相邻 `*.lock` 文件;打开 `logs/` 及文件后每一跳 no-follow,拒绝中间与最终的 symlink/reparse/junction。
-- 需要本地数据根的选定命令必须先 `Paths.Absolute()`,再 `NewPrivateFS(absolutePaths.Root)`,然后才允许 `EnsureDirs`、默认 in-root token 或 Settings IO。`EnsureDirs` 可预创建 `logs/` 但不是 root 创建/加固入口。`--help`/`--version` 不得调用该路径。`NewPrivateFS` 失败时 TUI 可继续运行;daemon 不得在失败后继续目录 IO。
+- 需要本地数据根的选定命令必须先 `Paths.Absolute()`,再 `NewPrivateFS(absolutePaths.Root)`,然后才允许 `EnsureDirs`、默认 in-root token 或 Settings IO。`EnsureDirs` 可预创建 `logs/` 但不是 root 创建/加固入口。`--help`/`--version` 不得调用该路径。root/LocalSystem 遇到缺失 data root 必须零目录 IO fail closed,不得创建仅 root/System 可用的替代根。该 `NewPrivateFS` 失败不得写入 CLI `SetupError`(避免拦截 TUI);TUI 可继续运行并接管 `PrivateFS=nil`,daemon 不得在失败后继续目录/Settings IO。daemon 与 TUI 复用并接管这一个进程级 `PrivateFS` capability,不得在 `EnsureDirs`/Settings 之后再次调用 `NewPrivateFS`。
 - `service install` 将**绝对**的 `MIHARI_DATA=<data root>` 写入 OS 服务环境,使 LocalSystem/root 服务与安装它的用户共享同一棵树(而非 `systemprofile` 或 `/root`)。
 - `service uninstall` 只移除 OS 注册并**保留**数据根目录。请手动删除数据目录(或未来的 `--purge`)以清除残留文件。`%AppData%\mihari` 或 `%ProgramData%\mihari` 下的旧树不会自动迁移或删除。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,8 @@ Mihari 围绕一个由守护进程持有的控制面(control plane)设计,由 CL
 
 ## TUI
 
-- TUI 只通过 `internal/control/client` 经原生 IPC 控制面与本地守护进程通信。它从不打开 mihomo 控制器、从不接收控制器密钥、也从不自己执行持久化写入。
+- TUI 只通过 `internal/control/client` 经原生 IPC 控制面与本地守护进程通信。它从不打开 mihomo 控制器、从不接收控制器密钥。
+- TUI 对数据根的唯一直接写入例外是经 `internal/logging` 追加/轮转固定的 `mihari-tui.log*` 序列;不得写 `mihari.yaml`、订阅、token、面板或其他业务状态。日志配置变更仍只走 daemon 控制面。
 - 搜索与表单字段中的括号粘贴和 Ctrl+V 使用纯 Go 实现的 `github.com/atotto/clipboard` 辅助库;Mihari 本身从不把密钥写入剪贴板。
 - 页面:独立的首次运行 Setup 路由、Overview、可展开的 Proxies、带本地 GeoIP 详情的活动/已关闭 Connections、Rules/Providers、有界的结构化 Logs 流、订阅管理表单、分类的 System 页面,以及驱动面板安装/更新/激活/打开/回滚的 Web GUI 页面(在守护进程通告 `web-gui` 能力之后)。
 - Setup 安装核心、可添加初始订阅、准备本地 GeoIP 数据,并请求守护进程持久化校验过的本地端点。
@@ -75,6 +76,9 @@ Mihari 围绕一个由守护进程持有的控制面(control plane)设计,由 CL
 
 - 每次安装保持**一个数据根目录**(可用 `MIHARI_DATA` 覆盖):Windows 默认 `%USERPROFILE%\.mihari`,macOS/Linux 默认 `$HOME/.mihari`。
 - 几乎所有内容都位于该根目录下:设置、控制令牌(`control.token`)、运行时配置、核心二进制、订阅、GeoIP、面板资产、日志与暂存。
+- 文件日志布局:`logs/mihari-daemon.log`、`logs/mihari-tui.log`、`logs/mihomo.log`;默认导出目录为 `logs-export/`(首次默认导出时创建,不由 `EnsureDirs` 预创建)。
+- 日志与默认导出目录经 `PrivateFS` 创建/加固:Unix `0700` 目录/`0600` 文件;Windows 受保护 DACL 只授予数据根 owner 与 LocalSystem。跨进程协调使用相邻 `*.lock` 文件;打开 `logs/` 及文件后每一跳 no-follow,拒绝中间与最终的 symlink/reparse/junction。
+- 需要本地数据根的选定命令必须先 `Paths.Absolute()`,再 `NewPrivateFS(absolutePaths.Root)`,然后才允许 `EnsureDirs`、默认 in-root token 或 Settings IO。`EnsureDirs` 可预创建 `logs/` 但不是 root 创建/加固入口。`--help`/`--version` 不得调用该路径。`NewPrivateFS` 失败时 TUI 可继续运行;daemon 不得在失败后继续目录 IO。
 - `service install` 将**绝对**的 `MIHARI_DATA=<data root>` 写入 OS 服务环境,使 LocalSystem/root 服务与安装它的用户共享同一棵树(而非 `systemprofile` 或 `/root`)。
 - `service uninstall` 只移除 OS 注册并**保留**数据根目录。请手动删除数据目录(或未来的 `--purge`)以清除残留文件。`%AppData%\mihari` 或 `%ProgramData%\mihari` 下的旧树不会自动迁移或删除。
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -53,7 +53,7 @@ mihari status --json
 
 守护进程、TUI 与捕获的 mihomo 输出会分别以 JSONL 写入数据根目录下的 `logs/mihari-daemon.log`、`logs/mihari-tui.log` 与 `logs/mihomo.log`。多个 TUI 实例共享 `mihari-tui.log`，写入与轮转会跨进程协调。
 
-默认级别为 `info`，每个活跃文件达到 10 MiB 时轮转，最多保留三份文件（活跃文件与最多两份归档）。mihomo stdout 捕获为 `INFO`，stderr 捕获为 `WARN`；这只描述 Mihari 的捕获级别，不表示 mihomo 行内消息的实际严重程度。
+守护进程与捕获的 mihomo 日志默认级别为 `info`，每个活跃文件达到 10 MiB 时轮转，最多保留三份文件（活跃文件与最多两份归档）。TUI 启动时使用 bootstrap 配置：`debug`、100 MiB、10 份文件，以便在守护进程设置可用前也能记录日志；在后续控制面同步前保持该 bootstrap 配置。mihomo stdout 捕获为 `INFO`，stderr 捕获为 `WARN`；这只描述 Mihari 的捕获级别，不表示 mihomo 行内消息的实际严重程度。
 
 日志脱敏是尽力而为，所有日志仍须按敏感资料处理，分享前应检查内容。本版本没有日志配置 UI，也不提供日志导出命令或界面。
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -49,6 +49,14 @@ mihari status
 mihari status --json
 ```
 
+## 文件日志
+
+守护进程、TUI 与捕获的 mihomo 输出会分别以 JSONL 写入数据根目录下的 `logs/mihari-daemon.log`、`logs/mihari-tui.log` 与 `logs/mihomo.log`。多个 TUI 实例共享 `mihari-tui.log`，写入与轮转会跨进程协调。
+
+默认级别为 `info`，每个活跃文件达到 10 MiB 时轮转，最多保留三份文件（活跃文件与最多两份归档）。mihomo stdout 捕获为 `INFO`，stderr 捕获为 `WARN`；这只描述 Mihari 的捕获级别，不表示 mihomo 行内消息的实际严重程度。
+
+日志脱敏是尽力而为，所有日志仍须按敏感资料处理，分享前应检查内容。本版本没有日志配置 UI，也不提供日志导出命令或界面。
+
 ## 核心与代理管理
 
 通过守护进程管理和检查 mihomo:

--- a/docs/superpowers/plans/2026-09-02-file-logging-foundation.md
+++ b/docs/superpowers/plans/2026-09-02-file-logging-foundation.md
@@ -467,7 +467,7 @@ Expected: FAIL，缺少 writer。
 
 - [ ] **Step 2: 最小实现 capture**
 
-每次 `Write` 返回原输入 `len(p), nil`，即使日志 level 过滤或底层 JSONL 落盘失败也不误导子进程；失败只计入 logging 失败计数。只有 Close 后返回 `os.ErrClosed`。非法 UTF-8 替换为 U+FFFD 且 JSON 带 `invalid_utf8=true`。`Flush` 写出半行但不关闭。缓冲区永不超 `MaxCaptureLineBytes+utf8.UTFMax`。capture 必须可在多次子进程生命周期中继续 `Write`。测试：Close 前连续两次「写半行→Flush→再写」都成功；「写半行 → 子进程 Wait/Flush → 再 Start 写一行」得到两条独立 JSONL，不得粘成一行。
+每次 `Write` 返回原输入 `len(p), nil`，即使日志 level 过滤或底层 JSONL 落盘失败也不误导子进程；失败只计入 logging 失败计数。只有 Close 后返回 `os.ErrClosed`。非法 UTF-8（包括恰好在 16 KiB 边界被截断的 rune）替换为 U+FFFD 且 JSON 带 `invalid_utf8=true`。`Flush` 写出半行但不关闭。缓冲区永不超 `MaxCaptureLineBytes`。capture 必须可在多次子进程生命周期中继续 `Write`。测试：Close 前连续两次「写半行→Flush→再写」都成功；「写半行 → 子进程 Wait/Flush → 再 Start 写一行」得到两条独立 JSONL，不得粘成一行。
 
 - [ ] **Step 3: 写 Runtime/Group Red 并实现生命周期**
 

--- a/docs/superpowers/plans/2026-09-02-file-logging-foundation.md
+++ b/docs/superpowers/plans/2026-09-02-file-logging-foundation.md
@@ -1,0 +1,749 @@
+# 安全文件日志基础 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在不改变稳定控制协议和 `mihari.yaml` 的前提下，让 daemon、TUI 和 mihomo 分别安全写入 JSONL 文件，实现按大小轮转、多 TUI 跨进程互斥、写入前脱敏与可验证的关闭顺序。
+
+**Architecture:** `internal/platform` 提供绝对路径解析、可关闭的受限文件 capability、owner/ACL 和 advisory lock；`internal/logging` 在其上组合 `Redactor` → `slog.JSONHandler` → `RotatingWriter`，并以 `Runtime`/`Group` 暴露热更新与生命周期。`cmd/mihari` 在 Settings 和目录就绪后装配 daemon/mihomo logger，TUI 则以 debug/100 MiB/10 的保守 bootstrap 独立打开共享日志；进程装配点在最后一个使用者结束后关闭 `PrivateFS`。
+
+**Tech Stack:** Go 1.26.5，标准库 `log/slog`、`sync/atomic`，既有 `golang.org/x/sys/windows`、`golang.org/x/sys/unix`，Bubble Tea v2，Go `testing`/helper subprocess。
+
+**Spec:** `docs/superpowers/specs/2026-09-02-file-logging-export-design.md`
+
+**Worktree:** `.worktrees/feat-file-logging-export`
+
+**Branch:** `feat/file-logging-export`
+**Delivery:** 本文档对应 spec 第 1 个顺序 PR，目标分支为 `dev`。
+
+## Global Constraints
+
+- 本 PR 不新增 `/v1/logging`，不改 `config.Settings`，不增 CLI，不修改 `CHANGELOG.md`。
+- 首个行为 commit 先修改根 `AGENTS.md` 与 `docs/architecture.md`：TUI 仅可通过 `internal/logging` 向固定 `mihari-tui.log*` 追加/轮转，不得扩展为 settings 或业务状态写入。
+- daemon 或 mihomo 任一侧文件日志 `Open` 失败都是启动失败；TUI 初始化失败不退出，只写入限频且脱敏的 stderr。
+- `max-files` 包含活跃文件；`1` 仅在 rotate 时原子替换为新空 inode，禁止原 inode truncate，Open/Apply 不得替换活跃文件；`N` 最多留 `.1` 到 `.(N-1)`。
+- 写入锁最多等待 250 ms；未获锁就丢弃整条 record 并累加计数，不拆行、不阻塞进程。Open/Apply 的 archive 维护同样只对 advisory-lock **获取**施加调用方 context 与 250ms 上限；获锁后的 `ReadDir`/`Remove` 不能被 Go context 抢占，也不承诺整个本地文件系统维护在 250ms 内结束。
+- 活跃文件只能在获得跨进程锁后打开；不缓存跨锁的 file handle，避免写入已被其他 TUI rename 的旧 inode。
+- 符号链接、目录、reparse point、非法 suffix 全部 fail closed 或记录后跳过。打开必须从已验证 dataRoot 句柄逐段 no-follow，禁止完整路径一次 `Open`/`O_NOFOLLOW`，禁止 Windows「打开后再拒绝 reparse」。
+- `NewPrivateFS` 安全创建尚不存在的绝对 dataRoot，并在任何 `Paths.EnsureDirs`、默认 in-root token 或 Settings IO 前、由**需要本地数据根的选定命令**调用；root/LocalSystem 缺根必须零 IO fail closed。该失败不得写入 CLI `SetupError`。`cmd/mihari` 的 `main` 与 Cobra 解析不得在 `--help`/`--version` 之前调用 `Absolute`/`NewPrivateFS`/`LoadOrCreate`。daemon 与 TUI 复用并接管这一个进程级 capability，不得在 `EnsureDirs`/Settings 之后再调一次 `NewPrivateFS`；在 `Open` 前都调用 `PrivateFS.EnsureDir(LogDir)`；`logging.Open` 对父目录再 EnsureDir 一次。`Paths.EnsureDirs` 的 `MkdirAll` 只能在 capability 建立后调用且不算加固。TUI 在 `PrivateFS=nil` 时继续运行；daemon 见到 nil 则启动失败并跳过目录/Settings IO。
+- `cmd/mihari` 在首次使用 Paths 前调用 `DefaultPaths().Absolute()`；相对 `MIHARI_DATA` 以启动 working directory 为基准。保留 `MIHARI_CONTROL_CREDENTIAL`：非空覆盖也只 `Abs/Clean` 一次，为空才用 `absolutePaths.ControlToken`；client/daemon/TUI/redactor 共用最终 path/token。
+- `PrivateFS` 持有 dataRoot 目录 handle，必须幂等 `Close`；所有方法在 Close 后返回 `os.ErrClosed`。先关闭/等待所有 logger、lock、Apply/Export 使用者，最后关闭 `PrivateFS`，Unix relaunch 前必须完成。
+- Unix 保持 0700 目录/0600 文件；打开一律 `O_CLOEXEC`。root service 对已有数据根使用该根的 owner UID/GID。Windows 目录 DACL 带 `OICI` 继承，文件 DACL 不带继承；只授予数据根 owner SID 与 LocalSystem。Windows 日志/lock/temp 打开一律 `FILE_SHARE_READ|FILE_SHARE_WRITE|FILE_SHARE_DELETE` 且 `InheritHandle=false`；rotate/`ReplaceEmpty` 前关闭本进程 write handle。
+- mihomo capture 单行上限 `MaxCaptureLineBytes = 16 << 10`；导出解析上限 `MaxExportRecordBytes = 1 << 20`。JSON 字段名是 `component`，不是 `source`。
+- 轮转 size 判断禁止 `currentSize + incoming`，必须用溢出安全比较。
+- 不增新依赖；使用现有 `golang.org/x/sys v0.46.0`。保持 `CGO_ENABLED=0` 和 Windows/Linux/macOS amd64/arm64。
+- 行为修改必须 Red–Green–Refactor；外部 IO、锁等待和时钟可注入，测试不读用户目录、不访公网、不启动真实 mihomo。
+- 实际 commit 仅在用户明确要求时创建；以下 commit 命令是可审查的任务边界，不是预授权。
+
+## File Structure
+
+| 文件 | 职责 |
+| --- | --- |
+| `AGENTS.md` | 声明 TUI 固定日志写入的狭义例外 |
+| `docs/architecture.md` | 记录三日志、锁和 owner/ACL 边界 |
+| `internal/platform/paths.go` | 绝对化 Root；`LogDir`、`DaemonLog`、`TUILog`、`MihomoLog`、`LogExportDir` |
+| `internal/platform/privatefs.go` | 可关闭的受限目录/文件通用入口与路径边界验证 |
+| `internal/platform/privatefs_unix.go` / `_windows.go` | UID/GID、mode 或 protected DACL；Unix 文件必须 `//go:build unix` |
+| `internal/platform/filelock.go` | advisory lock 接口和可取消重试器 |
+| `internal/platform/filelock_unix.go` / `_windows.go` | `flock` / `LockFileEx` 非阻塞尝试；Unix 文件必须 `//go:build unix` |
+| `internal/logging/config.go` | `Config`、`DefaultConfig`/`BootstrapConfig`、`ParseLevel`、size/files 范围；`ConfigFromFields` 由 PR 2 增补 |
+| `internal/logging/redactor.go` | 不可变规则快照、通用规则和 exact secrets |
+| `internal/logging/rotator.go` | 整 record 写入、溢出安全轮转、热 limits、分类失败计数 |
+| `internal/logging/handler.go` | `slog.JSONHandler`、`LevelVar`、RFC3339Nano 本地偏移、`component`、attr 脱敏 |
+| `internal/logging/runtime.go` | logger/writer 所有权、`Group` 热更新、`Apply(context.Context, Config)` |
+| `internal/logging/capture.go` | mihomo stdout/stderr 行切分、UTF-8 和 16 KiB 截断 |
+| `internal/app/runtime.go` | 将 mihomo capture 注入 `supervisor.CommandStarter` |
+| `internal/supervisor/command.go` | Child.Wait 后 Flush capture，不 Close |
+| `cmd/mihari/main.go` | 抽出 `prepareLocalRoot`；daemon/mihomo 日志打开、背景错误和关闭顺序 |
+| `internal/cli/root.go` | `PersistentPreRunE` 调用 `prepareLocalRoot`；help/`self version` 跳过 |
+| `internal/control/client/client.go` | `SetToken`：PreRun 之后把最终 token 写入已构造的 local client |
+| `internal/tui/run.go` | TUI bootstrap logger 创建、降级、关闭 |
+| `internal/tui/model.go` | 注入 `LocalLoggingHealth` |
+| `README.md` / `README.zh-CN.md` | 用户可见日志路径、轮转缺省与隐私提示 |
+| `docs/commands.md` | daemon/TUI 文件日志行为与排障入口 |
+
+---
+
+### Task 1: 先固化架构例外与路径契约
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `docs/architecture.md`
+- Modify: `internal/platform/paths.go`
+- Modify: `internal/platform/paths_test.go`
+
+**Interfaces:** `platform.Paths` 删除 `Log`，新增 `LogDir`、`DaemonLog`、`TUILog`、`MihomoLog`、`LogExportDir`。`EnsureDirs` 可以预创建 `LogDir`（`MkdirAll`），但不加固、不拒绝中间 symlink；不预创建 `LogExportDir`。加固只认 `PrivateFS.EnsureDir`。
+
+```go
+func (p Paths) Absolute() (Paths, error)
+```
+
+`Absolute` 对 `p.Root` 调 `filepath.Abs/Clean` 后用 `NewPaths(absRoot)` 重建全部派生字段；不得保留调用方可能混入的相对字段。它不 EvalSymlinks，dataRoot 允许跟随的一跳仍由 `NewPrivateFS` 固定 identity。
+
+- [ ] **Step 1: 写 Paths 失败测试**
+
+在 `paths_test.go` 表驱动断言五个路径的 exact basename，断言 `EnsureDirs` 创建 `logs` 但不创建 `logs-export`。另用 `t.Chdir(t.TempDir())` 和 `NewPaths(filepath.Join(".", "relative-data"))` 断言 `Absolute` 返回绝对 Root、五个派生字段全部来自该 Root，原值不变；绝对 Root round-trip。删除 `Paths.Log` 后迁移全部调用点；Task 9 用 `rg 'Paths\.Log\b|\.Log\b' --glob '*paths*.go'` 以及 `rg 'filepath\.Dir\(p\.Log\)|paths\.Log\b' --glob '*.go'` 验收，不把 `event.Log` 当命中，不写依赖编译失败的测试。
+
+```go
+want := map[string]string{
+	"LogDir":      filepath.Join(root, "logs"),
+	"DaemonLog":   filepath.Join(root, "logs", "mihari-daemon.log"),
+	"TUILog":      filepath.Join(root, "logs", "mihari-tui.log"),
+	"MihomoLog":   filepath.Join(root, "logs", "mihomo.log"),
+	"LogExportDir": filepath.Join(root, "logs-export"),
+}
+```
+
+Run:
+
+```powershell
+go test -run '^Test(NewPathsLoggingLayout|EnsureDirsLoggingLayout)$' ./internal/platform
+```
+
+Expected: FAIL，因新字段尚未存在。
+
+- [ ] **Step 2: 最小修改 Paths 并更新架构文档**
+
+`EnsureDirs` 加 `p.LogDir`，删 `filepath.Dir(p.Log)`；不加 `p.LogExportDir`。实现 `Paths.Absolute`，错误包装为 `resolve absolute data root: %w`。调用契约明确：需要本地数据根的选定命令必须在 `EnsureDirs`/默认 token 之前调用 `NewPrivateFS(absolutePaths.Root)`，`EnsureDirs` 自身不是 root 创建/加固入口。`--help`/`--version` 不得调用。TUI 允许该调用失败并继续；daemon 不允许在失败后继续做目录 IO。根规范和架构文档明确：TUI 只写固定日志序列，settings 仍只有 daemon/Manager 可写。
+
+```powershell
+gofmt -w internal/platform/paths.go internal/platform/paths_test.go
+go test ./internal/platform
+git diff --check
+```
+
+Expected: PASS；`git diff` 无 `CHANGELOG.md`。
+
+- [ ] **Step 3: Commit（仅得到用户明确提交授权时）**
+
+```powershell
+git add AGENTS.md docs/architecture.md internal/platform/paths.go internal/platform/paths_test.go
+git commit -s -m "docs: 明确 TUI 日志写入例外"
+```
+
+---
+
+### Task 2: 私有文件与数据根 owner/ACL
+
+**Files:**
+- Create: `internal/platform/privatefs.go`
+- Create: `internal/platform/privatefs_unix.go`
+- Create: `internal/platform/privatefs_windows.go`
+- Create: `internal/platform/privatefs_test.go`
+- Create: `internal/platform/privatefs_unix_test.go`
+- Create: `internal/platform/privatefs_windows_test.go`
+
+**Interfaces:**
+
+```go
+type PrivateFS struct { /* platform-owned identity */ }
+type FileIdentity struct { /* opaque platform file identity */ }
+type DirectoryIdentity struct { /* held opaque platform directory identity */ }
+type FileEntry struct {
+	Name     string
+	Mode     os.FileMode
+	Identity FileIdentity
+}
+
+func NewPrivateFS(dataRoot string) (*PrivateFS, error)
+func (fs *PrivateFS) EnsureDir(path string) error
+func (fs *PrivateFS) OpenAppend(path string) (*os.File, error)
+func (fs *PrivateFS) OpenReadChecked(path string, expected FileIdentity) (*os.File, error)
+func (fs *PrivateFS) CreateTemp(dir, pattern string) (*os.File, error)
+func (fs *PrivateFS) ReplaceEmpty(path string) error
+func (fs *PrivateFS) ReadDir(path string) ([]FileEntry, error)
+func (fs *PrivateFS) OpenDirIdentity(path string) (*DirectoryIdentity, error)
+func (d *DirectoryIdentity) Close() error
+func (fs *PrivateFS) Rename(oldpath, newpath string) error
+func (fs *PrivateFS) Remove(path string) error
+func (fs *PrivateFS) Close() error
+```
+
+`NewPrivateFS` 只接受绝对 dataRoot。若根不存在，交互用户进程以 Unix 0700 或 Windows 当前用户+LocalSystem protected DACL 创建并立即打开/加固；root/LocalSystem 直接 fail closed，服务安装必须预先创建固定 dataRoot 并赋予桌面 owner，不能创建仅 root/System 可访问或宽权限替代根。若已存在，打开时**允许跟随这一跳**（`~/.mihari` 可以是指向其他盘的 symlink/junction）。随后 `fstat` 确认是目录并持有 identity。公开方法接受绝对路径或单段 basename（Task 5/7/8 继续传 `LogDir`/`BasePath`；PR 3 传 `LogExportDir`）。内部把路径 Rel 到已验证 dataRoot：必须落在 dataRoot、LogDir 或默认 ExportDir 下，最后一段无分隔符且不是 `.`/`..`，再对该 parent fd + basename 操作。禁止内部再 walk 完整路径调用 `os.OpenFile` / `os.Rename` / `os.Remove` / `os.ReadDir` / `chmod` / `chown` / `SetNamedSecurityInfo`。Unix 用 `openat`/`renameat`/`unlinkat` 以及 `fchmod`/`fchownat`；Windows 用相对 `NtCreateFile` / `NtSetInformationFile`，DACL 在创建时经 `SECURITY_ATTRIBUTES` 或对已打开 handle 调 `windows.SetSecurityInfo`。`ReadDir` 对每个 no-follow 目录项返回可与 handle 比较的 opaque identity；`OpenReadChecked` 用 delete-sharing/no-follow 打开后比较实际 identity，不符则关闭并返回稳定错误。`OpenDirIdentity` 只从已验证且持有的目录 handle 派生一个独立、幂等可关闭的 capability，供 PR 3 containment 使用，不对路径字符串做 `EvalSymlinks`；PrivateFS 关闭前必须先关闭这些派生 capability。`Rename` 要求 old/new 解析到同一已验证目录 fd。`PrivateFS` 用一个 `sync.RWMutex` 和 `closed bool` 保护 dataRoot/缓存目录 handle；重复 Close 返回 nil，Close 后所有公开文件操作返回可 `errors.Is(err, os.ErrClosed)` 的错误。
+
+- [ ] **Step 1: 写通用边界与 Unix 权限 Red**
+
+测试覆盖：拒绝相对 dataRoot、data root 外路径、`logs/../outside`、`.`/`..` 最后一段；尚不存在的绝对 dataRoot 被安全创建并持有，control credential 位于根外也不影响；接受绝对 `LogDir`/`BasePath`/`LogExportDir` 与单段 `"logs"` / `"logs-export"`；dataRoot 本身是指向普通目录的 symlink/junction 时 `NewPrivateFS` 成功且后续打开落在目标目录；`logs/` 换成 junction/symlink 后 `EnsureDir(LogDir)`/`OpenAppend`/`ReadDir`/`Rename`/`Remove`/`OpenReadChecked` 失败且外部目标零写入、零改名、零删除、DACL 不被打到 junction 目标；目录项 identity 与打开 handle 不符时 `OpenReadChecked` 关闭 handle 并失败；`OpenDirIdentity(LogDir)` 持有真实目录而不是 symlink dataRoot 字符串，Close 幂等且关闭后 capability 操作返回 `os.ErrClosed`；最终名指向根内 `mihari.yaml` 的链接时失败且 yaml 不被追加；已有宽权限目录收紧为 0700；新文件为 0600（root + umask 022 也必须 `fchmod`）；`ReplaceEmpty` 产生新 inode 且经 `OpenReadChecked` 打开的旧 handle 仍可读完（Windows DELETE share）。显式断言 `Close` 关闭持有的根/子目录 handle、重复调用幂等、Close 后每个公开文件操作都是 `os.ErrClosed`。Unix owner 测试通过注入 `effectiveUID`/`fstat`/`fchownat` 模拟 root，断言从已有 data root fd 取 UID/GID，不使用 `/root` 或受污染环境变量。
+
+```powershell
+go test -run '^TestPrivateFS_' ./internal/platform
+```
+
+Expected: FAIL，缺少 `PrivateFS`。
+
+- [ ] **Step 2: 实现通用/Unix 路径**
+
+Unix 文件顶部写 `//go:build unix`。打开 dataRoot 允许跟随最后一跳。`EnsureDir` 可接收绝对 `LogDir` 或 `"logs"`，内部 Rel 后对 parent fd + 单段名 `mkdirat`/`openat`。**文件操作只允许 LogDir / 默认 LogExportDir 的单段子名**，不得对 dataRoot 下任意 basename 做 `OpenAppend`（`logs/../outside` Rel 后变成兄弟名也必须拒绝）。操作只对已验证目录 fd + basename：`openat(..., O_NOFOLLOW|O_CLOEXEC)`，append 加 `O_APPEND|O_CREAT|O_WRONLY`，read 加 `O_RDONLY`；mode/owner 用 `fchmod`/`fchownat`，禁止路径名 `chmod`/`chown`。`renameat`/`unlinkat` 同样相对该 fd。root 时 owner 来自 data root fd 的 `Stat_t`；非 root 不 chown。`ReplaceEmpty` 本身不接收已打开 handle：调用方（rotator）必须先关掉本进程 write handle，再 `CreateTemp` 于同一目录 fd，`Sync`、`Close` 后 `Rename`，任何失败 `Remove` temp。公开操作在 `RWMutex.RLock` 覆盖的区间内检查 closed 并完成所有依赖根/目录 handle 的 syscall；`Close` 取得写锁，等待这些调用离开后原子标记 closed、逐一关闭全部目录 fd 并 `errors.Join`，避免 Close 与相对路径操作交错。
+
+- [ ] **Step 3: 实现 Windows protected DACL 并写平台测试**
+
+Windows 从 data root security descriptor 取 owner SID。目录与文件使用不同 ACL 模板：目录 `D:P(A;OICI;FA;;;<OWNER>)(A;OICI;FA;;;SY)`，文件 `D:P(A;;FA;;;<OWNER>)(A;;FA;;;SY)`。DACL 在 `NtCreateFile`/`CreateFile` 时经 `SECURITY_ATTRIBUTES` 带入，或对已打开 handle 调 `windows.SetSecurityInfo(..., DACL_SECURITY_INFORMATION|PROTECTED_DACL_SECURITY_INFORMATION, ...)`；**禁止** `SetNamedSecurityInfo`。实际 owner 为 SYSTEM 时只保留一个 SYSTEM ACE。打开 dataRoot 允许跟随用户配置的最后一跳；之后每一跳相对打开：`CreateFile` 用 `FILE_FLAG_OPEN_REPARSE_POINT`，`NtCreateFile` 用 CreateOptions `FILE_OPEN_REPARSE_POINT`。看到 reparse/junction 立即失败。对已存在对象加固 DACL 需要 `WRITE_DAC`。`NtSetInformationFile` 带 `FILE_RENAME_POSIX_SEMANTICS` 以支撑「旧 OpenReadChecked handle 仍可读完」。dataRoot、目录、`OpenAppend`/`OpenReadChecked`/`CreateTemp`/`ReplaceEmpty`/lock 一律 `FILE_SHARE_READ|FILE_SHARE_WRITE|FILE_SHARE_DELETE`，`bInheritHandle=false`；`Close` 与操作用同一 closed/handle 所有权协议，关闭全部 `windows.Handle`。平台测试枚举 DACL，拒绝 `Everyone`/`Users`/匿名 SID，验证 owner 和 SYSTEM 可打开，断言子文件继承后仍只有 owner/System，并覆盖父目录 junction 零写入且 DACL 未打到外部目标。
+
+```powershell
+gofmt -w internal/platform/privatefs.go internal/platform/privatefs_unix.go internal/platform/privatefs_windows.go internal/platform/privatefs_unix_test.go internal/platform/privatefs_windows_test.go
+go test ./internal/platform
+```
+
+Expected: 当前 Windows 测试 PASS。Unix 权限/no-follow 测试由 GitHub Actions 的 Ubuntu 或 macOS job 实际执行 `go test ./internal/platform`，六目标 `go build` 不编译 `*_test.go`，不能代替 Unix 测试。
+
+- [ ] **Step 4: Commit（仅得到授权时）**
+
+```powershell
+git add internal/platform/privatefs*.go
+git commit -s -m "feat: 增加日志私有文件边界"
+```
+
+---
+
+### Task 3: 可取消的跨进程 advisory lock
+
+**Files:**
+- Create: `internal/platform/filelock.go`
+- Create: `internal/platform/filelock_unix.go`
+- Create: `internal/platform/filelock_windows.go`
+- Create: `internal/platform/filelock_test.go`
+- Create: `internal/platform/filelock_subprocess_test.go`
+
+**Interfaces:**
+
+```go
+type LockMode uint8
+const (
+	LockShared LockMode = iota
+	LockExclusive
+)
+
+type AdvisoryLock interface {
+	Lock(context.Context, LockMode) error
+	Unlock() error
+	Close() error
+}
+
+func OpenAdvisoryLock(fs *PrivateFS, path string) (AdvisoryLock, error)
+```
+
+lock file 必须经 `fs.OpenAppend` 打开，因此 `OpenAdvisoryLock` 接收 `*PrivateFS`，不得自行 `os.OpenFile`。平台文件导出 `tryLock() (busy bool, err error)`：Unix 把 `EWOULDBLOCK`/`EAGAIN` 标 `busy=true`，Windows 把 `ERROR_LOCK_VIOLATION` 标 `busy=true`；其它 errno 原样返回。无 build tag 的通用等待器只看 `busy`，禁止 import `golang.org/x/sys/unix` 或 `windows`。重试 tick 为 5 ms 且通过包内 ops 注入。Unix lock 文件同样 `//go:build unix`。
+
+- [ ] **Step 1: 写锁语义 Red**
+
+测试不用固定 sleep：channel 同步证明 exclusive 互斥、shared 可共存、context cancel/deadline 返回 `context.Canceled`/`DeadlineExceeded`、Unlock 后可重新获取、Close/子进程退出释放锁。锁文件存在不等于锁被持有。
+
+```powershell
+go test -run '^TestAdvisoryLock_' ./internal/platform
+```
+
+Expected: FAIL，缺少锁类型。
+
+- [ ] **Step 2: 实现两组平台调用**
+
+- Unix: 文件顶部 `//go:build unix`；`unix.Flock(fd, LOCK_SH|LOCK_NB)` / `LOCK_EX|LOCK_NB` / `LOCK_UN`。lock fd 来自带 `O_CLOEXEC` 的 `OpenAppend`。
+- Windows: `windows.LockFileEx` 配 `LOCKFILE_FAIL_IMMEDIATELY` 及可选 `LOCKFILE_EXCLUSIVE_LOCK`，固定锁 0..1 byte；`UnlockFileEx` 使用同一 `Overlapped`。handle 不可继承。
+- lock file 通过 `PrivateFS.OpenAppend` 打开，不通过删除 lock file 表示释放。
+
+```powershell
+gofmt -w internal/platform/filelock.go internal/platform/filelock_unix.go internal/platform/filelock_windows.go internal/platform/filelock_test.go internal/platform/filelock_subprocess_test.go
+go test -run '^TestAdvisoryLock_' ./internal/platform
+go test -race -run '^TestAdvisoryLock_' ./internal/platform
+```
+
+Expected: PASS，race 无报告。
+
+- [ ] **Step 3: Commit（仅得到授权时）**
+
+```powershell
+git add internal/platform/filelock*.go
+git commit -s -m "feat: 增加跨进程日志锁"
+```
+
+---
+
+### Task 4: Redactor 与 JSON handler
+
+**Files:**
+- Create: `internal/logging/redactor.go`
+- Create: `internal/logging/redactor_test.go`
+- Create: `internal/logging/handler.go`
+- Create: `internal/logging/handler_test.go`
+
+**Interfaces:**
+
+```go
+type Redactor struct { rules atomic.Pointer[redactionRules] }
+
+func NewRedactor(exact ...string) *Redactor
+func (r *Redactor) ReplaceExact(values []string)
+func (r *Redactor) String(value string) string
+func (r *Redactor) ReplaceAttr(groups []string, attr slog.Attr) slog.Attr
+
+func NewJSONHandler(out io.Writer, level *slog.LevelVar, component string, redactor *Redactor) slog.Handler
+```
+
+- [ ] **Step 1: 写通用规则与 attr 递归 Red**
+
+表驱动覆盖 exact control token/secret/web credential/subscription URL，sensitive key（`secret`、`token`、`authorization`、`password`、`credential`、`cookie`、`api-key`），`http/https/ws/wss` URL，Basic/Bearer/auth 形式，64 位 hex，group/`LogValuer`、error 字符串、非敏感数字和 bool。断言原值不出现，并按 taxonomy 替换：敏感 key 整值为 `***`，URL 为 `[REDACTED_URL]`，已注册 exact secret/credential/URL 为 `***`，不得统一成一个 `[REDACTED]`。过短通用字符串不得进入 exact 集合。另覆盖短 token 不误伤、非 64-hex credential 仍被 exact 替换。
+
+```powershell
+go test -run '^TestRedactor_' ./internal/logging
+```
+
+Expected: FAIL，包不存在或缺少符号。
+
+- [ ] **Step 2: 实现不可变规则快照**
+
+`ReplaceExact` 复制、去空和按长度降序排序，编译通用 regex 后一次 `Store`；读路径只 `Load`，不在记录时持锁。`ReplaceAttr` 递归 group，先按 key 整值替换，再处理 string/error/`LogValuer`。
+
+- [ ] **Step 3: 写 handler 格式 Red 并实现**
+
+用固定时间断言每行为单个 JSON object，`time` 为 RFC3339Nano 且含数值偏移，`level`、`msg`、`component` 存在，`component` 仅为 `daemon`/`tui`/`mihomo`（或更细 daemon 子系统名），JSON 中不出现 `source`。复合 attr 在 JSON 编码前已脱敏。
+
+```powershell
+gofmt -w internal/logging/redactor.go internal/logging/redactor_test.go internal/logging/handler.go internal/logging/handler_test.go
+go test ./internal/logging
+go test -race ./internal/logging
+```
+
+Expected: PASS。
+
+- [ ] **Step 4: Commit（仅得到授权时）**
+
+```powershell
+git add internal/logging/redactor*.go internal/logging/handler*.go
+git commit -s -m "feat: 增加日志结构化脱敏"
+```
+
+---
+
+### Task 5: 多进程安全 rotator
+
+**Files:**
+- Create: `internal/logging/config.go`
+- Create: `internal/logging/rotator.go`
+- Create: `internal/logging/rotator_test.go`
+- Create: `internal/logging/rotator_subprocess_test.go`
+
+**Interfaces:**
+
+```go
+const (
+	MaxCaptureLineBytes   = 16 << 10
+	MaxExportRecordBytes  = 1 << 20
+)
+
+type Config struct {
+	Level        slog.Level
+	MaxSizeBytes int64
+	MaxFiles     int
+}
+
+func DefaultConfig() Config   // info, 10 MiB, 3
+func BootstrapConfig() Config // debug, 100 MiB, 10
+
+type FailureClass string
+const (
+	FailureDropped FailureClass = "dropped"
+	FailureWrite   FailureClass = "write"
+	FailureRotate  FailureClass = "rotate"
+	FailureCleanup FailureClass = "cleanup"
+)
+
+type FailureReporter interface {
+	Report(class FailureClass, err error)
+}
+
+func NewFailureReporter(out io.Writer, redactor *Redactor, now func() time.Time) FailureReporter
+
+type RotatorOptions struct {
+	BasePath  string
+	Config    Config
+	PrivateFS *platform.PrivateFS
+	OpenLock  func(*platform.PrivateFS, string) (platform.AdvisoryLock, error)
+	WriteWait time.Duration
+	Reporter  FailureReporter
+}
+
+type RotatingWriter struct { /* mutex + atomic config/counters */ }
+
+func OpenRotatingWriter(context.Context, RotatorOptions) (*RotatingWriter, error)
+func (w *RotatingWriter) Write([]byte) (int, error)
+func (w *RotatingWriter) Apply(context.Context, Config)
+func (w *RotatingWriter) Dropped() uint64
+func (w *RotatingWriter) Close() error
+```
+
+- [ ] **Step 1: 写单进程轮转 Red**
+
+测试矩阵：整条 record 超阈值前轮转；预先放置 `.1`–`.9` 且 `max-files=3` 时 Open **只删 `.3+`、不改写活跃内容**，一次 rotate 后只留 base/.1/.2；`max-files=1` 的 **rotate** 换新 inode、全部 archive 被删且已打开旧 handle 不被清空；Apply 缩到 `max-files=1` 只删 archive、**不 ReplaceEmpty 活跃文件**；固定匹配 basename 的普通 suffix 才可 rename/delete；symlink/目录/异常 suffix 不跟随。溢出安全矩阵覆盖 `currentSize`/`incoming`/`maxSize` 接近 `math.MaxInt64` 的组合，禁止使用 `currentSize + len(record)`。失败风暴测试断言 `FailureReporter` 只输出限频、经 redactor 净化且不含完整路径的稳定类别。
+
+```powershell
+go test -run '^TestRotatingWriter_' ./internal/logging
+```
+
+Expected: FAIL，缺少 rotator。
+
+- [ ] **Step 2: 实现单进程核心和热 limits**
+
+`Write` 要求输入为一条完整 JSONL record；先进程 mutex，再以 `context.WithTimeout(..., 250*time.Millisecond)` 获 exclusive lock，获锁后打开/`Stat` base。轮转判定固定为：
+
+```go
+incoming := int64(len(record))
+needRotate := incoming > maxSize || (incoming <= maxSize && currentSize > maxSize-incoming)
+```
+
+禁止 `currentSize + incoming`。Open、Apply 缩容和每次 rotate 都在进程内 mutex 及同一 exclusive advisory lock 下先 `ReadDir` 再 `Remove` 掉 `suffix >= max-files` 的匹配普通文件，不能使用锁外目录项。**仅 rotate** 再执行经典移位（`max-files>1` 用 `Remove`+`Rename`；`max-files=1` 才 `ReplaceEmpty`）。枚举/改名/删除 **只** 走 `PrivateFS`，禁止 `os.ReadDir`/`os.Rename`/`os.Remove`。Open 用传入 context 可取消地等待锁；失败则关闭已取得资源并返回，不能无期限卡住启动。Open/Apply 不得移位或替换活跃 inode。rotate/`ReplaceEmpty` 前关闭本进程当前 write handle，再改名，再 `OpenAppend` 新 base。`Apply(ctx, cfg)` 有意无 error：先同步原子切换 config 值，再以 `min(ctx deadline, 250ms)` 等待 advisory lock；取得锁后的 `ReadDir`/`Remove` 同步执行、不受 context 抢占，文档不承诺整个维护在 250ms 内结束。`ctx` 取消或锁超时只停止尚未开始的维护，已切换的 level/limits 保留。失败分别计 `dropped`/`write`/`rotate`/`cleanup`，交给 `FailureReporter`，不把底层全文或完整路径交给 stderr。
+
+- [ ] **Step 3: 写两子进程 Red 并实现陈旧 handle 防护**
+
+helper subprocess 各写带 writer/sequence ID 的 2,000 条 JSONL，故意使轮转频繁。合并 base+archives 后每行可解码、不交叉、不重复，且没有 record 写到 rename 后的陈旧 inode。另让一个进程在 Open 收敛枚举点暂停、第二个进程 rotate，断言 Open 只有取得 exclusive lock 后才枚举/删除。注入永不成功锁，断言 Write 的 250ms deadline 路径返回整条丢弃、`Dropped()==1`，Open 的 context cancel 关闭已经取得的资源并及时返回。
+
+```powershell
+gofmt -w internal/logging/config.go internal/logging/rotator.go internal/logging/rotator_test.go internal/logging/rotator_subprocess_test.go
+go test ./internal/logging
+go test -race ./internal/logging
+```
+
+Expected: PASS，race 无报告。
+
+- [ ] **Step 4: Commit（仅得到授权时）**
+
+```powershell
+git add internal/logging/config.go internal/logging/rotator*.go
+git commit -s -m "feat: 实现多进程安全日志轮转"
+```
+
+---
+
+### Task 6: mihomo 行捕获与 logging runtime
+
+**Files:**
+- Create: `internal/logging/capture.go`
+- Create: `internal/logging/capture_test.go`
+- Create: `internal/logging/runtime.go`
+- Create: `internal/logging/runtime_test.go`
+
+**Interfaces:**
+
+```go
+type LineCaptureWriter interface {
+	io.WriteCloser
+	Flush() error
+}
+func NewLineCaptureWriter(logger *slog.Logger, level slog.Level, stream string) LineCaptureWriter
+
+type RuntimeOptions struct {
+	BasePath  string
+	Component string
+	Config    Config
+	PrivateFS *platform.PrivateFS
+	OpenLock  func(*platform.PrivateFS, string) (platform.AdvisoryLock, error)
+	Redactor  *Redactor
+	Reporter  FailureReporter
+}
+
+type Runtime struct { /* logger + level + rotator */ }
+func Open(context.Context, RuntimeOptions) (*Runtime, error)
+func (r *Runtime) Logger() *slog.Logger
+func (r *Runtime) Apply(context.Context, Config)
+func (r *Runtime) Config() Config
+func (r *Runtime) Close() error // 只关 rotator/lock/当前 write handle，不得 Close 共享的 PrivateFS
+func (r *Runtime) EnterRecordMutex() func() // PR 3 同进程 snapshot：先拿该 mutex 再 shared flock
+
+type Group struct { /* daemon + mihomo targets */ }
+func NewGroup(dir string, config Config, targets ...*Runtime) *Group
+func (g *Group) Apply(context.Context, Config)
+func (g *Group) Config() Config
+func (g *Group) Dir() string
+```
+
+`Runtime` 包内拆成不等待 IO 的 `swapConfig(Config)` 与 `convergeArchives(context.Context)`：前者同步替换 `LevelVar` 与 rotator limits，后者才获取 advisory lock 做 archive 收敛。`Runtime.Apply` 依次组合两者。`Group.Apply` 必须先对 daemon/mihomo 的**所有** target 调 `swapConfig`，再逐个调 `convergeArchives`；禁止 `for _, t := range targets { t.Apply(ctx, cfg) }`，否则第一个 target 的锁等待被取消时后续 target 会残留旧 config。`convergeArchives` 的 250ms/context 只约束锁获取。
+
+- [ ] **Step 1: 写 LineCaptureWriter 边界 Red**
+
+覆盖：一次多行、跨 Write 分割、CRLF、空行、非法 UTF-8 转 U+FFFD **并写 `invalid_utf8=true`**、16 KiB 内单条、超 16 KiB 截断并带 `truncated=true`、Flush 写出半行后仍可再 Write、Close 刷新未结尾行、Close 后 Write 返回稳定错误。stdout 映射 INFO，stderr 映射 WARN，attr 带 `component=mihomo`/`stream`，JSON 不含 `source`。注入永远失败的 logger 时，`Write` 仍返回 `len(p), nil`，不得把 slog/rotator 错误传出管道。
+
+```powershell
+go test -run '^TestLineCaptureWriter_' ./internal/logging
+```
+
+Expected: FAIL，缺少 writer。
+
+- [ ] **Step 2: 最小实现 capture**
+
+每次 `Write` 返回原输入 `len(p), nil`，即使日志 level 过滤或底层 JSONL 落盘失败也不误导子进程；失败只计入 logging 失败计数。只有 Close 后返回 `os.ErrClosed`。非法 UTF-8 替换为 U+FFFD 且 JSON 带 `invalid_utf8=true`。`Flush` 写出半行但不关闭。缓冲区永不超 `MaxCaptureLineBytes+utf8.UTFMax`。capture 必须可在多次子进程生命周期中继续 `Write`。测试：Close 前连续两次「写半行→Flush→再写」都成功；「写半行 → 子进程 Wait/Flush → 再 Start 写一行」得到两条独立 JSONL，不得粘成一行。
+
+- [ ] **Step 3: 写 Runtime/Group Red 并实现生命周期**
+
+断言 `Runtime.Open(ctx, ...)` 立即创建 base file且 ctx 取消能终止初始锁等待；`Apply(ctx, cfg)` 同步更新 `LevelVar` 与 rotator limits，即使传入已取消 context 也先完成内存切换，随后停止 archive 收敛。`Group.Apply` 必须先让 daemon/mihomo 的完整 config 全部 `swapConfig`，再逐 target `convergeArchives`；阻塞第一个 target 的 lock 并取消 context，第二个 target 也不得保留旧 config。另覆盖获锁后的假 `Remove` 忽略取消：维护会做完，不把已开始的本地文件系统调用伪装成 250ms 可中断。`Close` 幂等并不遗留 handle。JSON 固定 `component=daemon|tui|mihomo`。
+
+```powershell
+gofmt -w internal/logging/capture.go internal/logging/capture_test.go internal/logging/runtime.go internal/logging/runtime_test.go
+go test ./internal/logging
+go test -race ./internal/logging
+```
+
+Expected: PASS。
+
+- [ ] **Step 4: Commit（仅得到授权时）**
+
+```powershell
+git add internal/logging/capture*.go internal/logging/runtime*.go
+git commit -s -m "feat: 增加 mihomo 行捕获与日志 runtime"
+```
+
+---
+
+### Task 7: daemon/mihomo 生产装配与关闭顺序
+
+**Files:**
+- Modify: `internal/app/runtime.go`
+- Modify: `internal/app/runtime_test.go`
+- Modify: `cmd/mihari/main.go`
+- Modify: `cmd/mihari/main_test.go`
+- Modify: `internal/cli/root.go`
+- Create: `internal/cli/root_test.go`
+- Modify: `internal/control/client/client.go`
+- Modify: `internal/control/client/client_test.go`
+- Modify: `internal/supervisor/command.go`
+- Modify: `internal/supervisor/command_test.go`
+
+**Interfaces:**
+
+```go
+type RuntimeBuildOptions struct {
+	InitialSetupRequired bool
+	SettingsPath         string
+	ServiceStatus        func() (string, error)
+	MihomoStdout         io.Writer
+	MihomoStderr         io.Writer
+	OnBackgroundError    func(component string, err error)
+}
+
+type daemonRunDeps struct {
+	Paths         platform.Paths
+	PrivateFS     *platform.PrivateFS
+	Token         string
+	Version       string
+	Endpoint      string
+	Ready         chan<- struct{}
+	ServiceStatus func() (string, error)
+}
+func runDaemonWith(ctx context.Context, deps daemonRunDeps) error
+
+func resolveCredentialPath(absolutePaths platform.Paths) (string, error)
+func (c *client.Client) SetToken(token string)
+
+type processLocalRoot struct {
+	Paths platform.Paths
+	FS    *platform.PrivateFS
+	Token string
+}
+func prepareLocalRoot() (processLocalRoot, error)
+
+// cli.Dependencies 新增；nil = 测试跳过数据根 IO
+PrepareLocalRoot func() error
+
+type daemonLoggingResources struct {
+	StdoutCapture io.Closer
+	StderrCapture io.Closer
+	MihomoRuntime io.Closer
+	DaemonRuntime io.Closer
+	PrivateFS     io.Closer
+}
+func (r *daemonLoggingResources) Close() error
+```
+
+`BuildRuntime` 的旧 stdout/stderr 入参保留为兼容 wrapper。`MihomoStdout`/`MihomoStderr` 非 nil 时 **只** 把它们接到 `CommandStarter`；生产调用 positional 传 `io.Discard`，不得把 `os.Stdout`/`os.Stderr` 与 capture 并联（禁止 tee 到服务控制台）。`CommandStarter.Start` 返回的 Child 在 `Wait()` 返回后对 Stdout/Stderr 若实现 `Flush() error` 则 Flush，不得 Close capture。`OnBackgroundError` 传入 `runtime.Options`。
+
+抽出可测的 `prepareLocalRoot()`（`package main`）。`cli.Dependencies` 新增 `PrepareLocalRoot func() error`：nil 时 PreRun 不做数据根 IO（现有 `cli.Execute` 测试保持隔离）。`main` 在 `cli.Execute` **之前**只构造 endpoint 与 **空 token** 的 `controlclient.New`，不得调用 `DefaultPaths().Absolute`、`NewPrivateFS` 或 `credential.LoadOrCreate`。生产注入：
+
+```go
+PrepareLocalRoot: func() error {
+	root, err := prepareLocalRoot() // 进程内 Once；测试可重置；Close 只关已缓存结果，禁止为 Close 再入 Once
+	if err != nil { return err }
+	localClient.SetToken(root.Token)
+	return nil
+}
+```
+
+`PersistentPreRunE` 先调用该回调（若非 nil），再保留现有 `SetupError` 短路，禁止删掉 `TestSetupErrorUsesDataExitCode` 路径。禁止 `internal/cli` import `cmd/mihari` 或自己调 `NewPrivateFS`。Cobra `--help`、`help` 子命令、以及只打印 buildinfo 的 `self version` 必须跳过该回调。`main` 不得 `os.Exit(cli.Execute(...))` 直接丢掉 Close：必须先收退出码，只 Close **已经缓存** 的 `processLocalRoot.FS`（含 nil），再 `os.Exit`。**禁止**为 Close 再次进入 `prepareLocalRoot`/`Once`。`--help`/`self version` 跳过回调时 Once 未跑，缓存为 nil，收尾 Close 为零 IO。`cmd/mihari` 表驱动测试必须重置 Once（或每例 helper 子进程），禁止跨用例共享第一次的 Root/token/FS。`PrepareLocalRoot` 失败以返回值把 `APIError{CodeDataFailure}` 交给 PreRun，不要依赖 Execute 前拷贝的 `Dependencies.SetupError` 值字段。跳过回调的 help 路径仍保留现有 `SetupError` 短路。`SetToken` 对空串是 no-op；测试覆盖 PreRun 后 `status` 使用的 Bearer 与 daemon/TUI 相同。`prepareLocalRoot` 顺序：`absolutePaths, pathsErr := platform.DefaultPaths().Absolute()`，成功后立刻 `processFS, fsErr := platform.NewPrivateFS(absolutePaths.Root)`，随后只调用一次 `resolveCredentialPath(absolutePaths)`。该 helper 在 `MIHARI_CONTROL_CREDENTIAL` 非空时对其 `filepath.Abs/Clean`，为空时返回 `absolutePaths.ControlToken`；两种相对路径都以进程启动 working directory 为基准。`NewPrivateFS` 成功后才允许默认 in-root token 的 `LoadOrCreate`。失败时：凡最终 credential path 落在 `absolutePaths.Root` 下（默认或 `MIHARI_CONTROL_CREDENTIAL` 显式指回根内）都只 `Load`，禁止 `MkdirAll`/`LoadOrCreate`；`Load` 的缺文件、权限或损坏错误也不得写入 CLI `SetupError`，token 可为空。只有解析后位于 dataRoot **外** 的显式 credential 才允许在 `PrivateFS` 失败后 `LoadOrCreate`。`fsErr` 本身不得写入 `SetupError`。`SetupError` 仅用于 `Absolute`/`resolveCredentialPath` 失败，以及 `PrivateFS` **成功之后** 的默认 token `LoadOrCreate` 失败。token 只从最终 path 加载一次，local client、daemon/TUI closures 与 redactor 共用该 token，不再调用 `transport.DefaultCredentialPath()` 重算。路径或 credential 解析失败时不做任何 data-root/credential IO，把固定 `resolve Mihari data root` 或 `resolve Mihari control credential` 放入 `SetupError`。`runDaemonBody` 装配 `daemonRunDeps{Paths: absolutePaths, PrivateFS: processFS, Token: token, ServiceStatus: 现有 serviceManager.Status 闭包, ...}` 并调用 `runDaemonWith`，该闭包继续传给 `RuntimeBuildOptions.ServiceStatus`。`processFS` 由 `prepareLocalRoot` 创建：daemon/TUI 接管后由各自 cleanup Close；CLI/`SetupError` 提前返回时 main 在 `cli.Execute` 之后幂等 Close。Unix relaunch 前必须由 TUI cleanup 关闭，不能依赖 main 在 `Run` 返回之后的 defer。双重 Close 安全。测试分别注入相对 `MIHARI_DATA`、未设置和相对/绝对 `MIHARI_CONTROL_CREDENTIAL`，断言默认 credential/Settings/logger 共用绝对 Root，而显式 credential 保留其独立绝对位置但 daemon/TUI 仍使用同一 token；另注入 Abs 失败 seam，断言没有 token/目录 IO。再覆盖：`mihari --help`、`mihari help`、`mihari daemon --help`、`mihari self version` 经 `cli.Execute` 时 `NewPrivateFS`/`MkdirAll`/`LoadOrCreate` spy 为零；`mihari status` 经 PreRun 后 client token 非空（注入已有 token 文件）；`NewPrivateFS` 失败后，默认 in-root 与显式 in-root credential 的 `MkdirAll`/`LoadOrCreate`/`EnsureDirs` spy 为零；缺 token 文件时 `SetupError` 仍为 nil。必须经 `cli.Execute`（Interactive、无子命令）断言会调用 `RunTUI` 且 `PrivateFS=nil`。daemon `runDaemonWith` 在 nil fs 时返回稳定 data failure 且零 Settings IO。`runDaemonWith` 测试继续使用 `t.TempDir()` Paths、先 `NewPrivateFS` 再传入 deps，以及 `transporttest.Endpoint(t)`，禁止打到真实用户数据根或默认 named pipe。
+
+- [ ] **Step 1: 写装配 Red**
+
+测试注入 bytes buffer/capture spy，证明 `CommandStarter.Stdout/Stderr` 只来自 `MihomoStdout/MihomoStderr`，positional stdout/stderr 即使非 Discard 也不进入 Starter。调用 Manager 背景错误路径后 daemon logger 收到脱敏 component/error。用五个 `io.Closer` spy 单测 `daemonLoggingResources.Close` 的 capture stdout→capture stderr→mihomo runtime→daemon runtime→PrivateFS 顺序、`errors.Join` 与全部继续执行，不要求替换具体 `NewPrivateFS`/`logging.Open` 构造器。`TestRunDaemon_LoggingOpensBeforeBuildRuntime` 与 `TestRunDaemon_CatalogLoadFailureStillOpensLogger` 都必须：`Endpoint: transporttest.Endpoint(t)`、`Ready` channel、在 goroutine 里调 `runDaemonWith`、看到 Ready 或 JSONL 后 cancel、`t.Cleanup` 等待退出。不得同步调用卡在 `Serve`，不得使用空 Endpoint（Windows 会撞默认 `\\.\pipe\mihari-control`）。前者：注入 temp Paths，Open 成功后故意让 BuildRuntime 失败，degraded daemon 的 JSONL 仍存在且含 token/secret 的记录已被脱敏。后者：损坏 catalog 时仍 Open，不在 Open 前 return。
+
+```powershell
+go test -run '^TestBuildRuntime.*(Capture|Background)$' ./internal/app
+go test -run '^TestRunDaemon_(LoggingOpensBeforeBuildRuntime|CatalogLoadFailureStillOpensLogger)$' ./cmd/mihari
+```
+
+Expected: FAIL，新 options 或 `runDaemonWith` 尚未接入。
+
+- [ ] **Step 2: 在 `runDaemonWith` 打开 logger**
+
+顺序必须为：`deps.PrivateFS`（进程入口已创建；nil 则立即 data failure，零 `EnsureDirs`/Settings IO）→ `EnsureDirs` → `LoadOrCreateWithSidecar` → `EnsureDir(LogDir)` → 收集 exact secrets 并 `ReplaceExact` → 用 daemon context 打开 daemon/mihomo Runtime →创建 stdout/stderr capture → `BuildRuntimeWithOptions(..., io.Discard, io.Discard, options{MihomoStdout, MihomoStderr, ...})` → `daemon.Run`。`runDaemonWith` 不得再次调用 `NewPrivateFS`。本 PR Settings 尚无 `log` 块，因此打开时使用 `DefaultConfig()`；PR 2 必须在同一打开点改用 `settings.EffectiveLogging()` 并把启动加载迁移到 outcome API，本任务不得把自定义 YAML 永久绑死成 info/10/3。
+
+`ReplaceExact` 必须发生在 `Open` 之前。token 与 `settings.ControllerSecret` 已有则注册。`panel.LoadOrCreateCredential` 与 catalog URL（`subscription.LoadOrCreate` / 一次性 `Open` 后只读 Snapshot，不保留第二份长期 Service）成功才加入 exact 集合；**任一步失败不得在 Open 前 `return`**，跳过那些值，仍 EnsureDir+Open，再让 BuildRuntime 失败走 degraded。cleanup `defer` 必须包住 degraded 与正常两条 `daemon.Run` 路径。通用 URL/64-hex regex 不能替代 exact 值。`FailureReporter` 接到限频 stderr。`logging.Open` 对 `filepath.Dir(BasePath)` 再调一次 `EnsureDir`。
+
+关闭顺序由 `daemonLoggingResources.Close` 和外层 `sync.Once` 固化，且 **只在 `daemon.Run` 返回后** 执行：supervisor 已等子进程；先 `Close` stdout/stderr capture 刷新残行，再关 mihomo Runtime，再关 daemon Runtime，最后 `PrivateFS.Close`。capture 在 mihomo 重启之间保持打开，子进程退出不得 Close；任何 Runtime/lock 仍可能使用 fs 时不得提前关 fs。错误用 `errors.Join` 合并，不提前跳过后续 close。daemon 或 mihomo 任一侧 `logging.Open` 失败都是启动失败，必须 `return` 该错误，不得带着缺失的 `mihomo.log`/`mihari-daemon.log` 继续 `daemon.Run`。已打开的一侧与 fs 仍走同一 cleanup。正常、degraded、BuildRuntime 失败都走同一 cleanup；组合类型允许直接注入 `io.Closer` spy，断言 fs 最后且只关一次。
+
+- [ ] **Step 3: 验证正常/降级生命周期**
+
+```powershell
+gofmt -w internal/app/runtime.go internal/app/runtime_test.go cmd/mihari/main.go cmd/mihari/main_test.go internal/supervisor/command.go internal/supervisor/command_test.go
+go test ./internal/app ./internal/supervisor ./internal/cli ./internal/control/client ./cmd/mihari
+go test -race ./internal/app ./internal/supervisor ./internal/cli ./internal/control/client ./cmd/mihari
+```
+
+Expected: PASS，测试 temp dir 中出现 daemon/mihomo JSONL，不含注入 secret。`TestCommandStarter_FlushesCaptureOnWait`：半行 stdout 在 Wait 后成为一条 JSONL，随后再 Start 写入的一行是另一条。
+
+- [ ] **Step 4: Commit（仅得到授权时）**
+
+```powershell
+git add internal/app/runtime.go internal/app/runtime_test.go cmd/mihari/main.go cmd/mihari/main_test.go internal/cli/root.go internal/cli/root_test.go internal/control/client/client.go internal/control/client/client_test.go internal/supervisor/command.go internal/supervisor/command_test.go
+git commit -s -m "feat: 接入 daemon 与 mihomo 文件日志"
+```
+
+---
+
+### Task 8: TUI bootstrap 日志与失败降级
+
+**Files:**
+- Modify: `internal/tui/run.go`
+- Modify: `internal/tui/run_test.go`
+- Modify: `internal/tui/model.go`
+- Modify: `cmd/mihari/main.go`
+- Modify: `cmd/mihari/main_test.go`
+
+**Interfaces:**
+
+```go
+type LocalLoggingHealth interface{ Available() bool }
+
+type LoggingResources struct {
+	Runtime   *logging.Runtime
+	Redactor  *logging.Redactor
+	PrivateFS *platform.PrivateFS
+	Health    LocalLoggingHealth
+}
+func (r *LoggingResources) Close() error
+
+type LoggingFactory func(context.Context) (LoggingResources, error)
+
+type Options struct {
+	// existing fields remain
+	OpenLogging LoggingFactory // nil = 不打开 TUI 文件日志，health.Available()==false
+	ErrorOutput io.Writer
+}
+
+func finishRun(final tea.Model, runErr error, warningWriter io.Writer, relaunch func() error, cleanup func(tea.Model) error) error
+```
+
+抽出 `openTUILogging(ctx context.Context, paths platform.Paths, token string, fs *platform.PrivateFS) (tui.LoggingResources, error)`。`paths.Root` 必须已经绝对化；`fs` 必须是进程入口已经创建的那一份，本函数不得再调 `NewPrivateFS`。顺序固定：复用 `fs` → `EnsureDir(LogDir)` → `NewRedactor(token)` → 再用 ctx 尝试 `Open`（`BootstrapConfig()`）。`fs == nil` 时保存该错误，仍可用 token 构造 redactor，返回 `PrivateFS=nil` 且不再尝试 EnsureDir/Open。`EnsureDir` 失败时保存该错误但仍构造 redactor，不再尝试 Runtime.Open，并返回包含 fs/redactor 的 partial resources。`cmd/mihari` 的 TUI closure 复用进程入口已经解析的 absolute Paths、最终 credential token 与 `processFS`；测试先对 temp Root 调 `NewPrivateFS` 再注入，或显式传 nil fs。返回值即使伴随 error，也必须保留已经成功创建的 redactor/`PrivateFS`，让 `Run` 接管并最终关闭。Open/EnsureDir/`PrivateFS=nil` 时 TUI 仍运行，`health.Available()==false`，stderr 降级；redactor 与非 nil `PrivateFS` 仍交给 PR 3 Export。`LoggingResources.Close` 幂等，先 Close Runtime，再 Close `PrivateFS`（nil 跳过），使用 `errors.Join`；PR 2/3 会在它之前插入 applier/export wait。本 PR 把 health 从 `Run` 注入 root Model，UI 文案在 PR 2 落地。
+
+- [ ] **Step 1: 写 TUI 启动/失败 Red**
+
+`internal/tui` 测试断言 factory 以 Run context 在 session 之前调用；正常退出、Bubble Tea 返错、relaunch 路径都只 Close 一次，顺序为 session → Runtime → `PrivateFS`，且全部 **发生在 relaunch 回调之前**（对标 `TestFinishRunCleansUpSessionBeforeRelaunch`）。`finishRun` 把 final model 传给 cleanup，PR 1 暂不使用该值；PR 3 改为 `Run` 持有稳定 ExportLogsModel 指针并直接 `CancelAndWait`，不得从 final model 类型断言回找 runner。factory 返回部分 resources+error 时 TUI 仍运行并最终关闭非 nil fs；传入 nil fs 时 TUI 仍运行、不创建数据根、`health.Available()==false`；`ErrorOutput` 只出现稳定净化文案且限频；bootstrap exact 为 debug/100 MiB/10。`cmd/mihari` 的 `TestOpenTUILogging_UsesInjectedPaths` 用 absolute temp Paths 和调用方创建的 `PrivateFS`，并增加 relative Paths 被入口 `Absolute`+`NewPrivateFS` 后成功、credential override 位于根外且根尚不存在仍由进程入口创建 TUI 日志、ctx 取消初始锁等待、入口 `NewPrivateFS` 失败后默认 token 零创建的测试，不得读真实用户目录。
+
+```powershell
+go test -run '^TestRun.*Logging$' ./internal/tui
+go test -run '^Test(OpenTUILogging|ResolveCredentialPath|PrepareLocalRoot|HelpCreatesNoDataRoot)_' ./cmd/mihari
+```
+
+Expected: FAIL，Options 或 `openTUILogging` 尚未接入。
+
+- [ ] **Step 2: 实现装配与幂等 cleanup**
+
+`Run` 首先尝试 `OpenLogging` 并无论 err 是否为空都接管返回的 `LoggingResources`，成功后记录 TUI start。现有 `Run` 在 `options.Client != nil` 时执行 `model = newModelWithClientContext(...)` **整棵替换** Model。health、OpenLogging 注入、以及后续 PR 的 applier/`exportLogs` 必须在这次替换之后写入最终 model，仿照现有 `SetServiceController`；禁止写进第一份 `NewModel()`。session Close 与 resources Close 使用同一个 `sync.Once` cleanup，并以 `func(final tea.Model) error` 传给 `finishRun`；本 PR 顺序为 session → Runtime → `PrivateFS`，并在调用 `Relaunch` **之前**完成。cleanup error 经 redactor 后写 warning，仍继续后续 close；`finishRun` 不得因首个 close error 跳过 Relaunch 前其余清理。禁止只靠 `Run` 返回之后的 `defer Close`：Unix `syscall.Exec` 成功不会跑到那之后。初始化失败时使用只记首次+固定时窗的 stderr reporter，优先使用返回的 Redactor.String；无 redactor 时只输出固定文案，不输出完整路径或底层错误。
+
+- [ ] **Step 3: 验证 TUI 包**
+
+```powershell
+gofmt -w internal/tui/run.go internal/tui/run_test.go internal/tui/model.go cmd/mihari/main.go cmd/mihari/main_test.go
+go test ./internal/tui ./cmd/mihari
+go test -race ./internal/tui ./cmd/mihari
+```
+
+Expected: PASS。
+
+- [ ] **Step 4: Commit（仅得到授权时）**
+
+```powershell
+git add internal/tui/run.go internal/tui/run_test.go internal/tui/model.go cmd/mihari/main.go cmd/mihari/main_test.go
+git commit -s -m "feat: 接入 TUI bootstrap 文件日志"
+```
+
+---
+
+### Task 9: 文档与 PR 1 总验收
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/commands.md`
+- Add: `docs/superpowers/specs/2026-09-02-file-logging-export-design.md`
+- Add: `docs/superpowers/plans/2026-09-02-file-logging-foundation.md`
+
+- [ ] **Step 1: 更新用户文档**
+
+说明三个 JSONL 路径、默认 info/10 MiB/3、mihomo stdout=INFO/stderr=WARN、多 TUI 共享文件、脱敏是 best effort 且日志仍应按敏感资料处理。本 PR 不宣称配置 UI 或导出已可用。
+
+- [ ] **Step 2: 包级、race、vet 与全仓验证**
+
+```powershell
+gofmt -l .
+go test ./internal/platform ./internal/logging ./internal/supervisor ./internal/app ./internal/tui ./cmd/mihari
+go test -race ./internal/platform ./internal/logging ./internal/supervisor ./internal/app ./internal/tui ./cmd/mihari
+go test ./...
+go vet ./...
+git diff --check
+```
+
+Expected: `gofmt -l .` 无输出，全部 PASS，`git diff --check` 无错误。
+
+- [ ] **Step 3: 六目标 CGO-free 编译**
+
+```powershell
+$env:CGO_ENABLED='0'
+$targets=@(@('windows','amd64','.exe'),@('windows','arm64','.exe'),@('linux','amd64',''),@('linux','arm64',''),@('darwin','amd64',''),@('darwin','arm64',''))
+foreach($t in $targets){$env:GOOS=$t[0];$env:GOARCH=$t[1];go build -o (Join-Path $env:TEMP ("mihari-{0}-{1}{2}" -f $t[0],$t[1],$t[2])) ./cmd/mihari;if($LASTEXITCODE -ne 0){throw "build failed: $($t[0])/$($t[1])"}}
+```
+
+Expected: 六目标编译成功。
+
+- [ ] **Step 4: 审查准确变更范围**
+
+```powershell
+git status --short
+git diff --stat
+git diff --name-only
+```
+
+不得出现 `CHANGELOG.md`、`internal/control/protocol/**`、`internal/config/settings.go`。除 spec 和本 plan 外，只应有本文 File Structure 所列生产/测试/文档（含 `internal/cli/root.go`、`internal/control/client/client.go`、`README.zh-CN.md`）。Windows 本地 `go test` 覆盖 Windows 文件；Unix no-follow/mode/lock 测试必须由 CI 的 Ubuntu 或 macOS job 实际执行，不能只靠六目标 `go build`。
+
+- [ ] **Step 5: Commit 文档（仅得到授权时）**
+
+```powershell
+git add README.md README.zh-CN.md docs/commands.md docs/superpowers/specs/2026-09-02-file-logging-export-design.md docs/superpowers/plans/2026-09-02-file-logging-foundation.md
+git commit -s -m "docs: 记录文件日志行为"
+```
+
+---
+
+## Self-Review
+
+| Spec 要求 | 任务 |
+| --- | --- |
+| TUI 日志狭义架构例外 | Task 1 |
+| 五个日志/导出路径、相对 Root 一次性绝对化；保留并绝对化 credential override；`EnsureDir(LogDir)` 才是加固，`EnsureDirs` 不是 | Task 1–2、7–8 |
+| 缺失 dataRoot 安全创建；Unix 0700/0600 与 owner；Windows protected DACL、逐段 no-follow、`FILE_SHARE_DELETE`；opaque `FileIdentity`、可关闭 `DirectoryIdentity`、`OpenReadChecked`；幂等 `PrivateFS.Close`/`os.ErrClosed` | Task 2、7–8 |
+| `flock` / `LockFileEx`、context 取消、进程退出释放 | Task 3 |
+| exact secrets + URL/auth/key/64-hex 脱敏 taxonomy，JSONHandler 时间格式与 `component` | Task 4 |
+| 整 record 临界区、溢出安全 size 判断、250ms、陈旧 handle、Open/Apply/rotate 收敛均持 exclusive lock、Open context 可取消、仅 rotate 移位/`max-files=1` 新 inode | Task 5 |
+| stdout INFO/stderr WARN、chunk/UTF-8/16 KiB/Close 语义 | Task 6 |
+| Runtime/Group 无失败 `Apply(ctx, Config)` 先对全部 target `swapConfig`，再逐个做锁获取受 250ms/context 约束的 `convergeArchives` | Task 5–6 |
+| 选定命令的 `prepareLocalRoot` 先 `NewPrivateFS` 再默认 token/`EnsureDirs`；`--help`/`--version` 零数据根 IO；Settings 后 `EnsureDir(LogDir)`、Open 前 ReplaceExact（catalog/credential 失败仍 Open）、`FailureReporter`、degraded 可记录；nil fs 时 daemon 零 Settings IO | Task 7 |
+| capture 独占 CommandStarter、跨 mihomo 重启存活，仅 daemon 关闭路径 Close | Task 6–7 |
+| `runDaemonWith` 可注入绝对 Paths 与已创建的 `PrivateFS`；`resolveCredentialPath` 保留 override；positional stdout 为 Discard；可注入 closer composite 固化 capture→runtime→PrivateFS 关闭 | Task 7 |
+| TUI debug/100 MiB/10；缺失 root 由进程入口创建；`openTUILogging(ctx, paths, token, fs)` 复用入口 fs 并返回可接管的完整 resources；nil fs 时 TUI 仍运行；session→logger→PrivateFS Close 在 Relaunch 之前；`O_CLOEXEC`/`InheritHandle=false` | Task 2、8 |
+| 文档、race/vet/全仓/六目标 CGO-free、Windows+Unix CI 实测 | Task 9 |
+
+**Placeholder scan:** 计划不含占位任务或未定接口；`Paths.Absolute`、`prepareLocalRoot`/`processLocalRoot`、`Client.SetToken`、`resolveCredentialPath`、`RuntimeOptions`、`RuntimeBuildOptions`、`daemonRunDeps`（含 `PrivateFS`）/`runDaemonWith`、`daemonLoggingResources`、`LoggingResources`/`openTUILogging(ctx, paths, token, fs)`、`PrivateFS`（含 `FileIdentity`/`DirectoryIdentity`/`ReadDir`/`OpenDirIdentity`/`OpenReadChecked`/`Rename`/`Remove`/`Close`）、包内 `swapConfig`/`convergeArchives`、`tryLock() (busy bool, err error)`、`OpenAdvisoryLock(*PrivateFS, path)`、`FailureReporter`、`LineCaptureWriter.Flush`、`Config`、`Runtime`、`Group` 的输入输出均已固定。
+
+**Type consistency:** 大小在 logging runtime 使用 `int64` bytes，份数在内部使用 `int`；PR 2 的稳定 DTO 使用 `int64` 后只在经过 `1..10` 校验后转换。写入路径通过 `io.Writer`，捕获关闭路径通过 `io.WriteCloser`。

--- a/docs/superpowers/specs/2026-09-02-file-logging-export-design.md
+++ b/docs/superpowers/specs/2026-09-02-file-logging-export-design.md
@@ -1,0 +1,518 @@
+# 文件日志、轮转与 zip 导出设计
+
+日期：2026-09-02
+
+状态：已批准，准备实施
+
+目标分支：`feat/file-logging-export`
+
+工作目录：`.worktrees/feat-file-logging-export`
+
+## 1. 背景
+
+Mihari 今天的「Logs」只是 mihomo controller 的实时 WebSocket 流：
+
+- TUI Logs 页把事件放进最多 1 万条的内存环形缓冲，关掉 TUI 即丢失。
+- CLI `mihari logs` 不带 `--follow` 时只打印一条。
+- 数据根预留了 `logs/mihari.log`，`EnsureDirs()` 会创建目录，但没有任何代码写入该文件。
+- Mihari daemon / TUI 没有 slog，也没有落盘。质量审计曾拒绝「引入 slog 全局 logger」，那是当时范围外的选择，不是架构禁令。
+- 作为 Windows 服务运行时，mihomo stdout/stderr 绑在服务进程标准输出上，用户通常找不到。
+- 没有导出、没有轮转、没有 System 页配置。用户反馈问题后无法交出可复盘的历史日志。
+
+排障需要的是：daemon、TUI、mihomo 三类日志随时能写到文件；文件按大小轮转；用户能在 TUI 里改级别、大小与保留份数，并按时间范围打 zip 发出来。
+
+## 2. 目标
+
+- daemon、TUI、mihomo 分别写入数据根下三个 JSONL 日志文件，进程一启动就能写；daemon 未运行时 TUI 仍能写自己的文件。
+- 多个 TUI 实例可同时写 `mihari-tui.log`，不得因跨进程 write/rotate 竞争造成丢行、交叉覆盖或错误删除。
+- 三个文件共用一套配置：级别、单文件大小、保留份数。配置在 `mihari.yaml`，只经 daemon 控制面修改；daemon 与已连接的 TUI 热更新。
+- System 页新增 Logging 区；Logs 页与 Logging 区都能打开同一套导出对话框。
+- 导出生成 zip（唯一格式），默认目录 `{dataRoot}/logs-export/`，成功后显示绝对路径并一键复制。
+- 导出在日志继续写入、轮转或多个 TUI 并存时仍读取一个有界、无重复的快照；取消或失败不得留下目标 zip。
+- 导出按用户本地时区选择时间范围，对话框展示当前时间与时区偏移，避免 UTC/本地混淆。
+- Mihari 自己持有的 controller secret、Web credential、control token、订阅 URL 与认证字段不得进入日志或导出；权限在 Unix 和 Windows 上都必须限制到数据所有者及必要的服务账户。
+- 保持 `CGO_ENABLED=0`，不新增第三方依赖，不改 `CHANGELOG.md`。
+
+## 3. 非目标
+
+- 不改 TUI Logs 页的数据源：它仍是 mihomo 实时流（过滤、暂停、环形缓冲保持原样）。本设计只在该页加 Export，不把 daemon/TUI 文件日志接进该页。
+- 不提供 CLI `mihari logs export` / `mihari logging`（控制面先落地，CLI 可后续加）。
+- 不支持 7z、tar.gz、gzip；导出只有 zip。
+- 不弹系统文件管理器，不「打开所在文件夹」。
+- 不把 Mihari 的 log level 同步成 mihomo 配置里的 `log-level`；mihomo 仍使用生成配置中的 `info`。mihomo 文件只记录它实际写到 stdout/stderr 的内容。
+- 不把 status、settings、订阅 catalog、token 打进 zip。
+- 不压缩已轮转的 `.log.N`（压缩只发生在导出 zip）。
+- 不引入 lumberjack 或其他日志库。
+- 不把 slog 做成全局 `slog.SetDefault` 强制所有包使用；logger 由装配点注入或作为包级显式依赖。
+- 不为一次性 CLI 子命令写文件日志。
+- 不在本功能中修改 coordinator 的全局 revision 溢出行为；该问题由 GitHub Issue #191 独立跟踪。
+
+## 4. 方案比较
+
+### 4.1 采用：分文件落盘 + TUI 本地 zip 导出
+
+三个来源各写各的逻辑文件。配置由 daemon 写入 `mihari.yaml`。导出由 TUI 直接读取 `logs/` 的受控快照、过滤并写 zip。这满足「任何时候都能写、daemon 挂了也能把文件给你」。
+
+对「daemon 单写入者」的明确例外：
+
+- daemon 追加 `mihari-daemon.log` 和 `mihomo.log`；一个或多个 TUI 只追加共享的 `mihari-tui.log`。
+- 所有进程只通过 `internal/logging` 的受锁 writer 写日志，不得自行 open/rename/delete 日志文件。
+- TUI 不写 `mihari.yaml`、订阅、token、面板或 daemon settings；日志配置变更仍只走 daemon 控制面。
+- TUI 读取日志只用于导出，不把文件内容当成第二份控制面真相。
+- 该例外必须与第一批 TUI 文件写入代码在同一 PR 落入根 `AGENTS.md` 和 `docs/architecture.md`。
+
+### 4.2 不采用：单一 `mihari.log` 由 daemon 代写
+
+TUI 在连上 daemon 之前无法落盘，恰好丢掉启动和连接失败——这是最需要的日志。
+
+### 4.3 不采用：导出走控制 API
+
+这更贴近单写入者，但 daemon 不可用时导出失败。第一期不采用。控制面仍只负责读写日志配置。
+
+### 4.4 不采用：每个 TUI 写 PID 专属文件
+
+PID/会话专属文件可以绕开写竞争，但会让跨会话保留数量无限增长，并让导出和清理语义依赖进程存活判断。采用共享逻辑文件和跨进程锁后，三个固定来源及统一保留上限都能维持。
+
+### 4.5 不采用：slog 文本 / logfmt
+
+mihomo stdout 是任意文本（引号、等号、空格）。JSONL 把净化后的原行放进 `msg`，转义由 `encoding/json` 负责。导出按 `time` 过滤只需解析 JSON。
+
+## 5. 详细设计
+
+### 5.1 包、平台边界与装配
+
+新增 `internal/logging`：
+
+- 构造 slog handler（JSONL、`slog.LevelVar`、轮转 writer）；
+- 同进程与跨进程串行写入、轮转、热更新与失败计数；
+- mihomo stdout/stderr 的按行捕获；
+- 结构化脱敏；
+- 导出快照、时间过滤、zip 与 manifest。
+
+平台差异不散落在 `internal/logging`。以下小能力放在 `internal/platform` 的 `_windows.go` / `_unix.go` / `_linux.go` / `_darwin.go` 实现中，并通过最小接口注入测试：
+
+- 日志文件的跨进程共享锁；
+- opaque file identity、checked-open 与 Windows 可删除共享方式的只读快照句柄；
+- Unix mode 与 Windows DACL 的安全创建/加固；
+- 持有 source/target 目录 identity、私有 workspace，以及 workspace→parent 不覆盖既有目标的文件发布。
+
+装配：
+
+| 进程 | 入口 | 文件 | `component` |
+|---|---|---|---|
+| daemon | `cmd/mihari` 的 `runDaemonBody`，Settings 与目录准备完成后、`BuildRuntime` 之前打开 | `logs/mihari-daemon.log` | `daemon` 及更细的 slog attr（`supervisor` / `scheduler` / `web-gateway` 等） |
+| TUI | `tui.Run` 开始时以保守 bootstrap 配置打开 | `logs/mihari-tui.log` | `tui` |
+| mihomo | daemon 里 `supervisor.CommandStarter` 的 Stdout/Stderr 接到两个 line capture writer | `logs/mihomo.log` | `mihomo`，另有 `stream=stdout\|stderr` |
+
+`OnBackgroundError` 在生产装配中接到 daemon logger，不再丢弃。一次性 CLI 仍只把错误写到 stderr。
+
+资源所有权：
+
+- daemon/TUI 各自拥有并在退出时关闭自己的 slog handler 与 rotator；装配点同时拥有一个持有 dataRoot 目录 handle 的 `PrivateFS`，不得把它交给 logger 或 Export 隐式关闭；
+- supervisor 在每次 `Start()` 复用同一对 capture writer；capture **跨 mihomo 重启存活**，只在 daemon 关闭路径 `Close`。`CommandStarter` 包一层 Child：`Wait()` 返回后对 Stdout/Stderr 若实现 `Flush() error` 则 Flush，**不得 Close**（否则下次 `Write` 得到 `os.ErrClosed`，mihomo 日志中断）。这样上一代半行不会和下一次 `Start` 的首 chunk 粘成一行；
+- capture writer 的 `Close`/`Flush` 只处理自己的半行，不关闭共享 mihomo logger；
+- daemon 先停止 supervisor，再 `Close` capture，再关闭 mihomo/daemon logger，最后关闭不再有使用者的 `PrivateFS`；
+- TUI 先停止 session 事件生产，再 cancel+wait 导出 runner 与本地 Logging applier，随后关闭 logger/lock，最后关闭 `PrivateFS`；全部使用同一条 once-cleanup，在 `finishRun` 里、调用 `Relaunch` **之前**完成。`tui.Run` 必须持有并向 root/cleanup 注入同一份全生命周期 ExportLogsModel，不从 final model 类型断言回找 runner；每次打开只重置表单，generation 单调不复用。导出 runner 必须在 `Update` 返回前同步登记并启动自己拥有的 goroutine；返回给 Bubble Tea 的 `tea.Cmd` 只等待一个容量为 1 的结果 channel，不能承担启动 Export 的职责。runner 在写入/关闭 result channel 后才关闭本次 `done`，且此后不再访问所拥有资源。这样即使 Bubble Tea 在 `Update` 返回后、Cmd 入队前取消，cleanup 仍有一个必定结束并关闭 `done` 的实际 runner 可等待。Unix 自更新是 `syscall.Exec`，成功则不会跑 `finishRun` 之后的 `defer`；
+- Unix 打开日志/lock/temp 一律 `O_CLOEXEC`；Windows `InheritHandle=false`，避免 Exec/`CreateProcess` 继承未关的 fd 导致 flock 自锁；
+- `PrivateFS.Close`、派生 `DirectoryIdentity`、logger/lock/publish-directory/workspace Close 与 TUI runner/applier cleanup 都必须幂等；Close 后再调用文件能力返回 `os.ErrClosed`。所有锁、文件/目录句柄、workspace 和临时导出文件都有 `Close`/cleanup 路径，不启动无所有者后台 goroutine。
+
+### 5.2 路径与权限
+
+`platform.Paths` 现有 `Log` 改为三个明确路径，并增加导出目录：
+
+| 字段 | 路径 |
+|---|---|
+| `LogDir` | `{root}/logs` |
+| `DaemonLog` | `{root}/logs/mihari-daemon.log` |
+| `TUILog` | `{root}/logs/mihari-tui.log` |
+| `MihomoLog` | `{root}/logs/mihomo.log` |
+| `LogExportDir` | `{root}/logs-export` |
+
+删除不再使用的单一 `Log` 字段（测试与 `EnsureDirs` 一起改）。目录名用连字符 `logs-export`，与现有 `core-channel`、`mihari-channel` 一致，不用下划线。
+
+需要本地数据根的选定命令在第一次读取 Settings/token 或创建目录前，把 `platform.DefaultPaths()` 通过一个可返回错误的 `Paths.Absolute()` 解析一次，并立即对该绝对 Root 调 `NewPrivateFS` 建立进程级 root capability；只有成功后才允许 `Paths.EnsureDirs`、默认 in-root credential 的 `LoadOrCreate` 或 Settings IO。该步骤发生在 Cobra `PersistentPreRun`，不得发生在 `main` 解析 argv 之前。相对 `MIHARI_DATA` 以进程启动时的 working directory 为基准；解析后重新从绝对 `Root` 构造所有派生字段，daemon/TUI logger、Settings、状态 DTO 与默认导出都只使用这一份绝对 `Paths`。control credential 保留现有 `MIHARI_CONTROL_CREDENTIAL` 契约：环境变量非空时也以同一启动 working directory 为基准只做一次 `filepath.Abs/Clean`，为空时使用 `absolutePaths.ControlToken`；local client、daemon、TUI 和 redactor 必须共用这个最终 credential path 加载出的同一 token，不得再由各 closure 重算。不得只把对外展示的 `dir` 转绝对而让 writer 继续使用相对路径。服务安装已有的绝对数据根规则不变。root/LocalSystem 遇到缺失 Root 时必须在任何 `MkdirAll`/token 写入前 fail closed；不能先创建 root-owned 根，再把它当作“既有根”接受。`NewPrivateFS` 失败不得写入 CLI `SetupError` 去拦截 TUI：TUI 继续运行并接管 `PrivateFS=nil`。凡最终 credential path 落在 dataRoot 内（默认或显式指回根内）都只 `Load` 已有文件，不得 `MkdirAll`/`LoadOrCreate`；该 `Load` 失败（含缺文件）也不得变成 `SetupError`。只有解析到 dataRoot **外** 的显式 `MIHARI_CONTROL_CREDENTIAL` 才允许在 `PrivateFS` 失败后 `LoadOrCreate`。daemon 在 `runDaemonWith` 见到 nil `PrivateFS` 时以 data failure 退出，且不得补跑 `EnsureDirs` 或 Settings IO。Cobra `--help`/`--version` 必须零 `Absolute`/`NewPrivateFS`/`MkdirAll`/`LoadOrCreate`。
+
+`LogDir` 由 `PrivateFS.EnsureDir` 创建并加固：`NewPrivateFS` 只接受已经绝对化的 dataRoot；dataRoot 不存在时，交互用户进程以 Unix 0700/Windows 当前用户+LocalSystem protected DACL 安全创建；root/LocalSystem 直接 fail closed，服务安装必须预先创建固定 dataRoot 并赋予桌面 owner，不创建仅 root/System 可用或宽权限的替代根。已存在时允许跟随用户配置的最后一跳（支持 `~/.mihari` 指向其他盘的 symlink/junction），随后 `fstat` 确认为目录、收紧权限并持有该 identity。这样即使 control credential 显式放在 dataRoot 外，首次离线启动 TUI 也能建立本地日志能力。其后 `logs/` 及文件的每一跳 no-follow，拒绝中间及最终的符号链接 / reparse / junction。轮转所需的枚举、改名、删除、只读打开必须走同一套已验证目录 fd + basename API（`ReadDir`/`Rename`/`Remove`/`OpenReadChecked`），禁止 `os.Rename`/`os.Remove`/`os.ReadDir` 完整路径。`PrivateFS` 是必须显式关闭的进程级 capability；它从 `prepareLocalRoot` 转交给实际运行的 daemon 或 TUI cleanup，不随任一子 logger 关闭。`Paths.EnsureDirs` 只能在该 root capability 建立后预创建 `logs/`，且不算安全边界，不能代替 `EnsureDir`。daemon 与 TUI 在打开 logger 之前都必须调用 `EnsureDir(LogDir)`；`logging.Open` 对 `BasePath` 父目录再确保一次。`LogExportDir` 在首次默认导出时由 `PrivateFS.EnsureDir` 创建。轮转文件命名为 `mihari-daemon.log.1` … `.N`，与当前文件同目录。当前文件算一份，因此 `max-files=3` 时最多存在 `*.log`、`*.log.1`、`*.log.2`。
+
+每个逻辑文件有一个相邻 lock file（例如 `mihari-tui.log.lock`），只用于 Mihari 进程间协调，不进入导出。lock file 不承载配置或业务数据。
+
+权限语义：
+
+- Unix：`LogDir`/默认 `LogExportDir` 为 0700；日志、lock file、临时导出与最终 zip 为 0600。对象归数据根 owner UID/GID 所有；root daemon 创建时必须按数据根 owner 修正 ownership，使桌面用户可读写，而 root 仍可执行服务职责。打开 dataRoot 允许跟随用户配置的最后一跳；之后从该目录 fd 对 `LogDir` 及文件逐段 `openat(..., O_NOFOLLOW)` 并 `fstat`，禁止对完整路径一次 `Open`/`O_NOFOLLOW`。无法安全确定或设置 owner 时不创建宽权限替代物。
+- Windows：不能把 0600/0700 当作 ACL。创建或打开时应用受保护 DACL，只授予数据根所有者 SID 和 LocalSystem 必要访问；不授予 `Everyone`、`Users` 或匿名主体。目录 ACE 继承到日志与 lock file。TUI 导出到数据根外时授予当前交互用户及 LocalSystem，且不放宽父目录 ACL。打开 dataRoot 允许跟随用户配置的最后一跳；之后每一跳相对打开必须带 `FILE_FLAG_OPEN_REPARSE_POINT`（或等价 `NtCreateFile`），看到 reparse/junction 立即失败，禁止先跟随再检查。日志、lock、temp、快照打开一律 `FILE_SHARE_READ|FILE_SHARE_WRITE|FILE_SHARE_DELETE`。
+- Windows 服务使用安装时固定的数据根；以 LocalSystem 创建日志时，从既有数据根的 owner SID 识别桌面数据所有者。无法可靠确定 owner 或无法加固 ACL 时，不创建一个宽权限文件。
+- daemon 无法安全准备 `LogDir` 或日志文件时启动失败；TUI 日志初始化失败则降级到净化后的 stderr，并保持 TUI/导出错误可见。
+
+### 5.3 JSONL 行与 mihomo 捕获
+
+每一行一个 UTF-8 JSON 对象，无 JSON 数组包装，扩展名仍为 `.log`。
+
+公共字段：
+
+| 键 | 必填 | 说明 |
+|---|---|---|
+| `time` | 是 | RFC3339Nano，带本地数值时区偏移，例如 `2026-09-02T23:41:08.123456789+08:00` |
+| `level` | 是 | `DEBUG` / `INFO` / `WARN` / `ERROR` |
+| `msg` | 是 | 人类可读且已经脱敏的消息；mihomo 为净化后的单行文本 |
+| `component` | 是 | `daemon` / `tui` / `mihomo` 或更细的 daemon 子系统名 |
+
+可选字段：`stream`（仅 mihomo：`stdout` / `stderr`）、`truncated`、`invalid_utf8` 及业务 attr。所有 attr 都经过同一 redactor。
+
+mihomo 第一期不解析行内格式，其 `level` 明确定义为 **Mihari 的捕获级别**，不是 mihomo 声称的业务级别：
+
+- stdout 行：`level=INFO`，`stream=stdout`；
+- stderr 行：`level=WARN`，`stream=stderr`；
+- Logging level 会按上述捕获级别过滤；例如 `warn` 会过滤 stdout。这不会改变生成配置中的 mihomo `log-level: info`；
+- 文档和 manifest 必须说明该字段不能用来推断核心行内真实严重度。
+
+line capture writer 接受任意 chunk，而不是假定一次 `Write` 等于一行：
+
+1. 跨 `Write` 缓存半行，一次 chunk 可产生零行、一行或多行。
+2. `\n` 结束逻辑行并去掉前面的 `\r`；空行也作为 `msg=""` 写出。
+3. 每条逻辑行最多保留前 16 KiB；达到上限后丢弃该行余下字节直至换行，并写 `truncated=true`，不得继续扩张缓冲。
+4. chunk 可以拆开 UTF-8 rune；到行结束时统一验证，非法或被截断的序列替换为 U+FFFD，并写 `invalid_utf8=true`。
+5. `Close` 把最后一个没有换行的半行 flush 一次；空缓冲不生成记录；`Close` 幂等。
+6. capture 的底层日志失败由 logging 失败计数与限频 stderr 记录吸收；`Write` 仍返回 `len(p), nil`，不得因诊断落盘失败反向终止 mihomo pipe。
+7. `Close` 后的 `Write` 返回 `os.ErrClosed`，且不触碰共享 logger。
+
+TUI/daemon 使用 `log/slog` 的 `JSONHandler` 与 `LevelVar`。handler 的 `ReplaceAttr` 把 `time` 格式化为带本地偏移的 RFC3339Nano，并在最终编码前完成键和值脱敏。
+
+### 5.4 写入、轮转与热更新
+
+`internal/logging` 的 rotator 实现 `io.WriteCloser`。每条完整 JSONL record 的 write、size check、rotate 和 append 在同一逻辑临界区完成：先取进程内 mutex，再取该逻辑文件的跨进程排他锁。活跃文件必须在取得跨进程锁后打开或核对 identity；不得跨锁长期使用一个可能已被其他进程 rename 的陈旧句柄。
+
+跨进程锁使用 OS 随进程退出自动释放的 advisory lock（Windows `LockFileEx`、Unix `flock`），不能把 lock file 是否存在当成“仍被持有”。普通日志 write 最多等待 250ms；超时后丢弃该条、增加失败计数并返回，不能无限阻塞 TUI 或 daemon。Open 初始收敛、Apply 配置维护、rotate 和导出都必须在各自操作期间持有同一逻辑文件的 advisory lock；Open 接收调用方 context，不得在启动时无限等待。等待器和时钟必须可注入，测试不依赖固定 sleep。
+
+轮转前使用不发生加法溢出的判断：
+
+```text
+incoming > maxSize                     => 先轮转，再完整写入这一条
+incoming <= maxSize 且 current > maxSize-incoming => 先轮转，再写入
+其它                                    => 直接写入
+```
+
+单条记录超过 `max-size` 时允许新活跃文件暂时超过阈值，以免截断已经编码完成的日志记录；下一条写入前再按正常规则轮转。
+
+`max-files` 包含活跃文件。Open、Apply 缩容和每次 rotate 都在进程内 mutex 及该逻辑文件的跨进程 exclusive lock 下做收敛：删除本逻辑文件、严格数字 suffix、且 `suffix >= max-files` 的普通文件（`max-files=1` 时删除全部 archive）。不得根据锁外枚举或陈旧目录项执行删除。磁盘上因上次缩容失败或崩溃留下的 `.3`–`.9` 不得残留。Open 与 Apply **只收敛，不移位、不 ReplaceEmpty**，不得改写活跃文件内容。经典移位与 `max-files=1` 的空 inode 替换只发生在 rotate。
+
+轮转算法：
+
+- `max-files=1`：收敛后创建一个安全的空同目录临时文件并原子替换活跃路径，不创建 `.1`，也不得在原 inode 上 `truncate`。rotate/`ReplaceEmpty` 前关闭本进程当前 write handle。这样导出已经打开的快照句柄仍能读完旧 inode，不会被并发清空。
+- `max-files>1`：收敛后删除 `.max-files-1`（若存在）；将 `.max-files-2` 到 `.1` 由大到小改名为下一号；将活跃文件改名为 `.1`；创建 0600/受限 DACL 的新活跃文件。rename 前关闭本进程当前 write handle。
+- rename/delete 只处理严格匹配本逻辑文件的普通文件；符号链接、目录或异常 suffix 记错并跳过，不跟随。
+
+默认 `max-size=10 MiB`、`max-files=3`。合法范围分别为 `1..100 MiB` 和 `1..10`。不按日期轮转。
+
+热更新语义：
+
+- `Apply(context.Context, Config)` 有意不返回 error：level、max-size、max-files 的内存替换是同步、不会失败的提交动作；调用者只传入已经验证的有效值。Runtime 在包内拆成不等待 IO 的 `swapConfig` 与 `convergeArchives` 两阶段；`Runtime.Apply` 依次组合两者，`Group.Apply` 则必须先对 daemon/mihomo 的所有 target 调 `swapConfig`，再逐个调 `convergeArchives`，不能简单顺序调用 `Runtime.Apply`，也不能因为第一个 target 的 context 取消而漏掉后续 target。
+- max-size 调小但当前文件已经超限时，不立即制造空轮转；下一条非空记录写入前轮转。
+- max-files 调小时在配置内存切换后，立即在同一跨进程锁下 best-effort 删除超出新上限的旧 archive；advisory-lock **获取**受调用方 context 和 250ms deadline 约束。取得锁后同步的 `ReadDir`/`Remove` 不能由 Go context 抢占，文档不承诺整个本地文件系统维护在 250ms 内结束。取消/锁超时/清理失败不回滚已经持久化的配置，也不让 PATCH 失败，但必须计入失败计数并限频写 stderr；后续每次 rotate 都再次收敛到新上限。
+- max-files 调大不创建空 archive。
+- TUI 与 daemon 各自应用 daemon 返回的完整有效配置，不按本地旧值做增量猜测。
+
+普通 write/rotate 失败不得 panic 或退出进程；该条允许丢失，错误计数增加，并按错误类别限频写一行净化后的 stderr，避免磁盘故障造成错误风暴。
+
+### 5.5 `mihari.yaml`、唯一 Settings owner 与兼容性
+
+schema 保持 `mihari.settings/v1`，新增可省略的 `log` 块：
+
+```yaml
+log:
+  level: info          # debug | info | warn | error；有效缺省 = info
+  max-size-mb: 10      # 1–100；有效缺省 = 10
+  max-files: 3         # 1–10；有效缺省 = 3
+```
+
+加载旧文件时，缺少 `log` 或字段为零都解析成有效缺省值；非法非零值由 `Validate` 拒绝。保存时如果三个有效值都是缺省值，则省略整个 `log` 块；只有非缺省配置才写入，从而避免用户仅运行新版本就无意义地破坏旧版读取。
+
+daemon 启动加载发生在 Manager 尚不存在之前，是唯一的 bootstrap 写入例外。`LoadOrCreateWithSidecarOutcome` 对首次创建和既有文件 sidecar 更新都返回 `CommitResult`：replace 前失败才返回 error；replace 后 sync 失败随已加载 Settings 返回 `Warning`，启动继续，并在 logger 建立后经净化的 `OnBackgroundError` 上报。旧 `LoadOrCreateWithSidecar` 只作为兼容 wrapper 保留原有“Warning 作为 error”行为，生产 daemon 装配不得继续调用它。
+
+Manager 构造时必须深拷贝 bootstrap Settings；从构造完成起，`runtime.Manager` 是进程内完整 `config.Settings` 的唯一权威 owner，也是 `mihari.yaml` 的唯一写入者：
+
+- onboarding service 只拥有 onboarding completion 等自身状态，不保存 Settings 副本，不直接调用 `config.Save`；
+- Ports、Logging、system proxy desired、TUN、core channel 等所有 Settings mutation 都调用 Manager 的同一候选配置提交入口；
+- 候选入口从当前权威 Settings 克隆，应用 update，校验完整 Settings，原子保存候选文件；单文件写入把 replace 定义为不可逆 commit point，并返回结构化 `CommitResult{Committed, Warning}`：replace 前失败返回 error 且 `Committed=false`，磁盘不变；replace 成功后 `Committed=true` 且调用方必须发布内存，即使随后的 parent-directory sync 失败也只通过 `Warning` 上报，不能把已提交写入伪装成失败；
+- 校验或 replace 前保存失败时，磁盘、Manager 内存、运行时 logger/rotator 和全局 revision 全部不变；post-commit warning 不改变成功语义，经脱敏的 `OnBackgroundError` 上报；
+- Logging 保存成功后再执行不会失败的 `LevelVar`/limits 内存替换，然后 coordinator 提交 revision；archive 的 best-effort 热缩容属于文件维护，不改变配置 mutation 的成功与否；
+- Manager 内所有会调用 coordinator 写 revision 的路径都必须先取得同一 `maintenance` gate；用户 mutation 在取得 gate 后、任何外部副作用或持久化前重新检查 closing/degraded，不能只在 `doOperation` 入队前检查。只读 GET 和后台 runtime observation 允许在 degraded 时继续，但同样通过 maintenance 与 mutation 串行，防止 system proxy/TUN 已产生副作用后被迟到的后台 revision 变更造成最终 conflict；
+- 用户 mutation 在等待 maintenance gate 和越过首个 commit point/外部副作用之前遵从请求取消；一旦产生必须由 revision 反映的已提交事实，后续纯内存 publish、补偿结果记录、coordinator commit 与 operation-cache 结果收口必须使用仅移除取消信号的 context 完成，不能因客户端断开留下“磁盘/OS 已变而 revision 未增”。`context.WithoutCancel` 只允许用于已经持 gate 的短小本地收口，不得包住下载、磁盘 replace、controller、进程等待或其它慢 IO；这些慢操作取消失败时仍按各自补偿语义处理。
+- coordinator 继续提供最终 revision 检查和串行提交；不得通过多个组件各持一份值拷贝来“共享” Settings，也不得在 maintenance 外直接 `Coordinator.Do` 写 Store。
+
+onboarding 同一请求可能同时修改 `mihari.yaml` 与 `onboarding.json`，普通文件系统不能提供跨文件原子 replace，因此使用显式补偿语义而不虚构全不变：Settings 先 commit 但不 publish，state commit 后才一起 publish；state 在 commit 前失败时回写 before Settings。若该补偿也在 commit 前失败，磁盘确定仍为 after Settings + before state，Manager 必须发布这个实际 Settings、保留实际 onboarding state、置 `restartRequired=true`，把全局 health 标为 degraded，并通过 coordinator 的 committed-error 路径增加一次 revision 后返回稳定 `data_failure`。daemon 在本次进程余下时间拒绝所有 mutation、继续允许只读状态与日志导出；重启从现有两文件重新装载并解除 degraded，用户可重试 onboarding。补偿 replace 成功但 directory sync 警告则按已恢复 before 处理，不进入 degraded。
+
+system proxy/TUN/controller 等外部副作用遵循相同候选与补偿规则：先在 held mutation gate 内完成 revision 预检和 Settings candidate commit/publish，再应用外部状态；外部应用失败则恢复 before Settings，并在可行时恢复已观察的外部状态。Settings 或 live 补偿失败时以内存对齐已提交磁盘值、推进 revision、以固定的 `mutation compensation failed; restart required` 进入只读 degraded，不得返回错误同时留下旧内存/旧 revision；底层 OS/path 错误不进入稳定状态。该极端分支允许请求部分生效，但必须显式可观察；正常校验、首次保存和可成功补偿的失败仍保持请求级原子。Settings 首次保存失败时不得触碰 system proxy/controller。daemon 重启按 desired 收敛 Mihari-owned proxy，但不得清除 foreign proxy。
+
+必须用顺序回归测试证明 Logging→Ports、Ports→Logging，以及 Logging 与现有 Settings mutation 任意先后都不会覆盖对方字段；还要覆盖 replace 前失败、replace 后 sync warning、onboarding state 失败后补偿成功，以及补偿 commit 前失败后的磁盘/Manager/revision/health 对齐。
+
+降级边界：当前旧版使用 `KnownFields(true)`，因此无法读取包含未知 `log` 块的文件。保留 v1 是一次加法扩展，不承诺旧二进制读取自定义 Logging 配置。缓解措施是：
+
+- 默认配置不序列化 `log`，未自定义的用户可直接降级；
+- 把三个值恢复默认会移除 `log` 块；
+- README/升级文档明确说明：使用自定义 Logging 配置后，降级到不认识 `log` 的版本前必须先恢复默认或手动备份并删除该块；
+- 不用偷偷忽略未知字段来削弱当前版本的配置校验。
+
+该块不是 mihomo 的 `log-level`；生成的 runtime config 仍按现有逻辑写 `log-level: info`。
+
+### 5.6 控制协议
+
+daemon Logging runtime 正常初始化时在 capabilities 中新增 `logging`；degraded runtime 不宣告该能力，调用 endpoint 返回 `invalid_state`。新增：
+
+```http
+GET /v1/logging
+PATCH /v1/logging
+```
+
+GET 与成功 PATCH 都返回完整的有效状态：
+
+```json
+{
+  "schema": "mihari/v1",
+  "revision": 13,
+  "level": "info",
+  "max_size_mb": 10,
+  "max_files": 3,
+  "dir": "C:\\Users\\…\\.mihari\\logs"
+}
+```
+
+`dir` 是供本机特权客户端只读展示的绝对路径，不是 secret。PATCH 请求：
+
+```json
+{
+  "operation_id": "logging-…",
+  "if_revision": 12,
+  "level": "debug",
+  "max_size_mb": 20,
+  "max_files": 5
+}
+```
+
+协议 DTO：
+
+- `operation_id string` 必填且非空；`if_revision *uint64` 可选，`0` 是合法的显式 revision；
+- `level *string`、`max_size_mb *int64`、`max_files *int64` 均可选，至少一个非 nil；
+- `null` 等价于未提供；如果最终没有修改字段，返回 `invalid_argument`；
+- 数值必须是 JSON 整数。字符串、小数、指数形式、负数、零、超过 `int64` 或业务范围的值全部拒绝；
+- 先验证 `max_size_mb` 为 `1..100`、`max_files` 为 `1..10`，再把 MiB 转成 `int64` bytes 或把 files 缩窄为内部 `int`；
+- 未知字段继续由 `DisallowUnknownFields` 拒绝；handler 与 runtime/domain 边界都校验，非 HTTP 调用不能绕过。
+
+PATCH 是请求级原子操作：先构造并验证完整候选配置，再原子持久化，随后切换 Manager、daemon logger 与 rotator，最后增加 revision。失败请求不得部分生效。`Apply` 的不会失败部分是所有 target 的 level/limits 内存切换；archive 删除是有界 best-effort 维护。磁盘替换和并发日志 write 不要求物理同一瞬间发生，但成功响应返回前所有配置消费者必须收敛到响应值。请求在 Settings replace 后取消时内部仍完成 publish/runtime/revision/operation-cache 收口；客户端可以收不到响应，但相同 operation ID 重试必须取得第一次已提交结果。
+
+成功与幂等语义：
+
+- PATCH 返回 HTTP 200 和上述完整 `LoggingStatus`，不另包一层，也不把 `operation_id` 放入状态 DTO；
+- 使用新的 `operation_id` 提交与当前值相同的字段，仍是成功 mutation，revision 增加一次；实现可跳过无意义的 YAML 重写和热应用；
+- 接入现有 `doOperation`，key 为 `logging:<operation_id>`。同一 ID 的相同逻辑请求在进程内缓存存在时返回第一次结果，不重复提交或增加 revision；客户端不得把同一 ID 用于不同 payload；
+- revision 的全局耗尽不在本功能中处理，见 Issue #191。
+
+错误契约：
+
+| 场景 | HTTP | code |
+|---|---:|---|
+| JSON/类型/未知字段错误、缺 operation ID、空 PATCH、非法 level/数值 | 400 | `invalid_argument` |
+| `if_revision` 不匹配 | 409 | `revision_conflict`，details 含 expected/current |
+| Logging runtime 不可用 | 409 | `invalid_state`（GET 与 PATCH） |
+| Manager 因补偿失败要求重启 | 409 | `invalid_state`（仅 PATCH；GET/只读/Export 仍成功） |
+| Settings 在 replace commit point 前持久化失败 | 422 | `data_failure` |
+| 未分类内部错误 | 500 | `internal` |
+
+错误 envelope 沿用 `/v1` 既有格式，消息不得包含凭据、完整路径中的敏感片段或底层错误全文。Logging 热更新不要求 daemon/mihomo restart，不设置 `RestartRequired`，也不塞进 onboarding DTO。
+
+### 5.7 TUI bootstrap 与 System Logging 区
+
+TUI 在控制连接建立前不能读取 `mihari.yaml`，也不能把编译期缺省值当成权威配置，否则默认 `max-files=3` 可能误删用户配置保留的 4..10 号 archive。启动 writer 使用合法范围内最保守的 bootstrap：
+
+- `level=debug`，避免连接前丢掉可能被权威配置允许的级别；
+- `max-size=100 MiB`、`max-files=10`，保证不会比任何合法权威配置更早轮转或删除历史；
+- 连上 daemon 并 GET 成功后，一次性应用返回的 level / max-size / max-files；
+- daemon 不可用时，System Logging 配置值显示 `Unavailable`/未知，不显示伪造的默认值；配置行不可提交，Export 仍可用；
+- GET/PATCH 成功后保存响应 revision；即使 revision 为 0，后续 PATCH 也要显式发送 `if_revision: 0`；root 为每次连接维护单调递增的 logging sync epoch，重连或 capability 消失时先递增 epoch、清除已观察 revision 并回 bootstrap；
+- PATCH 成功只采用响应中的完整有效状态。`revision_conflict` 重新 GET，不用旧表单自动覆盖新状态。
+- 已连接 TUI 利用现有 session Status poll：首次连接、重连或观察到全局 revision 改变时重新 GET Logging。发现 revision 改变到 GET 成功之间，writer 临时回到 debug/100/10 的保守策略，避免另一个 TUI 把保留上限调大后，本实例长期拿旧的小上限继续删除 archive。session GET、System PATCH/冲突 GET 都把发起时的 sync epoch 随结果交给 root；root 只在 epoch 等于当前值且 revision 不小于当前已观察 revision 时采用完整状态，旧结果只清理其来源页面的 pending/error，不得回退 root/System/applier。`tui.Run` 拥有一个独立的串行 Logging applier：Model 的值接收 `Update` 只用非阻塞 `Submit` 覆盖 heap 上的 latest desired；单 worker 调 `Apply(ctx, config)`，若执行期间又收到新 generation，返回后立即再应用最新值。不得把阻塞 Apply 作为裸 `tea.Cmd`，因为 Bubble Tea 退出不等待 Cmd goroutine。GET 成功的完整配置不得被更早的 bootstrap Apply 晚到后改回 debug/100/10；applier 提供幂等 `CloseAndWait`，退出时 cancel 正在等待锁的 Apply 并等待 worker 结束。
+
+System 页新 section `Logging` 放在 `Ports Config` 之后、`Daemon` 之前：
+
+| 行 | 交互 |
+|---|---|
+| Level | Enter 在 `debug / info / warn / error` 间循环，立即 PATCH |
+| Max file size | Enter 行内编辑，单位 MiB；`ParseInt(..., 10, 64)` 后检查 `1..100`；Enter PATCH，Esc 取消 |
+| Files to keep | Enter 行内编辑；`ParseInt(..., 10, 64)` 后检查 `1..10`；Enter PATCH，Esc 取消 |
+| Directory | 只读显示 daemon 返回的 `dir`，离线时显示不可用 |
+| Export logs | Enter 打开导出对话框，不要求 daemon |
+
+配置失败显示 Failed 徽章和净化后的稳定原因；不把底层转换或文件错误原文显示给用户。帮助 catalog 新建 `ModeLoggingEdit`（Type value / Enter apply / Esc cancel），不复用 Ports 的 address 文案。
+
+### 5.8 导出对话框
+
+Logs 页与 System Logging 区共用 `internal/tui/ui/exportlogs.go` 的对话框组件，避免页面模型互相依赖。
+
+Logs 页 Controls 增加 `Export`；快捷键 `e` 打开。`e` 在搜索、详情或其它文本输入模式下不触发。页脚与 `?` 帮助同步更新。
+
+字段：
+
+1. **Now（只读）**：`2026-09-02 23:41:08 +08:00`。打开对话框时取样一次用于显示和默认文件名预览。提交 Export 时再取一次 Now，专用于时间窗 UTC 转换；若用户未改 Output path，默认 basename 按提交时刻重算。数值偏移是校对依据；`time.Local.String()` 只可作辅助。
+2. **Range**：Enter 循环 `Last 24 hours` → `Last 60 minutes` → `Between` → `All`；默认 Last 24 hours。
+3. **From / To（仅 Between）**：本地时间 `2006-01-02 15:04`；切入时 From=Now-24h、To=Now。
+4. **Output path**：默认 `{dataRoot}/logs-export/mihari-logs-YYYYMMDD-HHMMSS±HHMM.zip`。必须是绝对 `.zip` 路径。自定义父目录必须已存在；默认目录可安全创建。
+
+默认路径若已存在，UI 选择第一个空闲的 `-1`、`-2` 后缀；自定义目标已经存在时拒绝，永不覆盖。
+
+Tab 在可编辑字段间移动；文本焦点下 Enter 也提交导出；Esc 在编辑态关闭对话框。导出期间显示 Pending，禁止重复提交；此时 Esc 请求 context cancellation，等待 runner 回收资源后回到可编辑表单并显示 `Export cancelled`。
+
+根 overlay 打开时必须先收到每一条 `tea.Msg`（在 root typed switch / `dispatchPage` 之前）。它独占键盘、当前 generation 的结果消息，以及文本焦点下的 `tea.PasteMsg` / clipboard 回程；这些返回 `consumed=true`。其它消息——包括 `ui.LoggingSyncMsg`、`ui.LoggingObservedMsg`、session status/logging、service/network poll、`ui.PageResultMsg` 与 action completion——返回 `consumed=false` 后必须继续经过根模型原有完整路由。overlay 的 View 必须画在 Setup 短路和其它 `model.modal` 整屏替换之前，不得因为页面暂时不可见就阻止页面清除 pending 或吸收异步结果。其它 modal 仍可入队，但在导出关闭前不抢键盘、不覆盖导出 View。
+
+成功态：
+
+```text
+Export complete
+C:\Users\…\.mihari\logs-export\mihari-logs-20260902-234108+0800.zip
+Enter copy path  Esc close
+```
+
+Enter 用已有 clipboard 写绝对路径。复制失败时路径仍显示，并提示 `Could not copy path`。其它失败在对话框内显示一行净化原因，保留参数以便重试。
+
+### 5.9 导出快照与 zip 算法
+
+TUI 调用 `internal/logging.Export(ctx, request)`；库不依赖 daemon。算法：
+
+1. 在点击 Export 时再取一次 `Now`，把本地时间窗转换成 UTC 闭区间；All 不过滤。打开对话框时的只读 Now 只用于显示和默认文件名预览。From > To 返回 `invalid_argument` 风格 UI 错误。默认路径请求必须 `AutoNumber=true`；自定义路径禁止自动改名。
+2. 规范化并验证目标路径：要求绝对 `.zip`；默认 `LogExportDir` 可按安全权限创建，自定义父目录不递归创建。`PrivateFS.OpenDirIdentity(LogDir)` 从已经持有的可信 LogDir handle 派生一个必须关闭的 opaque `DirectoryIdentity` capability；打开目标父目录得到 `PublishDir` 后，用 `PublishDir.IsWithin(logDirIdentity)` 逐级比较持有目录的真实 identity，拒绝目标父目录等于或位于真实 LogDir 内。不得从未解析 symlink 的 `Paths.LogDir` 字符串构造安全结论。该 LogDir capability 与 `PublishDir` 一起转交给导出并保持到发布结束；每次 no-replace publish 尝试紧邻提交前都重新检查 held `PublishDir` 是否进入 held LogDir，检查失败或 containment 改变均 fail closed。target 只保留一个已校验的 basename，拒绝已经存在的对象（包括 symlink）和非目录父级。随后从该 `PublishDir` 创建 0700/protected-DACL 的私有 `PublishWorkspace`；temp、spool 只相对 workspace handle 操作，exists/final publish 只相对 parent handle 操作，不再用已校验的完整路径重新寻址。
+3. 对 daemon、tui、mihomo 三个来源依次取得有界快照。获取对应共享锁，在锁内通过 `PrivateFS.ReadDir` 枚举严格匹配的普通文件及其 opaque `FileIdentity`、按数值 suffix 从大到小排列 archive，最后是活跃 `.log`；`OpenReadChecked(path, expectedIdentity)` 相对同一可信目录打开允许 writer 后续 rename/delete 的只读句柄并比较实际 handle identity，不匹配就关闭并使该来源失败。记录当时 size 后释放锁。解析阶段只从每个句柄读取记录的 size，忽略之后 append 的字节。
+4. 快照锁保证不会截在一条由 Mihari writer 正在写的 JSONL 中间。锁释放后的 rotate 不改变已打开句柄指向的文件 identity；Windows 使用显式 delete-sharing open。某一来源的顺序是最旧 archive → … → `.1` → 活跃文件。不同来源不宣称共享同一纳秒级快照。
+5. 逐物理行使用启用 `UseNumber` 的 `json.Decoder` 解码到 `map[string]any`，避免二次编码把大整数先转成 `float64` 而损失精度。首次 Decode 必须得到 object，随后第二次 Decode 必须得到 `io.EOF`；数组、标量、同一行的第二个 JSON 值或任意尾随 token 都是一个 invalid record。单行解析上限为 1 MiB；超过上限时有界丢弃到下一个换行并计入 `skipped_invalid`，不得无界分配。缺 `time`、时间无效或 JSON 损坏同样计入 `skipped_invalid`，不写 zip。保留文件顺序和文件内记录顺序，不根据 wall clock 重新排序，避免系统时钟回拨改变因果顺序。
+6. 每个有效对象在导出边界再次递归脱敏，然后重新 `json.Marshal` 为一行；不保留原始 JSON 字节或字段顺序。窗内记录写到该来源唯一的 zip entry。某来源没有命中则省略 entry。
+7. 在枚举来源、读取批次、解析行、写 zip 和发布前检查 `ctx.Err()`。取消或失败关闭所有快照/zip/temp 句柄、删除 workspace 内临时文件，并按 `PublishWorkspace`→`PublishDir`→LogDir `DirectoryIdentity` 的所有权顺序关闭；成功发布后同样关闭所有派生目录 capability。若外部主体已把 workspace directory entry 移出 held parent，清理只能关闭 held handle并报告净化后的 warning；不得追随路径寻找或删除不再能按 identity 证明的对象，也不得因此触碰替换对象或把已发布结果改报失败。
+
+zip 固定布局：
+
+```text
+manifest.json
+daemon/mihari-daemon.log
+tui/mihari-tui.log
+mihomo/mihomo.log
+```
+
+zip entry 名是常量，不使用用户路径。`manifest.json`：
+
+```json
+{
+  "schema": "mihari-logs-export/v1",
+  "exported_at": "2026-09-02T23:41:08+08:00",
+  "timezone": "+08:00",
+  "range": { "kind": "last_24h", "from": "…", "to": "…" },
+  "files": [
+    {
+      "name": "daemon/mihari-daemon.log",
+      "lines": 120,
+      "skipped_invalid": 1,
+      "redacted": 2,
+      "sources": ["mihari-daemon.log.2", "mihari-daemon.log.1", "mihari-daemon.log"]
+    }
+  ],
+  "notes": ["mihomo level is Mihari capture classification; core-emitted node names and traffic metadata may remain"]
+}
+```
+
+三个来源都无命中时不发布 zip，提示 `No log lines in the selected range`。
+
+原子发布：
+
+- 目标解析阶段打开并持有真实父目录 handle；默认目录从 `PrivateFS` 的已验证子目录 handle 派生，自定义目录只跟随用户选择的父路径这一次，确认是目录并记录 canonical absolute path/identity，之后不修改其 mode/ACL；
+- 从该 `PublishDir` handle 创建不可预测名称的私有 `PublishWorkspace` 子目录，Unix mode 0700，Windows protected DACL 只含当前交互用户与 LocalSystem；即使自定义 parent 允许其它主体改名目录项，也不能进入 workspace 或替换其中 source basename。相对 workspace 创建随机 temp/spool basename并应用 0600/受限 DACL；使用标准库 `archive/zip` Deflate 写入；所有 workspace remove 与 parent exists 也只接受单段 basename；
+- 完成所有 entry 和 manifest 后依次关闭 zip writer、sync 临时文件；每次提交尝试先用仍持有的 LogDir `DirectoryIdentity` 重新执行 `PublishDir.IsWithin`，确认目标目录仍在真实 LogDir 外，再调用 handle-relative `PublishNoReplace(workspace, tempName, targetName)`；检查失败、结果为 inside 或检查期间 identity 不稳定均 fail closed。Unix 从 workspace dirfd `linkat` 到 parent dirfd 后 unlink source，Windows 对从 workspace handle 相对打开的 temp handle 调 `NtSetInformationFile` 并把 parent handle设为 RootDirectory，不得退回路径型 `os.Link`/`MoveFileEx`；必要时 sync 两个目录 handle；
+- 自定义目标在校验后被别的进程抢先创建时返回 `already exists`，不得覆盖；默认目标发生竞争时复用同一 held `PublishDir`、workspace 和已关闭 temp，直接以 no-replace publish 依次尝试下一个编号后缀，每次重试前检查 context，防止先查后用竞态。只有发布成功后才把实际 basename/canonical path 写入 `ExportResult.Path`；suffix 的 `int64` 递增溢出返回稳定失败；
+- 校验后原父路径被 rename 或替换为 symlink/junction 时，写入仍只落到已打开的目录 identity，绝不跟随替换路径；实现可以在 publish 前比较一次可见路径 identity 并选择安全失败，但不能把完整路径重新解析作为提交依据；
+- publish 是成功的不可逆点。publish 前取消必须无目标文件；publish 已成功后即使 context 随后取消也返回成功路径；
+- 任意 publish 前失败都删除仍能从 held workspace 访问的文件，并在 held parent 内按 identity 删除私有 workspace，随后关闭 workspace、PublishDir 与 LogDir identity 三个目录 capability；若外部主体已将 workspace entry 移出 held parent，则只关闭 handle并报警，禁止路径追删。publish 后的 cleanup/sync 失败只报警，不能把已发布 target 报成失败。不得先创建一个空目标再慢慢写 zip。
+
+zip 只含重新编码且再次脱敏的日志与 manifest，不含 `mihari.yaml`、token、订阅或 lock file。
+
+### 5.10 安全与脱敏
+
+仅靠“调用方不要 log secret”不足以形成安全边界。采用写入边界和导出边界两层防护。
+
+`logging.Redactor` 在 daemon 打开 logger **之前**注册已取得的 controller secret、control token、Web credential 及完整订阅 URL；凭据变化时通过显式更新方法替换不可变规则快照。token 与 controller secret 在 Open 前必须注册。Web credential 或 catalog 加载失败时跳过那些 exact 值，**仍 EnsureDir+Open**，再让 `BuildRuntime` 失败走既有 degraded daemon；不得因 catalog/credential 错误在 Open 前 `return`。degraded 路径只要 token/secret 已注册即可记录。TUI redactor 不读取 `mihari.yaml`，注册自身已经持有的 control token，并使用同一通用规则。TUI Runtime/logger Open 失败不得拿走已经创建的 redactor/`PrivateFS`；Export 依赖这两者，不依赖本进程 writer 是否成功。若失败发生在 `NewPrivateFS` 本身，则不能绕过安全边界读取日志：Export 对话框仍可打开，但提交返回固定 `Local log storage unavailable`。
+
+写入边界对 `msg`、error text 和所有嵌套 slog attrs 执行：
+
+- key 规范化后命中 `secret`、`token`、`password`、`credential`、`authorization`、`cookie`、`api-key` 等敏感名称时，值整体替换为 `***`；
+- 已注册的非空 secret/credential/full subscription URL 做精确字符串替换；过短的通用字符串不得注册，避免把正常文本抹掉；
+- 任意文本中的 `http://` / `https://` / `ws://` / `wss://` URL 整体替换为 `[REDACTED_URL]`，不尝试保留可能把 token 放在 path/userinfo/query 的“安全部分”；
+- Bearer、Basic、token/secret/password 等常见 `name[:=]value` 形式替换 value；独立的 64 字符十六进制 controller-secret 形态也必须遮蔽；
+- 不记录原始 HTTP/control body、完整 runtime config、环境变量或 `panel open` 一次性 URL；业务代码优先记录对象 ID、状态与稳定错误码。
+
+mihomo 捕获行在进入 JSON `msg` 前也执行通用文本规则；不得把它作为“无法解析所以不脱敏”的例外。通用规则无法判定节点名、目标域名、IP、流量元数据是否属于用户敏感业务信息，因此 UI 成功态和 manifest 提醒用户发送前自查；这不放宽 Mihari 已知凭据必须遮蔽的要求。
+
+导出边界对历史 JSON 对象再次递归检查敏感 key 和字符串并重新编码，防止旧版本日志或漏网调用点被直接打包。`redacted` 只统计发生过替换的记录数，不把原值、匹配规则或 secret hash 写进 manifest。
+
+stderr fallback 和 UI/protocol 错误同样先经 redactor；底层路径、URL 或 credential 不得因失败路径反向泄露。
+
+### 5.11 错误处理
+
+| 情况 | 行为 |
+|---|---|
+| daemon 无法安全创建/加固 `logs/` 或初始日志 | daemon 启动失败，返回净化错误 |
+| Web credential / 订阅 catalog 在 Open 前加载失败 | 跳过对应 exact 值，仍打开 logger；随后 BuildRuntime 失败则走 degraded daemon |
+| TUI Runtime/logger Open 失败但 `PrivateFS` 可用 | TUI 继续运行，使用限频且净化的 stderr；System 显示本地 writer 不可用；Export 仍可用 |
+| TUI `NewPrivateFS` 失败 | TUI 继续运行；Export 对话框可打开，提交只显示 `Local log storage unavailable`，不得回退普通路径 IO |
+| 日志 write/rotate/热缩容失败 | 不退出进程；当前记录可丢失或多保留旧 archive；失败计数 + 限频 stderr |
+| GET `/v1/logging` 失败 | 配置值显示不可用，配置行禁用；bootstrap writer 与 Export 继续工作 |
+| PATCH 校验/revision/replace 前持久化失败 | 按 5.6 稳定错误契约；不部分生效 |
+| replace 后目录 sync 警告 | 写入已经 committed；发布内存/runtime/revision 并返回成功，净化 warning 后限频记录 |
+| Settings 补偿写在 commit 前失败 | 内存对齐已提交磁盘、revision +1、health degraded、后续 mutation 返回 `invalid_state`，当前请求返回稳定 `data_failure`；只读与 Export 保持可用 |
+| 源快照中有 symlink/非普通文件 | 不跟随；该源导出失败并显示净化错误 |
+| 导出无命中、路径非法、目标存在、写入或发布失败 | 不留下目标 zip；对话框保留参数并显示错误 |
+| 导出取消 | 回收 runner、快照句柄、workspace 与 temp；回到表单显示 cancelled |
+| clipboard 失败 | 路径仍可见，不影响已经成功的导出 |
+
+### 5.12 测试
+
+全部使用 `t.TempDir()`、可注入 clock/file ops/locker，不读真实用户目录、不访问公网、不依赖已安装 mihomo。
+
+- **轮转**：跨 max-size 产生 `.1`；`max-files=1` 永不产生 archive；2/3/10 的精确上限；删除最旧；安全比较覆盖接近 `MaxInt64` 的 size/incoming；单条超限；权限；max-size 下调下一写轮转；max-files 下调立即 best-effort 清理与失败重试。
+- **跨进程协议**：两个独立 writer 交替写/轮转同一 TUI base，记录不交叉、不丢失、不写到被 rename 的陈旧句柄；Open 收敛与另一进程 rotate 并发时也只在 exclusive lock 内枚举/删除；advisory lock 随进程退出释放；250ms write 超时、Open/Apply/export context 取消和锁失败；Windows/Unix 平台实现各有目标测试。
+- **JSONL/capture**：time 带偏移；chunk 拆行/多行/CRLF/空行；半行 Close；16 KiB 截断后不增长；UTF-8 rune 跨 chunk 与非法字节；Close 幂等；底层失败不终止 pipe；capture level/stream 语义。
+- **脱敏**：嵌套敏感 key、注册 secret、64 hex、Bearer/Basic、URL path/query、error 和 mihomo 行都不泄露；导出能再次净化故意构造的旧日志；manifest 不含原值。
+- **权限**：Unix 目录 0700、文件 0600、owner UID/GID 正确、root service 与桌面 owner 均可按设计访问、拒绝 symlink；Windows DACL 只含预期数据 owner/System 且可由两者访问，拒绝无法安全加固的对象。
+- **settings owner**：缺 `log` 为有效缺省；默认不序列化块；非默认 round-trip；非法 level/size/files；bootstrap sidecar outcome 的 pre/post-commit 语义；Manager 构造深拷贝；Logging↔Ports 及其它 Settings mutation 顺序不互相覆盖；replace 前失败不改变内存；replace 后 sync warning 仍发布；system proxy 首次 Save 失败零 OS write，外部应用失败补偿；补偿 commit 前失败时磁盘/内存/revision/health 对齐并拒绝后续 mutation；排队 mutation 在取得 maintenance 后复查 degraded；后台 revision observation 不能插入 system proxy/TUN 的预检与提交之间；请求取消不能截断已越过 commit point 的本地 revision/cache 收口；恢复默认移除块。
+- **协议**：GET/PATCH 精确 JSON round-trip；revision 包含在两种响应；空/null PATCH；未知字段；整数类型/溢出/范围；显式 revision 0；冲突 details；data failure=422；degraded capability；相同新值 revision +1；相同 operation ID 重试不重复提交。
+- **TUI 配置**：离线 bootstrap 为 debug/100/10 且不删除合法 archive；离线显示 unavailable；GET/PATCH 应用完整响应；revision 0 仍发送；冲突 reload；连接 epoch 不同或 revision 较旧的迟到响应不回退 root/System/applier；另一个 TUI 改变全局 revision 后经 session poll 进入保守策略并重新同步；数字输入超长安全拒绝。
+- **导出快照**：archive 数字顺序从旧到新；枚举 `FileIdentity` 与打开 handle identity 不匹配时 fail closed；快照后 append 不进入结果；快照后并发 rotate/max-files=1 replacement 无重复、漏读或 inode 清空；`UseNumber` 保留大整数；数组/标量/第二 JSON 值/尾随 token、超 1 MiB 和其它无效 JSON 有界跳过并计数；All/Last 24h/Between；保留文件因果顺序；三个来源无命中不发布。
+- **导出发布**：用保持到提交结束的 trusted LogDir `DirectoryIdentity` 拒绝相同/后代目录及 symlink data-root 绕过，并在每次 publish 尝试紧邻提交前重新检查 containment；拒绝相对/非 zip/既有目标和不存在的自定义父目录；workspace 为 0700/protected-DACL 且来源 basename 不可由 parent writer 替换；默认目录/编号创建；取消和各阶段注入失败清理 workspace/temp 且不发布目标（外部主体将 workspace 移出 held parent 时允许留下不可寻址的私有 orphan 并报告 warning，禁止路径追删）；默认 publish 抢占后在同一 held Dir/workspace 重试并返回实际路径，自定义目标不重试；校验后替换父路径也不能改变已打开的发布目录 identity；最终 zip 权限与固定 entry；manifest 字段。
+- **TUI 导出**：打开时显示 Now、提交时再取 Now 算时间窗；Pending 防重复；Esc cancellation；成功绝对路径；clipboard 失败仍保留路径；Logs 页 `e` 与 System 共用对话框；搜索/详情态 `e` 不打开；Run 持有稳定 model/runner且重开 generation 不复用，在 `Update` 已登记 runner 但 Cmd 尚未入队时取消仍能 `CancelAndWait`；result channel 先完成、`done` 后关闭；root 在 typed switch 前把每条消息交给 overlay；paste/clipboard 在文本焦点下被 overlay 消费；未知消息含 LoggingSync/Observed 默认不消费；默认路径 Open 时目录缺失不建目录，提交 `AutoNumber=true`；overlay View 优先于 Setup/其它 modal；overlay 期间 action/page result 仍走原页面路由并清除 pending；golden 按 Controls/System 布局更新。
+- **装配/生命周期**：相对 `MIHARI_DATA` 在选定命令 PersistentPreRun 绝对化；`--help`/`--version` 零数据根 IO；在任何 EnsureDirs/默认 token/Settings IO 前建立进程级 PrivateFS，root/LocalSystem 缺根零 IO fail closed；该失败不写入 CLI SetupError；TUI 收到 nil fs 仍运行，daemon 见到 nil fs 零 Settings IO 后失败；health/`exportLogs` 在 `newModelWithClientContext` 替换之后注入；Settings 加载后创建 daemon logger；`OnBackgroundError` 接入；CommandStarter stdout/stderr 进入 mihomo.log；先关闭 capture 后关闭 logger；TUI applier/Export runner 可取消并等待；TUI/daemon 所有 file/lock/directory/workspace handle 关闭且 `PrivateFS.Close` 幂等。
+- **跨平台构建**：保持 `CGO_ENABLED=0`，至少检查 Windows/Linux/macOS 的 amd64/arm64 受影响目标；平台文件与 build tag 配对。
+
+覆盖率不得靠空测试抬高。功能 PR 不改 `CHANGELOG.md`。
+
+## 6. 用户可见变化
+
+- `{dataRoot}/logs/` 出现三个 JSONL 文件及其轮转文件；多个 TUI 共享同一个 TUI 日志序列。
+- `{dataRoot}/logs-export/` 在首次默认导出后出现 zip；导出永不覆盖已有文件。
+- System 页新增 Logging；离线时配置显示不可用而不是伪造默认值。
+- Logs 页 Controls 增加 Export，快捷键为 `e`。
+- `mihari.yaml` 只在使用非默认 Logging 配置后出现 `log:` 块；恢复默认后移除。
+- README、`docs/commands.md`、`docs/architecture.md` 同步日志路径、导出目录、跨进程写入例外、Windows ACL、脱敏边界与降级说明；不再把单一 `mihari.log` 写成事实。
+
+## 7. 风险与约束
+
+- TUI 写数据根日志是 daemon 单写入者约束的窄例外；只允许 `internal/logging` 追加/轮转固定日志，不扩展到 settings 或业务状态。
+- 跨进程锁和 Windows delete-sharing 处理错误会造成陈旧句柄或 rename 失败，因此不能只靠单元测试；需要 Windows 与至少一个 Unix 平台的并发集成测试。
+- 跨进程锁增加每条日志的系统调用开销。实现可在锁内验证并复用安全句柄，但不得以性能优化为由跨锁保留无法检测 rename 的句柄。
+- mihomo 捕获仍可能含节点名、目标域名/IP 和流量元数据；凭据与 URL 必须自动遮蔽，业务信息由导出提示要求用户自查。
+- max-files 热缩容的 archive 删除是 best-effort：配置立即生效，删除失败时可能暂时多保留文件，但不会因诊断清理失败回滚用户设置。
+- Settings 单文件 replace 后的 directory-sync 失败已经越过 commit point，只能作为 durability warning；补偿写也无法 commit 时会进入显式只读 degraded，而不是谎称请求完全未生效。该分支不新增持久化格式，重启后按磁盘现状恢复。
+- 自定义导出目录可能在长耗时生成期间被外部进程改名；持有 `PublishDir` identity 保证不会写入后来替换到同一路径的目录，但成功提示中的绝对路径是打开目录时解析的 canonical path，外部随后再次改名仍可能使显示路径失效。
+- 自定义 `log` 块不兼容不认识该字段的旧版严格 parser；默认省略、恢复默认移除和明确降级说明用于降低风险，不伪称完全 downgrade-compatible。
+- JSONL 对用记事本快速浏览不如纯文本友好；这是结构化过滤与安全重编码的已接受取舍。
+
+## 8. PR 切分与交付顺序
+
+实现阶段用 writing-plans 细化。预期三个顺序 PR 指向 `dev`，避免把平台文件系统、安全边界、Settings 重构、稳定协议和两页 TUI 交互塞进一个不可审查的大 PR：
+
+1. **安全文件日志基础**：第一 commit 先更新根 `AGENTS.md`/架构文档，声明 TUI 固定日志追加例外；随后实现平台锁/owner/ACL、Paths、logging/redactor/rotator/capture、daemon/TUI/mihomo 装配与生命周期。daemon 使用正常缺省值，TUI 暂用安全 bootstrap。该 PR 合并时三类文件日志已经能安全落盘和轮转，不修改稳定控制协议或持久化配置。
+2. **Settings 与 Logging 控制面**：集中 Manager Settings owner、修复所有 Settings mutation 的候选提交、增加可省略的 `log` 配置、GET/PATCH、client、session 重同步和 System Logging 配置 UI。稳定 DTO、持久化格式、降级说明与用户入口在同一个 PR 中落地，不留下只有 API、没有 UI 的中间状态。
+3. **快照导出与交互**：实现安全快照、二次脱敏、可取消的原子 zip 发布、共享对话框、Logs/System 入口及对应文档。
+
+每个 PR 独立通过相关包测试、race、vet、gofmt 和受影响平台的 CGO-free 编译检查；用户可见文档随产生该行为的 PR 更新，不全部拖到第二个 PR。禁止在功能 PR 修改 `CHANGELOG.md`。

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -30,15 +30,19 @@ import (
 )
 
 type RuntimeAssembly struct {
-	Manager *runtimeapi.Manager
-	Store   *state.Store
-	Web     *web.Server
+	Manager       *runtimeapi.Manager
+	Store         *state.Store
+	Web           *web.Server
+	mihomoStarter supervisor.CommandStarter
 }
 
 type RuntimeBuildOptions struct {
 	InitialSetupRequired bool
 	SettingsPath         string
 	ServiceStatus        func() (string, error)
+	MihomoStdout         io.Writer
+	MihomoStderr         io.Writer
+	OnBackgroundError    func(component string, err error)
 }
 
 func BuildRuntime(paths platform.Paths, settings config.Settings, daemonVersion string, stdout, stderr io.Writer) (*RuntimeAssembly, error) {
@@ -140,15 +144,29 @@ func BuildRuntimeWithOptions(paths platform.Paths, settings config.Settings, dae
 	if err != nil {
 		return nil, err
 	}
+	starterStdout, starterStderr := stdout, stderr
+	if options.MihomoStdout != nil {
+		starterStdout = options.MihomoStdout
+	}
+	if options.MihomoStderr != nil {
+		starterStderr = options.MihomoStderr
+	}
+	if starterStdout == nil {
+		starterStdout = io.Discard
+	}
+	if starterStderr == nil {
+		starterStderr = io.Discard
+	}
+	mihomoStarter := supervisor.CommandStarter{
+		BinaryPath: paths.CoreBinary,
+		DataDir:    paths.Root,
+		ConfigPath: paths.RuntimeConfig,
+		Stdout:     starterStdout,
+		Stderr:     starterStderr,
+	}
 	var manager *runtimeapi.Manager
 	coreSupervisor := supervisor.New(supervisor.Options{
-		Starter: supervisor.CommandStarter{
-			BinaryPath: paths.CoreBinary,
-			DataDir:    paths.Root,
-			ConfigPath: paths.RuntimeConfig,
-			Stdout:     stdout,
-			Stderr:     stderr,
-		},
+		Starter: mihomoStarter,
 		Health: func(ctx context.Context) error {
 			_, err := controller.Version(ctx)
 			return err
@@ -177,17 +195,18 @@ func BuildRuntimeWithOptions(paths platform.Paths, settings config.Settings, dae
 		PrepareGeoIP: func(ctx context.Context) (runtimeapi.GeoIPCandidate, error) {
 			return geoIPService.PrepareUpdate(ctx)
 		},
-		Onboarding:    onboardingService,
-		Panels:        panelService,
-		WebGateway:    webGateway,
-		WebOpenToken:  webCredential,
-		Settings:      settings,
-		SettingsPath:  settingsPath,
-		ServiceStatus: options.ServiceStatus,
-		SysProxy:      sysproxy.Platform(),
-		TunDetect:     tundetect.Platform(),
-		RuntimeConfig: paths.RuntimeConfig,
-		StagingDir:    paths.SubscriptionStaging,
+		Onboarding:        onboardingService,
+		Panels:            panelService,
+		WebGateway:        webGateway,
+		WebOpenToken:      webCredential,
+		Settings:          settings,
+		SettingsPath:      settingsPath,
+		ServiceStatus:     options.ServiceStatus,
+		OnBackgroundError: options.OnBackgroundError,
+		SysProxy:          sysproxy.Platform(),
+		TunDetect:         tundetect.Platform(),
+		RuntimeConfig:     paths.RuntimeConfig,
+		StagingDir:        paths.SubscriptionStaging,
 		ValidateConfig: func(ctx context.Context, candidatePath string) error {
 			return core.ValidateConfig(ctx, core.OSCommandRunner{}, paths.CoreBinary, paths.Root, candidatePath)
 		},
@@ -230,7 +249,7 @@ func BuildRuntimeWithOptions(paths platform.Paths, settings config.Settings, dae
 		},
 	})
 	webGateway.Mutator = webMutator{manager: manager}
-	return &RuntimeAssembly{Manager: manager, Store: store, Web: webGateway}, nil
+	return &RuntimeAssembly{Manager: manager, Store: store, Web: webGateway, mihomoStarter: mihomoStarter}, nil
 }
 
 type webMutationRuntime interface {

--- a/internal/app/runtime_test.go
+++ b/internal/app/runtime_test.go
@@ -1,19 +1,24 @@
 package app
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/mihari-proxy/mihari/internal/config"
 	"github.com/mihari-proxy/mihari/internal/control/protocol"
+	"github.com/mihari-proxy/mihari/internal/logging"
 	"github.com/mihari-proxy/mihari/internal/platform"
 	runtimeapi "github.com/mihari-proxy/mihari/internal/runtime"
 )
@@ -296,4 +301,88 @@ func testRuntimeSettings(t *testing.T) config.Settings {
 	settings.ControllerAddr = addresses[1]
 	settings.WebAddr = addresses[2]
 	return settings
+}
+
+func TestBuildRuntime_UsesOptionWritersCapture(t *testing.T) {
+	paths := platform.NewPaths(filepath.Join(t.TempDir(), "data"))
+	settings := testRuntimeSettings(t)
+	settings.ControllerSecret = strings.Repeat("a", 64)
+	captureOut := &bytes.Buffer{}
+	captureErr := &bytes.Buffer{}
+	positionalOut := &bytes.Buffer{}
+	positionalErr := &bytes.Buffer{}
+	assembly, err := BuildRuntimeWithOptions(paths, settings, "test-version", positionalOut, positionalErr, RuntimeBuildOptions{
+		SettingsPath: paths.Settings,
+		MihomoStdout: captureOut,
+		MihomoStderr: captureErr,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if assembly.mihomoStarter.Stdout != captureOut {
+		t.Fatalf("starter stdout=%T want capture buffer", assembly.mihomoStarter.Stdout)
+	}
+	if assembly.mihomoStarter.Stderr != captureErr {
+		t.Fatalf("starter stderr=%T want capture buffer", assembly.mihomoStarter.Stderr)
+	}
+	if assembly.mihomoStarter.Stdout == positionalOut || assembly.mihomoStarter.Stderr == positionalErr {
+		t.Fatal("positional stdout/stderr entered CommandStarter")
+	}
+}
+
+func TestBuildRuntime_LogsRedactedBackground(t *testing.T) {
+	paths := platform.NewPaths(filepath.Join(t.TempDir(), "data"))
+	settings := testRuntimeSettings(t)
+	settings.ControllerSecret = strings.Repeat("b", 64)
+	secret := "background-secret-value"
+	redactor := logging.NewRedactor(secret)
+	var buf bytes.Buffer
+	level := &slog.LevelVar{}
+	logger := slog.New(logging.NewJSONHandler(&buf, level, "daemon", redactor))
+	reported := make(chan struct{})
+	var once sync.Once
+	var gotComponent string
+	assembly, err := BuildRuntimeWithOptions(paths, settings, "test-version", nil, nil, RuntimeBuildOptions{
+		SettingsPath: paths.Settings,
+		OnBackgroundError: func(component string, err error) {
+			gotComponent = component
+			logger.Error("background "+secret+": "+err.Error(), slog.String("component", component))
+			once.Do(func() { close(reported) })
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	holder, err := net.Listen("tcp", settings.WebAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = holder.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- assembly.Manager.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("manager did not stop")
+		}
+	})
+	select {
+	case <-reported:
+	case <-time.After(5 * time.Second):
+		t.Fatal("manager background error was not reported")
+	}
+	if gotComponent != "web-gateway" {
+		t.Fatalf("component=%q", gotComponent)
+	}
+	logged := buf.String()
+	if strings.Contains(logged, secret) {
+		t.Fatalf("secret leaked into daemon logger: %s", logged)
+	}
+	if !strings.Contains(logged, "***") || !strings.Contains(logged, "web-gateway") {
+		t.Fatalf("logger=%s", logged)
+	}
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -171,5 +171,13 @@ func skipPrepareLocalRoot(cmd *cobra.Command) bool {
 		return true
 	}
 	parent := cmd.Parent()
-	return cmd.Name() == "version" && parent != nil && parent.Name() == "self"
+	if parent == nil || parent.Name() != "self" {
+		return false
+	}
+	switch cmd.Name() {
+	case "version", "channel":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -56,6 +56,8 @@ type Dependencies struct {
 	Interactive        bool
 	NewOperationID     func() string
 	SetupError         error
+	// PrepareLocalRoot runs once before selected commands. Nil skips data-root IO.
+	PrepareLocalRoot func() error
 }
 
 type runOptions struct {
@@ -99,7 +101,19 @@ func newRoot(dependencies Dependencies, options *runOptions) *cobra.Command {
 			}
 			return dependencies.RunTUI(command.Context())
 		},
-		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			if !skipPrepareLocalRoot(cmd) && dependencies.PrepareLocalRoot != nil {
+				if err := dependencies.PrepareLocalRoot(); err != nil {
+					var apiError protocol.APIError
+					if errors.As(err, &apiError) {
+						if apiError.Code == "" {
+							apiError.Code = protocol.CodeDataFailure
+						}
+						return apiError
+					}
+					return protocol.APIError{Code: protocol.CodeDataFailure, Message: "local control setup failed"}
+				}
+			}
 			if dependencies.SetupError == nil {
 				return nil
 			}
@@ -150,4 +164,12 @@ func wantsJSON(args []string) bool {
 
 func invalidArgument(message string) error {
 	return protocol.APIError{Code: protocol.CodeInvalidArgument, Message: message}
+}
+
+func skipPrepareLocalRoot(cmd *cobra.Command) bool {
+	if cmd.Name() == "help" {
+		return true
+	}
+	parent := cmd.Parent()
+	return cmd.Name() == "version" && parent != nil && parent.Name() == "self"
 }

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1,0 +1,126 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/mihari-proxy/mihari/internal/control/protocol"
+)
+
+func TestPrepareLocalRootSkippedForHelpCommand(t *testing.T) {
+	called := 0
+	code := Execute(context.Background(), []string{"help"}, io.Discard, io.Discard, Dependencies{
+		PrepareLocalRoot: func() error {
+			called++
+			return errors.New("prepare should not run")
+		},
+	})
+	if code != ExitOK || called != 0 {
+		t.Fatalf("code=%d called=%d", code, called)
+	}
+}
+
+func TestPrepareLocalRootSkippedForHelpFlag(t *testing.T) {
+	called := 0
+	code := Execute(context.Background(), []string{"--help"}, io.Discard, io.Discard, Dependencies{
+		PrepareLocalRoot: func() error {
+			called++
+			return errors.New("prepare should not run")
+		},
+	})
+	if code != ExitOK || called != 0 {
+		t.Fatalf("code=%d called=%d", code, called)
+	}
+}
+
+func TestPrepareLocalRootSkippedForDaemonHelp(t *testing.T) {
+	called := 0
+	code := Execute(context.Background(), []string{"daemon", "--help"}, io.Discard, io.Discard, Dependencies{
+		PrepareLocalRoot: func() error {
+			called++
+			return errors.New("prepare should not run")
+		},
+	})
+	if code != ExitOK || called != 0 {
+		t.Fatalf("code=%d called=%d", code, called)
+	}
+}
+
+func TestPrepareLocalRootSkippedForSelfVersion(t *testing.T) {
+	called := 0
+	code := Execute(context.Background(), []string{"self", "version"}, io.Discard, io.Discard, Dependencies{
+		PrepareLocalRoot: func() error {
+			called++
+			return errors.New("prepare should not run")
+		},
+	})
+	if code != ExitOK || called != 0 {
+		t.Fatalf("code=%d called=%d", code, called)
+	}
+}
+
+func TestPrepareLocalRootRunsForStatus(t *testing.T) {
+	called := 0
+	code := Execute(context.Background(), []string{"status"}, io.Discard, io.Discard, Dependencies{
+		PrepareLocalRoot: func() error {
+			called++
+			return nil
+		},
+		StatusClient: fakeStatusClient{status: protocol.Status{
+			DaemonVersion: "dev",
+			Health:        "ok",
+			StartedAt:     time.Unix(100, 0).UTC(),
+		}},
+	})
+	if code != ExitOK || called != 1 {
+		t.Fatalf("code=%d called=%d", code, called)
+	}
+}
+
+func TestPrepareLocalRootFailureUsesDataExitCode(t *testing.T) {
+	stderr := &bytes.Buffer{}
+	code := Execute(context.Background(), []string{"status", "--json"}, io.Discard, stderr, Dependencies{
+		PrepareLocalRoot: func() error {
+			return protocol.APIError{Code: protocol.CodeDataFailure, Message: "resolve Mihari data root"}
+		},
+		SetupError: errors.New("stale copied setup error must not be used"),
+	})
+	if code != ExitData {
+		t.Fatalf("code=%d stderr=%q", code, stderr.String())
+	}
+}
+
+func TestHelpCommandStillHonorsSetupError(t *testing.T) {
+	called := 0
+	code := Execute(context.Background(), []string{"help"}, io.Discard, io.Discard, Dependencies{
+		PrepareLocalRoot: func() error {
+			called++
+			return nil
+		},
+		SetupError: errors.New("credential unavailable"),
+	})
+	if code != ExitData || called != 0 {
+		t.Fatalf("code=%d called=%d", code, called)
+	}
+}
+
+func TestInteractiveRunTUIAfterPrepareLocalRoot(t *testing.T) {
+	called := false
+	code := Execute(context.Background(), []string{}, io.Discard, io.Discard, Dependencies{
+		Interactive: true,
+		PrepareLocalRoot: func() error {
+			return nil
+		},
+		RunTUI: func(context.Context) error {
+			called = true
+			return nil
+		},
+	})
+	if code != ExitOK || !called {
+		t.Fatalf("code=%d called=%v", code, called)
+	}
+}

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/mihari-proxy/mihari/internal/control/protocol"
+	"github.com/mihari-proxy/mihari/internal/elevate"
+	"github.com/mihari-proxy/mihari/internal/update"
 )
 
 func TestPrepareLocalRootSkippedForHelpCommand(t *testing.T) {
@@ -63,6 +65,42 @@ func TestPrepareLocalRootSkippedForSelfVersion(t *testing.T) {
 	}
 }
 
+func TestPrepareLocalRootSkippedForSelfChannel(t *testing.T) {
+	previousElevationCheck := elevate.Check
+	t.Cleanup(func() { elevate.Check = previousElevationCheck })
+	elevate.Check = func() bool { return true }
+
+	t.Setenv("MIHARI_DATA", t.TempDir())
+	called := 0
+	code := Execute(context.Background(), []string{"self", "channel"}, io.Discard, io.Discard, Dependencies{
+		PrepareLocalRoot: func() error {
+			called++
+			return errors.New("prepare should not run")
+		},
+	})
+	if code != ExitOK || called != 0 {
+		t.Fatalf("code=%d called=%d", code, called)
+	}
+}
+
+func TestPrepareLocalRootRunsForSelfUpdate(t *testing.T) {
+	previousElevationCheck := elevate.Check
+	t.Cleanup(func() { elevate.Check = previousElevationCheck })
+	elevate.Check = func() bool { return true }
+
+	called := 0
+	code := Execute(context.Background(), []string{"self", "update"}, io.Discard, io.Discard, Dependencies{
+		SelfUpdater: &fakeSelfUpdater{result: update.Result{Version: "v1.0.0", Channel: "main"}},
+		PrepareLocalRoot: func() error {
+			called++
+			return nil
+		},
+	})
+	if code != ExitOK || called != 1 {
+		t.Fatalf("code=%d called=%d", code, called)
+	}
+}
+
 func TestPrepareLocalRootRunsForStatus(t *testing.T) {
 	called := 0
 	code := Execute(context.Background(), []string{"status"}, io.Discard, io.Discard, Dependencies{
@@ -81,7 +119,7 @@ func TestPrepareLocalRootRunsForStatus(t *testing.T) {
 	}
 }
 
-func TestPrepareLocalRootFailureUsesDataExitCode(t *testing.T) {
+func TestPrepareLocalRootFailurePreservesAPIError(t *testing.T) {
 	stderr := &bytes.Buffer{}
 	code := Execute(context.Background(), []string{"status", "--json"}, io.Discard, stderr, Dependencies{
 		PrepareLocalRoot: func() error {
@@ -91,6 +129,9 @@ func TestPrepareLocalRootFailureUsesDataExitCode(t *testing.T) {
 	})
 	if code != ExitData {
 		t.Fatalf("code=%d stderr=%q", code, stderr.String())
+	}
+	if got, want := stderr.String(), "{\"schema\":\"mihari.error/v1\",\"error\":{\"code\":\"data_failure\",\"message\":\"resolve Mihari data root\"}}\n"; got != want {
+		t.Fatalf("stderr=%q want=%q", got, want)
 	}
 }
 

--- a/internal/control/client/client.go
+++ b/internal/control/client/client.go
@@ -40,6 +40,14 @@ func NewHTTP(baseURL, token string, httpClient *http.Client) *Client {
 	}
 }
 
+// SetToken replaces the Bearer token. An empty token is a no-op.
+func (c *Client) SetToken(token string) {
+	if token == "" {
+		return
+	}
+	c.token = token
+}
+
 func (c *Client) Status(ctx context.Context) (protocol.Status, error) {
 	var status protocol.Status
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/status", nil)

--- a/internal/control/client/client.go
+++ b/internal/control/client/client.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/mihari-proxy/mihari/internal/control/protocol"
@@ -16,6 +17,7 @@ import (
 
 type Client struct {
 	baseURL string
+	tokenMu sync.RWMutex
 	token   string
 	http    *http.Client
 }
@@ -45,7 +47,15 @@ func (c *Client) SetToken(token string) {
 	if token == "" {
 		return
 	}
+	c.tokenMu.Lock()
+	defer c.tokenMu.Unlock()
 	c.token = token
+}
+
+func (c *Client) bearerToken() string {
+	c.tokenMu.RLock()
+	defer c.tokenMu.RUnlock()
+	return c.token
 }
 
 func (c *Client) Status(ctx context.Context) (protocol.Status, error) {
@@ -54,7 +64,7 @@ func (c *Client) Status(ctx context.Context) (protocol.Status, error) {
 	if err != nil {
 		return status, err
 	}
-	request.Header.Set("Authorization", "Bearer "+c.token)
+	request.Header.Set("Authorization", "Bearer "+c.bearerToken())
 
 	response, err := c.http.Do(request)
 	if err != nil {

--- a/internal/control/client/client_test.go
+++ b/internal/control/client/client_test.go
@@ -30,6 +30,40 @@ func TestStatusDecodesSuccess(t *testing.T) {
 	}
 }
 
+func TestSetToken_EmptyIsNoOp(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Header.Get("Authorization") != "Bearer token" {
+			t.Fatalf("authorization=%q", request.Header.Get("Authorization"))
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{"schema":"mihari/v1","protocol_version":"v1","daemon_version":"dev","revision":1,"health":"ok","started_at":"1970-01-01T00:01:40Z"}`))
+	}))
+	defer server.Close()
+
+	control := NewHTTP(server.URL, "token", server.Client())
+	control.SetToken("")
+	if _, err := control.Status(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSetToken_UpdatesBearer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Header.Get("Authorization") != "Bearer new-token" {
+			t.Fatalf("authorization=%q", request.Header.Get("Authorization"))
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{"schema":"mihari/v1","protocol_version":"v1","daemon_version":"dev","revision":1,"health":"ok","started_at":"1970-01-01T00:01:40Z"}`))
+	}))
+	defer server.Close()
+
+	control := NewHTTP(server.URL, "old-token", server.Client())
+	control.SetToken("new-token")
+	if _, err := control.Status(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestStatusDecodesAPIError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 		writer.WriteHeader(http.StatusUnauthorized)

--- a/internal/control/client/client_test.go
+++ b/internal/control/client/client_test.go
@@ -3,8 +3,11 @@ package client
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/mihari-proxy/mihari/internal/control/protocol"
@@ -62,6 +65,46 @@ func TestSetToken_UpdatesBearer(t *testing.T) {
 	if _, err := control.Status(context.Background()); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestSetToken_ConcurrentRequests(t *testing.T) {
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if authorization := request.Header.Get("Authorization"); authorization != "Bearer first-token" && authorization != "Bearer second-token" {
+			t.Errorf("authorization=%q", authorization)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"schema":"mihari/v1","protocol_version":"v1","daemon_version":"dev","revision":1,"health":"ok","started_at":"1970-01-01T00:01:40Z"}`)),
+		}, nil
+	})
+	control := NewHTTP("http://mihari", "first-token", &http.Client{Transport: transport})
+
+	var workers sync.WaitGroup
+	workers.Add(2)
+	go func() {
+		defer workers.Done()
+		for range 1000 {
+			control.SetToken("second-token")
+			control.SetToken("first-token")
+		}
+	}()
+	go func() {
+		defer workers.Done()
+		for range 1000 {
+			if _, err := control.Status(context.Background()); err != nil {
+				t.Errorf("Status: %v", err)
+				return
+			}
+		}
+	}()
+	workers.Wait()
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
 }
 
 func TestStatusDecodesAPIError(t *testing.T) {

--- a/internal/control/client/runtime.go
+++ b/internal/control/client/runtime.go
@@ -257,7 +257,7 @@ func (c *Client) Stream(ctx context.Context, kind string, receive func(protocol.
 	}
 	streamURL.Path = strings.TrimRight(streamURL.Path, "/") + "/v1/streams/" + url.PathEscape(kind)
 	header := http.Header{}
-	header.Set("Authorization", "Bearer "+c.token)
+	header.Set("Authorization", "Bearer "+c.bearerToken())
 	connection, response, err := websocket.Dial(ctx, streamURL.String(), &websocket.DialOptions{HTTPClient: c.http, HTTPHeader: header})
 	if err != nil {
 		if ctx.Err() != nil {
@@ -304,7 +304,7 @@ func (c *Client) doRuntime(ctx context.Context, method, path string, input, outp
 	if err != nil {
 		return protocol.APIError{Code: protocol.CodeInternal, Message: "create control request"}
 	}
-	request.Header.Set("Authorization", "Bearer "+c.token)
+	request.Header.Set("Authorization", "Bearer "+c.bearerToken())
 	if input != nil {
 		request.Header.Set("Content-Type", "application/json")
 	}

--- a/internal/logging/capture.go
+++ b/internal/logging/capture.go
@@ -37,7 +37,7 @@ func NewLineCaptureWriter(logger *slog.Logger, level slog.Level, stream string) 
 		logger: logger,
 		level:  level,
 		stream: stream,
-		buf:    make([]byte, 0, MaxCaptureLineBytes+utf8.UTFMax),
+		buf:    make([]byte, 0, MaxCaptureLineBytes),
 	}
 }
 
@@ -161,44 +161,7 @@ func appendCapped(buf, chunk []byte) ([]byte, bool) {
 		return append(buf, chunk...), false
 	}
 	buf = append(buf, chunk[:room]...)
-	rest := chunk[room:]
-	for len(rest) > 0 && len(buf) < MaxCaptureLineBytes+utf8.UTFMax && incompleteTrailing(buf) {
-		buf = append(buf, rest[0])
-		rest = rest[1:]
-	}
 	return buf, true
-}
-
-func incompleteTrailing(p []byte) bool {
-	if len(p) == 0 {
-		return false
-	}
-	i := len(p) - 1
-	for i > 0 && !utf8.RuneStart(p[i]) && len(p)-i < utf8.UTFMax {
-		i--
-	}
-	if !utf8.RuneStart(p[i]) {
-		return false
-	}
-	need := utf8LeadSize(p[i])
-	return need > len(p)-i
-}
-
-func utf8LeadSize(b byte) int {
-	switch {
-	case b < 0x80:
-		return 1
-	case b < 0xC0:
-		return 1
-	case b < 0xE0:
-		return 2
-	case b < 0xF0:
-		return 3
-	case b < 0xF8:
-		return 4
-	default:
-		return 1
-	}
 }
 
 func sanitizeUTF8(b []byte) (string, bool) {

--- a/internal/logging/capture.go
+++ b/internal/logging/capture.go
@@ -1,0 +1,226 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+)
+
+// LineCaptureWriter splits arbitrary stdout/stderr chunks into JSONL records.
+type LineCaptureWriter interface {
+	io.WriteCloser
+	Flush() error
+}
+
+type lineCaptureWriter struct {
+	logger *slog.Logger
+	level  slog.Level
+	stream string
+
+	mu     sync.Mutex
+	buf    []byte
+	trunc  bool
+	drop   bool
+	closed bool
+}
+
+// NewLineCaptureWriter returns a writer that logs each logical line at level
+// with stream set. Write returns len(p), nil unless the writer is closed.
+func NewLineCaptureWriter(logger *slog.Logger, level slog.Level, stream string) LineCaptureWriter {
+	return &lineCaptureWriter{
+		logger: logger,
+		level:  level,
+		stream: stream,
+		buf:    make([]byte, 0, MaxCaptureLineBytes+utf8.UTFMax),
+	}
+}
+
+func (w *lineCaptureWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return 0, os.ErrClosed
+	}
+	w.consume(p)
+	return len(p), nil
+}
+
+func (w *lineCaptureWriter) Flush() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return os.ErrClosed
+	}
+	w.emitPartial()
+	return nil
+}
+
+func (w *lineCaptureWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return nil
+	}
+	w.emitPartial()
+	w.closed = true
+	return nil
+}
+
+func (w *lineCaptureWriter) consume(p []byte) {
+	for len(p) > 0 {
+		if w.drop {
+			i := bytes.IndexByte(p, '\n')
+			if i < 0 {
+				return
+			}
+			w.emitLine()
+			p = p[i+1:]
+			continue
+		}
+		i := bytes.IndexByte(p, '\n')
+		chunk := p
+		var rest []byte
+		hasNL := i >= 0
+		if hasNL {
+			chunk = p[:i]
+			rest = p[i+1:]
+		}
+		overflow := false
+		w.buf, overflow = appendCapped(w.buf, chunk)
+		if overflow {
+			w.trunc = true
+			w.drop = true
+			if !hasNL {
+				return
+			}
+			w.emitLine()
+			p = rest
+			continue
+		}
+		if hasNL {
+			w.emitLine()
+			p = rest
+			continue
+		}
+		return
+	}
+}
+
+func (w *lineCaptureWriter) emitPartial() {
+	if len(w.buf) == 0 && !w.trunc {
+		w.drop = false
+		return
+	}
+	w.emitLine()
+}
+
+func (w *lineCaptureWriter) emitLine() {
+	line := w.buf
+	if n := len(line); n > 0 && line[n-1] == '\r' {
+		line = line[:n-1]
+	}
+	truncated := w.trunc
+	msg, invalid := sanitizeUTF8(line)
+	w.buf = w.buf[:0]
+	w.trunc = false
+	w.drop = false
+	w.logLine(msg, truncated, invalid)
+}
+
+func (w *lineCaptureWriter) logLine(msg string, truncated, invalid bool) {
+	if w.logger == nil {
+		return
+	}
+	h := w.logger.Handler()
+	if h == nil || !h.Enabled(context.Background(), w.level) {
+		return
+	}
+	rec := slog.NewRecord(time.Now(), w.level, msg, 0)
+	rec.AddAttrs(slog.String("stream", w.stream))
+	if truncated {
+		rec.AddAttrs(slog.Bool("truncated", true))
+	}
+	if invalid {
+		rec.AddAttrs(slog.Bool("invalid_utf8", true))
+	}
+	_ = h.Handle(context.Background(), rec)
+}
+
+func appendCapped(buf, chunk []byte) ([]byte, bool) {
+	room := MaxCaptureLineBytes - len(buf)
+	if room < 0 {
+		room = 0
+	}
+	if len(chunk) <= room {
+		return append(buf, chunk...), false
+	}
+	buf = append(buf, chunk[:room]...)
+	rest := chunk[room:]
+	for len(rest) > 0 && len(buf) < MaxCaptureLineBytes+utf8.UTFMax && incompleteTrailing(buf) {
+		buf = append(buf, rest[0])
+		rest = rest[1:]
+	}
+	return buf, true
+}
+
+func incompleteTrailing(p []byte) bool {
+	if len(p) == 0 {
+		return false
+	}
+	i := len(p) - 1
+	for i > 0 && !utf8.RuneStart(p[i]) && len(p)-i < utf8.UTFMax {
+		i--
+	}
+	if !utf8.RuneStart(p[i]) {
+		return false
+	}
+	need := utf8LeadSize(p[i])
+	return need > len(p)-i
+}
+
+func utf8LeadSize(b byte) int {
+	switch {
+	case b < 0x80:
+		return 1
+	case b < 0xC0:
+		return 1
+	case b < 0xE0:
+		return 2
+	case b < 0xF0:
+		return 3
+	case b < 0xF8:
+		return 4
+	default:
+		return 1
+	}
+}
+
+func sanitizeUTF8(b []byte) (string, bool) {
+	if utf8.Valid(b) {
+		return string(b), false
+	}
+	var out strings.Builder
+	out.Grow(len(b) + utf8.UTFMax)
+	invalid := false
+	for i := 0; i < len(b); {
+		r, size := utf8.DecodeRune(b[i:])
+		if size == 0 {
+			break
+		}
+		if r == utf8.RuneError && size == 1 {
+			invalid = true
+			out.WriteRune(utf8.RuneError)
+			i++
+			continue
+		}
+		out.WriteRune(r)
+		i += size
+	}
+	return out.String(), invalid
+}

--- a/internal/logging/capture_test.go
+++ b/internal/logging/capture_test.go
@@ -1,0 +1,382 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestLineCaptureWriter_MultipleLinesOneWrite(t *testing.T) {
+	w, buf := newTestCapture(t, slog.LevelInfo, "stdout")
+	n, err := w.Write([]byte("one\ntwo\nthree\n"))
+	if err != nil || n != 14 {
+		t.Fatalf("Write n=%d err=%v", n, err)
+	}
+	recs := parseCaptureJSONL(t, buf.String())
+	if len(recs) != 3 {
+		t.Fatalf("records=%d, want 3 in %q", len(recs), buf.String())
+	}
+	assertCapture(t, recs[0], "INFO", "one", "stdout", false, false)
+	assertCapture(t, recs[1], "INFO", "two", "stdout", false, false)
+	assertCapture(t, recs[2], "INFO", "three", "stdout", false, false)
+}
+
+func TestLineCaptureWriter_SplitAcrossWrites(t *testing.T) {
+	w, buf := newTestCapture(t, slog.LevelInfo, "stdout")
+	if n, err := w.Write([]byte("hel")); err != nil || n != 3 {
+		t.Fatalf("Write n=%d err=%v", n, err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("partial write emitted %q", buf.String())
+	}
+	if n, err := w.Write([]byte("lo\n")); err != nil || n != 3 {
+		t.Fatalf("Write n=%d err=%v", n, err)
+	}
+	recs := parseCaptureJSONL(t, buf.String())
+	if len(recs) != 1 {
+		t.Fatalf("records=%d, want 1", len(recs))
+	}
+	assertCapture(t, recs[0], "INFO", "hello", "stdout", false, false)
+}
+
+func TestLineCaptureWriter_CRLF(t *testing.T) {
+	w, buf := newTestCapture(t, slog.LevelInfo, "stdout")
+	if _, err := w.Write([]byte("hello\r\nworld\r\n")); err != nil {
+		t.Fatal(err)
+	}
+	recs := parseCaptureJSONL(t, buf.String())
+	if len(recs) != 2 {
+		t.Fatalf("records=%d, want 2", len(recs))
+	}
+	assertCapture(t, recs[0], "INFO", "hello", "stdout", false, false)
+	assertCapture(t, recs[1], "INFO", "world", "stdout", false, false)
+}
+
+func TestLineCaptureWriter_EmptyLine(t *testing.T) {
+	w, buf := newTestCapture(t, slog.LevelInfo, "stdout")
+	if _, err := w.Write([]byte("a\n\nb\n")); err != nil {
+		t.Fatal(err)
+	}
+	recs := parseCaptureJSONL(t, buf.String())
+	if len(recs) != 3 {
+		t.Fatalf("records=%d, want 3", len(recs))
+	}
+	assertCapture(t, recs[1], "INFO", "", "stdout", false, false)
+}
+
+func TestLineCaptureWriter_InvalidUTF8(t *testing.T) {
+	w, buf := newTestCapture(t, slog.LevelInfo, "stdout")
+	if _, err := w.Write([]byte{0xff, 0xfe, '\n'}); err != nil {
+		t.Fatal(err)
+	}
+	recs := parseCaptureJSONL(t, buf.String())
+	if len(recs) != 1 {
+		t.Fatalf("records=%d, want 1", len(recs))
+	}
+	assertCapture(t, recs[0], "INFO", "\uFFFD\uFFFD", "stdout", false, true)
+}
+
+func TestLineCaptureWriter_UTF8SplitAcrossWrites(t *testing.T) {
+	w, buf := newTestCapture(t, slog.LevelInfo, "stdout")
+	world := []byte("世界")
+	if _, err := w.Write(world[:2]); err != nil {
+		t.Fatal(err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("incomplete rune emitted %q", buf.String())
+	}
+	if _, err := w.Write(append(world[2:], '\n')); err != nil {
+		t.Fatal(err)
+	}
+	recs := parseCaptureJSONL(t, buf.String())
+	if len(recs) != 1 {
+		t.Fatalf("records=%d, want 1", len(recs))
+	}
+	assertCapture(t, recs[0], "INFO", "世界", "stdout", false, false)
+}
+
+func TestLineCaptureWriter_Exact16KiB(t *testing.T) {
+	w, buf := newTestCapture(t, slog.LevelInfo, "stdout")
+	line := bytes.Repeat([]byte("x"), MaxCaptureLineBytes)
+	payload := append(line, '\n')
+	n, err := w.Write(payload)
+	if err != nil || n != len(payload) {
+		t.Fatalf("Write n=%d err=%v", n, err)
+	}
+	recs := parseCaptureJSONL(t, buf.String())
+	if len(recs) != 1 {
+		t.Fatalf("records=%d, want 1", len(recs))
+	}
+	assertCapture(t, recs[0], "INFO", string(line), "stdout", false, false)
+}
+
+func TestLineCaptureWriter_TruncatesOver16KiB(t *testing.T) {
+	w, buf := newTestCapture(t, slog.LevelInfo, "stdout")
+	line := bytes.Repeat([]byte("x"), MaxCaptureLineBytes+100)
+	payload := append(append(line, '\n'), []byte("next\n")...)
+	n, err := w.Write(payload)
+	if err != nil || n != len(payload) {
+		t.Fatalf("Write n=%d err=%v", n, err)
+	}
+	recs := parseCaptureJSONL(t, buf.String())
+	if len(recs) != 2 {
+		t.Fatalf("records=%d, want 2", len(recs))
+	}
+	assertCapture(t, recs[0], "INFO", strings.Repeat("x", MaxCaptureLineBytes), "stdout", true, false)
+	assertCapture(t, recs[1], "INFO", "next", "stdout", false, false)
+}
+
+func TestLineCaptureWriter_BufferNeverExceedsCap(t *testing.T) {
+	w, _ := newTestCapture(t, slog.LevelInfo, "stdout")
+	impl := w.(*lineCaptureWriter)
+	lead := bytes.Repeat([]byte("x"), MaxCaptureLineBytes-1)
+	rune3 := []byte("世")
+	rest := bytes.Repeat([]byte("y"), 64)
+	payload := append(append(lead, rune3...), rest...)
+	if _, err := w.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	impl.mu.Lock()
+	n := len(impl.buf)
+	impl.mu.Unlock()
+	if n > MaxCaptureLineBytes+utf8.UTFMax {
+		t.Fatalf("buf len=%d exceeds MaxCaptureLineBytes+utf8.UTFMax", n)
+	}
+	if n < MaxCaptureLineBytes {
+		t.Fatalf("buf len=%d, want at least %d", n, MaxCaptureLineBytes)
+	}
+}
+
+func TestLineCaptureWriter_FlushPartialThenWrite(t *testing.T) {
+	w, buf := newTestCapture(t, slog.LevelInfo, "stdout")
+	if _, err := w.Write([]byte("ab")); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write([]byte("cd")); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	recs := parseCaptureJSONL(t, buf.String())
+	if len(recs) != 2 {
+		t.Fatalf("records=%d, want 2", len(recs))
+	}
+	assertCapture(t, recs[0], "INFO", "ab", "stdout", false, false)
+	assertCapture(t, recs[1], "INFO", "cd", "stdout", false, false)
+}
+
+func TestLineCaptureWriter_FlushSurvivesChildLifetimes(t *testing.T) {
+	w, buf := newTestCapture(t, slog.LevelInfo, "stdout")
+	if _, err := w.Write([]byte("partial")); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write([]byte("next-start\n")); err != nil {
+		t.Fatal(err)
+	}
+	recs := parseCaptureJSONL(t, buf.String())
+	if len(recs) != 2 {
+		t.Fatalf("records=%d want 2 (must not glue child lifetimes): %q", len(recs), buf.String())
+	}
+	assertCapture(t, recs[0], "INFO", "partial", "stdout", false, false)
+	assertCapture(t, recs[1], "INFO", "next-start", "stdout", false, false)
+}
+
+func TestLineCaptureWriter_CloseFlushesPartial(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(NewJSONHandler(&buf, newDebugLevel(), "mihomo", NewRedactor()))
+	w := NewLineCaptureWriter(logger, slog.LevelInfo, "stdout")
+	if _, err := w.Write([]byte("no-nl")); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	recs := parseCaptureJSONL(t, buf.String())
+	if len(recs) != 1 {
+		t.Fatalf("records=%d, want 1 after idempotent Close", len(recs))
+	}
+	assertCapture(t, recs[0], "INFO", "no-nl", "stdout", false, false)
+	logger.Info("after-close")
+	if !strings.Contains(buf.String(), `"msg":"after-close"`) {
+		t.Fatalf("Close must not close shared logger: %s", buf.String())
+	}
+}
+
+func TestLineCaptureWriter_WriteAfterClose(t *testing.T) {
+	w, buf := newTestCapture(t, slog.LevelInfo, "stdout")
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	before := buf.String()
+	n, err := w.Write([]byte("late\n"))
+	if !errors.Is(err, os.ErrClosed) {
+		t.Fatalf("err=%v, want os.ErrClosed", err)
+	}
+	if n != 0 {
+		t.Fatalf("n=%d, want 0", n)
+	}
+	if buf.String() != before {
+		t.Fatalf("Write after Close touched logger: %q", buf.String())
+	}
+	if err := w.Flush(); !errors.Is(err, os.ErrClosed) {
+		t.Fatalf("Flush after Close err=%v, want os.ErrClosed", err)
+	}
+}
+
+func TestLineCaptureWriter_StdoutInfoStderrWarn(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(NewJSONHandler(&buf, newDebugLevel(), "mihomo", NewRedactor()))
+	out := NewLineCaptureWriter(logger, slog.LevelInfo, "stdout")
+	errw := NewLineCaptureWriter(logger, slog.LevelWarn, "stderr")
+	t.Cleanup(func() {
+		_ = out.Close()
+		_ = errw.Close()
+	})
+	if _, err := out.Write([]byte("from-out\n")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := errw.Write([]byte("from-err\n")); err != nil {
+		t.Fatal(err)
+	}
+	recs := parseCaptureJSONL(t, buf.String())
+	if len(recs) != 2 {
+		t.Fatalf("records=%d, want 2", len(recs))
+	}
+	assertCapture(t, recs[0], "INFO", "from-out", "stdout", false, false)
+	assertCapture(t, recs[1], "WARN", "from-err", "stderr", false, false)
+}
+
+func TestLineCaptureWriter_JSONHasComponentStreamNoSource(t *testing.T) {
+	w, buf := newTestCapture(t, slog.LevelInfo, "stdout")
+	if _, err := w.Write([]byte("hi\n")); err != nil {
+		t.Fatal(err)
+	}
+	recs := parseCaptureJSONL(t, buf.String())
+	if len(recs) != 1 {
+		t.Fatalf("records=%d, want 1", len(recs))
+	}
+	if recs[0]["component"] != "mihomo" {
+		t.Fatalf("component=%v", recs[0]["component"])
+	}
+	if _, ok := recs[0]["source"]; ok {
+		t.Fatalf("source key must not appear: %v", recs[0])
+	}
+}
+
+func TestLineCaptureWriter_WriteIgnoresLoggerErrors(t *testing.T) {
+	logger := slog.New(failHandler{})
+	w := NewLineCaptureWriter(logger, slog.LevelInfo, "stdout")
+	payload := []byte("boom\nand-more\n")
+	n, err := w.Write(payload)
+	if err != nil {
+		t.Fatalf("Write returned logger error: %v", err)
+	}
+	if n != len(payload) {
+		t.Fatalf("n=%d, want %d", n, len(payload))
+	}
+}
+
+func TestLineCaptureWriter_LevelFilterStillAcceptsWrite(t *testing.T) {
+	var buf bytes.Buffer
+	level := &slog.LevelVar{}
+	level.Set(slog.LevelWarn)
+	logger := slog.New(NewJSONHandler(&buf, level, "mihomo", NewRedactor()))
+	w := NewLineCaptureWriter(logger, slog.LevelInfo, "stdout")
+	t.Cleanup(func() { _ = w.Close() })
+	payload := []byte("filtered\n")
+	n, err := w.Write(payload)
+	if err != nil || n != len(payload) {
+		t.Fatalf("Write n=%d err=%v", n, err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("filtered line was written: %q", buf.String())
+	}
+}
+
+func newTestCapture(t *testing.T, level slog.Level, stream string) (LineCaptureWriter, *bytes.Buffer) {
+	t.Helper()
+	var buf bytes.Buffer
+	logger := slog.New(NewJSONHandler(&buf, newDebugLevel(), "mihomo", NewRedactor()))
+	w := NewLineCaptureWriter(logger, level, stream)
+	t.Cleanup(func() { _ = w.Close() })
+	return w, &buf
+}
+
+func newDebugLevel() *slog.LevelVar {
+	level := &slog.LevelVar{}
+	level.Set(slog.LevelDebug)
+	return level
+}
+
+func parseCaptureJSONL(t *testing.T, raw string) []map[string]any {
+	t.Helper()
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	var out []map[string]any
+	for _, line := range strings.Split(raw, "\n") {
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("json: %v in %q", err, line)
+		}
+		out = append(out, rec)
+	}
+	return out
+}
+
+func assertCapture(t *testing.T, rec map[string]any, level, msg, stream string, truncated, invalid bool) {
+	t.Helper()
+	if rec["level"] != level {
+		t.Fatalf("level=%v want %s", rec["level"], level)
+	}
+	if rec["msg"] != msg {
+		t.Fatalf("msg=%q want %q", rec["msg"], msg)
+	}
+	if rec["stream"] != stream {
+		t.Fatalf("stream=%v want %s", rec["stream"], stream)
+	}
+	if rec["component"] != "mihomo" {
+		t.Fatalf("component=%v", rec["component"])
+	}
+	if _, ok := rec["source"]; ok {
+		t.Fatalf("source present: %v", rec)
+	}
+	if _, ok := rec["truncated"]; ok != truncated {
+		t.Fatalf("truncated presence=%v want %v in %v", ok, truncated, rec)
+	}
+	if truncated {
+		if rec["truncated"] != true {
+			t.Fatalf("truncated=%v", rec["truncated"])
+		}
+	}
+	if _, ok := rec["invalid_utf8"]; ok != invalid {
+		t.Fatalf("invalid_utf8 presence=%v want %v in %v", ok, invalid, rec)
+	}
+	if invalid && rec["invalid_utf8"] != true {
+		t.Fatalf("invalid_utf8=%v", rec["invalid_utf8"])
+	}
+}
+
+type failHandler struct{}
+
+func (failHandler) Enabled(context.Context, slog.Level) bool  { return true }
+func (failHandler) Handle(context.Context, slog.Record) error { return errors.New("disk full") }
+func (failHandler) WithAttrs([]slog.Attr) slog.Handler        { return failHandler{} }
+func (failHandler) WithGroup(string) slog.Handler             { return failHandler{} }

--- a/internal/logging/capture_test.go
+++ b/internal/logging/capture_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"unicode/utf8"
 )
 
 func TestLineCaptureWriter_MultipleLinesOneWrite(t *testing.T) {
@@ -132,8 +131,8 @@ func TestLineCaptureWriter_TruncatesOver16KiB(t *testing.T) {
 	assertCapture(t, recs[1], "INFO", "next", "stdout", false, false)
 }
 
-func TestLineCaptureWriter_BufferNeverExceedsCap(t *testing.T) {
-	w, _ := newTestCapture(t, slog.LevelInfo, "stdout")
+func TestLineCaptureWriter_BufferNeverExceedsExactCap(t *testing.T) {
+	w, output := newTestCapture(t, slog.LevelInfo, "stdout")
 	impl := w.(*lineCaptureWriter)
 	lead := bytes.Repeat([]byte("x"), MaxCaptureLineBytes-1)
 	rune3 := []byte("世")
@@ -145,12 +144,20 @@ func TestLineCaptureWriter_BufferNeverExceedsCap(t *testing.T) {
 	impl.mu.Lock()
 	n := len(impl.buf)
 	impl.mu.Unlock()
-	if n > MaxCaptureLineBytes+utf8.UTFMax {
-		t.Fatalf("buf len=%d exceeds MaxCaptureLineBytes+utf8.UTFMax", n)
+	if n > MaxCaptureLineBytes {
+		t.Fatalf("buf len=%d exceeds MaxCaptureLineBytes", n)
 	}
 	if n < MaxCaptureLineBytes {
 		t.Fatalf("buf len=%d, want at least %d", n, MaxCaptureLineBytes)
 	}
+	if err := w.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	recs := parseCaptureJSONL(t, output.String())
+	if len(recs) != 1 {
+		t.Fatalf("records=%d, want 1", len(recs))
+	}
+	assertCapture(t, recs[0], "INFO", strings.Repeat("x", MaxCaptureLineBytes-1)+"\uFFFD", "stdout", true, true)
 }
 
 func TestLineCaptureWriter_FlushPartialThenWrite(t *testing.T) {

--- a/internal/logging/config.go
+++ b/internal/logging/config.go
@@ -1,0 +1,99 @@
+package logging
+
+import (
+	"io"
+	"log/slog"
+	"regexp"
+	"sync"
+	"time"
+)
+
+const (
+	// MaxCaptureLineBytes is the per-line capture cap for mihomo stdout/stderr.
+	MaxCaptureLineBytes = 16 << 10
+	// MaxExportRecordBytes is the per-record export parse cap.
+	MaxExportRecordBytes = 1 << 20
+
+	defaultMaxSizeBytes = 10 << 20
+	defaultMaxFiles     = 3
+	bootstrapMaxSize    = 100 << 20
+	bootstrapMaxFiles   = 10
+	writeWaitBound      = 250 * time.Millisecond
+	failureReportWindow = time.Second
+)
+
+// Config is the runtime logging level and rotation limits.
+type Config struct {
+	Level        slog.Level
+	MaxSizeBytes int64
+	MaxFiles     int
+}
+
+// DefaultConfig is info, 10 MiB, 3 files.
+func DefaultConfig() Config {
+	return Config{Level: slog.LevelInfo, MaxSizeBytes: defaultMaxSizeBytes, MaxFiles: defaultMaxFiles}
+}
+
+// BootstrapConfig is the conservative TUI bootstrap: debug, 100 MiB, 10 files.
+func BootstrapConfig() Config {
+	return Config{Level: slog.LevelDebug, MaxSizeBytes: bootstrapMaxSize, MaxFiles: bootstrapMaxFiles}
+}
+
+// FailureClass is a stable, rate-limited stderr category.
+type FailureClass string
+
+const (
+	FailureDropped FailureClass = "dropped"
+	FailureWrite   FailureClass = "write"
+	FailureRotate  FailureClass = "rotate"
+	FailureCleanup FailureClass = "cleanup"
+)
+
+// FailureReporter records classified logging failures.
+type FailureReporter interface {
+	Report(class FailureClass, err error)
+}
+
+type failureReporter struct {
+	out      io.Writer
+	redactor *Redactor
+	now      func() time.Time
+	mu       sync.Mutex
+	last     map[FailureClass]time.Time
+}
+
+var pathTokenPattern = regexp.MustCompile(`(?:[A-Za-z]:)?(?:[\\/][^\s\\/:*?"<>|]+)+`)
+
+// NewFailureReporter writes rate-limited, redacted failure lines without full paths.
+func NewFailureReporter(out io.Writer, redactor *Redactor, now func() time.Time) FailureReporter {
+	if now == nil {
+		now = time.Now
+	}
+	return &failureReporter{out: out, redactor: redactor, now: now, last: make(map[FailureClass]time.Time)}
+}
+
+func (r *failureReporter) Report(class FailureClass, err error) {
+	if r == nil || r.out == nil {
+		return
+	}
+	now := r.now()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if prev, ok := r.last[class]; ok && now.Sub(prev) < failureReportWindow {
+		return
+	}
+	r.last[class] = now
+	msg := ""
+	if err != nil {
+		msg = err.Error()
+	}
+	if r.redactor != nil {
+		msg = r.redactor.String(msg)
+	}
+	msg = pathTokenPattern.ReplaceAllString(msg, "[path]")
+	line := "logging: " + string(class)
+	if msg != "" {
+		line += ": " + msg
+	}
+	_, _ = io.WriteString(r.out, line+"\n")
+}

--- a/internal/logging/config.go
+++ b/internal/logging/config.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"log/slog"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 )
@@ -62,7 +63,7 @@ type failureReporter struct {
 	last     map[FailureClass]time.Time
 }
 
-var pathTokenPattern = regexp.MustCompile(`(?:[A-Za-z]:)?(?:[\\/][^\s\\/:*?"<>|]+)+`)
+var pathTokenPattern = regexp.MustCompile(`(?:[A-Za-z]:)?(?:[\\/][^\\/:*?"<>|\r\n]+)+`)
 
 // NewFailureReporter writes rate-limited, redacted failure lines without full paths.
 func NewFailureReporter(out io.Writer, redactor *Redactor, now func() time.Time) FailureReporter {
@@ -91,6 +92,7 @@ func (r *failureReporter) Report(class FailureClass, err error) {
 		msg = r.redactor.String(msg)
 	}
 	msg = pathTokenPattern.ReplaceAllString(msg, "[path]")
+	msg = strings.NewReplacer("\r", " ", "\n", " ").Replace(msg)
 	line := "logging: " + string(class)
 	if msg != "" {
 		line += ": " + msg

--- a/internal/logging/handler.go
+++ b/internal/logging/handler.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"context"
 	"io"
 	"log/slog"
 	"time"
@@ -20,13 +21,116 @@ func NewJSONHandler(out io.Writer, level *slog.LevelVar, component string, redac
 					return slog.String(slog.TimeKey, ts.Format(rfc3339NanoNumeric))
 				}
 			}
-			if redactor == nil {
-				return attr
-			}
-			return redactor.ReplaceAttr(groups, attr)
+			return attr
 		},
 	}
-	return slog.NewJSONHandler(out, opts).WithAttrs([]slog.Attr{
-		slog.String("component", component),
+	return &redactingHandler{next: slog.NewJSONHandler(out, opts), redactor: redactor, component: component}
+}
+
+type redactingHandler struct {
+	next      slog.Handler
+	redactor  *Redactor
+	component string
+	groups    []string
+	ops       []handlerOp
+}
+
+type handlerOp struct {
+	group string
+	attrs []slog.Attr
+}
+
+func (h *redactingHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.next.Enabled(ctx, level)
+}
+
+func (h *redactingHandler) Handle(ctx context.Context, record slog.Record) error {
+	msg := record.Message
+	if h.redactor != nil {
+		msg = h.redactor.String(msg)
+	}
+	clean := slog.NewRecord(record.Time, record.Level, msg, record.PC)
+	component := h.component
+	attrs := make([]slog.Attr, 0, record.NumAttrs())
+	record.Attrs(func(attr slog.Attr) bool {
+		attr, component = h.extractTopLevelComponent(attr, component)
+		if attr = h.cleanAttr(attr); !attr.Equal(slog.Attr{}) {
+			attrs = append(attrs, attr)
+		}
+		return true
 	})
+	clean.AddAttrs(attrs...)
+	next := h.next.WithAttrs([]slog.Attr{slog.String("component", component)})
+	for _, op := range h.ops {
+		if op.group != "" {
+			next = next.WithGroup(op.group)
+		} else {
+			next = next.WithAttrs(op.attrs)
+		}
+	}
+	return next.Handle(ctx, clean)
+}
+
+func (h *redactingHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	clean := make([]slog.Attr, 0, len(attrs))
+	component := h.component
+	for _, attr := range attrs {
+		attr, component = h.extractTopLevelComponent(attr, component)
+		if attr = h.cleanAttr(attr); !attr.Equal(slog.Attr{}) {
+			clean = append(clean, attr)
+		}
+	}
+	ops := append([]handlerOp{}, h.ops...)
+	if len(clean) > 0 {
+		ops = append(ops, handlerOp{attrs: clean})
+	}
+	return &redactingHandler{next: h.next, redactor: h.redactor, component: component, groups: h.groups, ops: ops}
+}
+
+func (h *redactingHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	groups := append(append([]string{}, h.groups...), name)
+	ops := append(append([]handlerOp{}, h.ops...), handlerOp{group: name})
+	return &redactingHandler{next: h.next, redactor: h.redactor, component: h.component, groups: groups, ops: ops}
+}
+
+func (h *redactingHandler) cleanAttr(attr slog.Attr) slog.Attr {
+	if h.redactor != nil {
+		return h.redactor.ReplaceAttr(h.groups, attr)
+	}
+	return attr
+}
+
+func (h *redactingHandler) extractTopLevelComponent(attr slog.Attr, component string) (slog.Attr, string) {
+	if len(h.groups) != 0 {
+		return attr, component
+	}
+	value := attr.Value.Resolve()
+	if attr.Key == "component" {
+		if value.Kind() == slog.KindString {
+			component = value.String()
+			if h.redactor != nil {
+				component = h.redactor.String(component)
+			}
+		}
+		return slog.Attr{}, component
+	}
+	if attr.Key != "" || value.Kind() != slog.KindGroup {
+		return attr, component
+	}
+
+	children := value.Group()
+	clean := make([]slog.Attr, 0, len(children))
+	for _, child := range children {
+		child, component = h.extractTopLevelComponent(child, component)
+		if !child.Equal(slog.Attr{}) {
+			clean = append(clean, child)
+		}
+	}
+	if len(clean) == 0 {
+		return slog.Attr{}, component
+	}
+	return slog.Attr{Value: slog.GroupValue(clean...)}, component
 }

--- a/internal/logging/handler.go
+++ b/internal/logging/handler.go
@@ -1,0 +1,32 @@
+package logging
+
+import (
+	"io"
+	"log/slog"
+	"time"
+)
+
+// RFC3339Nano with a numeric zone offset (never "Z").
+const rfc3339NanoNumeric = "2006-01-02T15:04:05.999999999-07:00"
+
+// NewJSONHandler returns a slog JSON handler that stamps component, formats time
+// as RFC3339Nano with a numeric offset, and redacts attrs through redactor.
+func NewJSONHandler(out io.Writer, level *slog.LevelVar, component string, redactor *Redactor) slog.Handler {
+	opts := &slog.HandlerOptions{
+		Level: level,
+		ReplaceAttr: func(groups []string, attr slog.Attr) slog.Attr {
+			if len(groups) == 0 && attr.Key == slog.TimeKey {
+				if ts, ok := attr.Value.Any().(time.Time); ok {
+					return slog.String(slog.TimeKey, ts.Format(rfc3339NanoNumeric))
+				}
+			}
+			if redactor == nil {
+				return attr
+			}
+			return redactor.ReplaceAttr(groups, attr)
+		},
+	}
+	return slog.NewJSONHandler(out, opts).WithAttrs([]slog.Attr{
+		slog.String("component", component),
+	})
+}

--- a/internal/logging/handler_test.go
+++ b/internal/logging/handler_test.go
@@ -10,6 +10,18 @@ import (
 	"time"
 )
 
+type sensitiveGroupLogValuer struct {
+	value  string
+	nested string
+}
+
+func (v sensitiveGroupLogValuer) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("value", v.value),
+		slog.Group("detail", slog.String("note", v.nested)),
+	)
+}
+
 func TestJSONHandler_FormatAndComponent(t *testing.T) {
 	fixed := time.Date(2026, 9, 2, 23, 41, 8, 123456789, time.FixedZone("CST", 8*3600))
 	redactor := NewRedactor(testWebCredential)
@@ -84,5 +96,65 @@ func TestJSONHandler_LevelVarFilters(t *testing.T) {
 	}
 	if !handler.Enabled(context.Background(), slog.LevelError) {
 		t.Fatal("error must be enabled when level=warn")
+	}
+}
+
+func TestJSONHandler_SensitiveParentGroupsRedactEveryLeaf(t *testing.T) {
+	tests := []struct {
+		name   string
+		parent string
+		attr   slog.Attr
+	}{
+		{
+			name:   "group",
+			parent: "token",
+			attr: slog.Group("token",
+				slog.String("value", "hunter-two"),
+				slog.Group("detail", slog.String("note", "nested-hunter-two")),
+			),
+		},
+		{
+			name:   "group LogValuer",
+			parent: "credential",
+			attr: slog.Any("credential", sensitiveGroupLogValuer{
+				value:  "valuer-hunter-two",
+				nested: "valuer-nested-hunter-two",
+			}),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			level := &slog.LevelVar{}
+			level.Set(slog.LevelDebug)
+			handler := NewJSONHandler(&buf, level, "tui", NewRedactor())
+			record := slog.NewRecord(time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC), slog.LevelInfo, "group test", 0)
+			record.AddAttrs(test.attr)
+			if err := handler.Handle(context.Background(), record); err != nil {
+				t.Fatalf("Handle: %v", err)
+			}
+
+			encoded := buf.String()
+			assertNotContains(t, encoded, "hunter-two", "nested-hunter-two", "valuer-hunter-two", "valuer-nested-hunter-two")
+			var payload map[string]any
+			if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &payload); err != nil {
+				t.Fatalf("decode JSON: %v in %q", err, encoded)
+			}
+			group, ok := payload[test.parent].(map[string]any)
+			if !ok {
+				t.Fatalf("%s group = %#v, want JSON object", test.parent, payload[test.parent])
+			}
+			if got := group["value"]; got != "***" {
+				t.Fatalf("%s.value = %#v, want ***", test.parent, got)
+			}
+			detail, ok := group["detail"].(map[string]any)
+			if !ok {
+				t.Fatalf("%s.detail = %#v, want JSON object", test.parent, group["detail"])
+			}
+			if got := detail["note"]; got != "***" {
+				t.Fatalf("%s.detail.note = %#v, want ***", test.parent, got)
+			}
+		})
 	}
 }

--- a/internal/logging/handler_test.go
+++ b/internal/logging/handler_test.go
@@ -99,7 +99,7 @@ func TestJSONHandler_LevelVarFilters(t *testing.T) {
 	}
 }
 
-func TestJSONHandler_SensitiveParentGroupsRedactEveryLeaf(t *testing.T) {
+func TestJSONHandler_SensitiveParentGroupsReplaceWholeValue(t *testing.T) {
 	tests := []struct {
 		name   string
 		parent string
@@ -141,20 +141,76 @@ func TestJSONHandler_SensitiveParentGroupsRedactEveryLeaf(t *testing.T) {
 			if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &payload); err != nil {
 				t.Fatalf("decode JSON: %v in %q", err, encoded)
 			}
-			group, ok := payload[test.parent].(map[string]any)
-			if !ok {
-				t.Fatalf("%s group = %#v, want JSON object", test.parent, payload[test.parent])
-			}
-			if got := group["value"]; got != "***" {
-				t.Fatalf("%s.value = %#v, want ***", test.parent, got)
-			}
-			detail, ok := group["detail"].(map[string]any)
-			if !ok {
-				t.Fatalf("%s.detail = %#v, want JSON object", test.parent, group["detail"])
-			}
-			if got := detail["note"]; got != "***" {
-				t.Fatalf("%s.detail.note = %#v, want ***", test.parent, got)
+			if got := payload[test.parent]; got != "***" {
+				t.Fatalf("%s = %#v, want whole sensitive value replaced with ***", test.parent, got)
 			}
 		})
+	}
+}
+
+func TestJSONHandler_ComponentOverrideEmitsOneKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		log         func(*slog.Logger)
+		want        string
+		wantRequest bool
+	}{
+		{name: "record attr", log: func(logger *slog.Logger) { logger.Info("component test", "component", "record-override") }, want: "record-override"},
+		{name: "With attr", log: func(logger *slog.Logger) { logger.With("component", "with-override").Info("component test") }, want: "with-override"},
+		{name: "record inline group", log: func(logger *slog.Logger) {
+			logger.Info("component test", slog.Group("", slog.String("component", "record-inline"), slog.String("request", "kept")))
+		}, want: "record-inline", wantRequest: true},
+		{name: "With inline group", log: func(logger *slog.Logger) {
+			logger.With(slog.Group("", slog.String("component", "with-inline"), slog.String("request", "kept"))).Info("component test")
+		}, want: "with-inline", wantRequest: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			level := &slog.LevelVar{}
+			level.Set(slog.LevelDebug)
+			logger := slog.New(NewJSONHandler(&buf, level, "daemon", NewRedactor()))
+
+			test.log(logger)
+
+			encoded := buf.String()
+			if got := strings.Count(encoded, `"component":`); got != 1 {
+				t.Fatalf("component key count = %d, want 1 in %s", got, encoded)
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &payload); err != nil {
+				t.Fatalf("decode JSON: %v in %q", err, encoded)
+			}
+			if got := payload["component"]; got != test.want {
+				t.Fatalf("component = %#v, want %s", got, test.want)
+			}
+			if test.wantRequest && payload["request"] != "kept" {
+				t.Fatalf("request = %#v, want kept", payload["request"])
+			}
+		})
+	}
+}
+
+func TestJSONHandler_WithGroupKeepsComponentAtTopLevel(t *testing.T) {
+	var buf bytes.Buffer
+	level := &slog.LevelVar{}
+	level.Set(slog.LevelDebug)
+	logger := slog.New(NewJSONHandler(&buf, level, "daemon", NewRedactor())).WithGroup("request")
+
+	logger.Info("grouped", "method", "GET")
+
+	var payload map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &payload); err != nil {
+		t.Fatalf("decode JSON: %v in %q", err, buf.String())
+	}
+	if got := payload["component"]; got != "daemon" {
+		t.Fatalf("top-level component = %#v, want daemon", got)
+	}
+	group, ok := payload["request"].(map[string]any)
+	if !ok || group["method"] != "GET" {
+		t.Fatalf("request group = %#v, want grouped method", payload["request"])
+	}
+	if _, nested := group["component"]; nested {
+		t.Fatalf("component was nested inside request: %#v", group)
 	}
 }

--- a/internal/logging/handler_test.go
+++ b/internal/logging/handler_test.go
@@ -1,0 +1,88 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestJSONHandler_FormatAndComponent(t *testing.T) {
+	fixed := time.Date(2026, 9, 2, 23, 41, 8, 123456789, time.FixedZone("CST", 8*3600))
+	redactor := NewRedactor(testWebCredential)
+
+	components := []string{"daemon", "tui", "mihomo", "daemon.subscription"}
+	for _, component := range components {
+		t.Run(component, func(t *testing.T) {
+			var buf bytes.Buffer
+			level := &slog.LevelVar{}
+			level.Set(slog.LevelDebug)
+			handler := NewJSONHandler(&buf, level, component, redactor)
+
+			record := slog.NewRecord(fixed, slog.LevelInfo, "hello "+testWebCredential, 0)
+			record.AddAttrs(
+				slog.String("token", "should-hide"),
+				slog.String("url", "https://example.test/path"),
+				slog.Group("nested", slog.String("password", "nested-pass")),
+			)
+			if err := handler.Handle(context.Background(), record); err != nil {
+				t.Fatalf("Handle: %v", err)
+			}
+
+			line := buf.String()
+			if strings.Count(line, "\n") != 1 || !strings.HasSuffix(line, "\n") {
+				t.Fatalf("want single JSON line with trailing newline, got %q", line)
+			}
+			var payload map[string]any
+			if err := json.Unmarshal([]byte(strings.TrimSpace(line)), &payload); err != nil {
+				t.Fatalf("json: %v in %q", err, line)
+			}
+			for _, key := range []string{"time", "level", "msg", "component"} {
+				if _, ok := payload[key]; !ok {
+					t.Fatalf("missing %q in %v", key, payload)
+				}
+			}
+			if payload["component"] != component {
+				t.Fatalf("component = %v, want %s", payload["component"], component)
+			}
+			if _, ok := payload["source"]; ok {
+				t.Fatalf("source key must not appear: %v", payload)
+			}
+			gotTime, _ := payload["time"].(string)
+			if gotTime != "2026-09-02T23:41:08.123456789+08:00" {
+				t.Fatalf("time = %q, want RFC3339Nano with numeric offset", gotTime)
+			}
+			if payload["level"] != "INFO" {
+				t.Fatalf("level = %v", payload["level"])
+			}
+			msg, _ := payload["msg"].(string)
+			if msg != "hello ***" {
+				t.Fatalf("msg = %q", msg)
+			}
+			encoded := line
+			assertNotContains(t, encoded, testWebCredential, "should-hide", "nested-pass", "example.test")
+			if !strings.Contains(encoded, `"token":"***"`) {
+				t.Fatalf("token attr not redacted: %s", encoded)
+			}
+			if !strings.Contains(encoded, `[REDACTED_URL]`) {
+				t.Fatalf("url attr not redacted: %s", encoded)
+			}
+		})
+	}
+}
+
+func TestJSONHandler_LevelVarFilters(t *testing.T) {
+	var buf bytes.Buffer
+	level := &slog.LevelVar{}
+	level.Set(slog.LevelWarn)
+	handler := NewJSONHandler(&buf, level, "daemon", NewRedactor())
+	if handler.Enabled(context.Background(), slog.LevelInfo) {
+		t.Fatal("info must be disabled when level=warn")
+	}
+	if !handler.Enabled(context.Background(), slog.LevelError) {
+		t.Fatal("error must be enabled when level=warn")
+	}
+}

--- a/internal/logging/redactor.go
+++ b/internal/logging/redactor.go
@@ -15,10 +15,12 @@ const (
 )
 
 var (
-	urlPattern         = regexp.MustCompile(`(?i)\b(?:https?|wss?)://[^\s"'<>\\]+`)
-	authSchemePattern  = regexp.MustCompile(`(?i)\b(bearer|basic)\s+[^\s]+`)
-	namedSecretPattern = regexp.MustCompile(`(?i)\b(token|secret|password|authorization|credential|api-key)\s*([:=])\s*[^\s&;,"']+`)
-	hex64Pattern       = regexp.MustCompile(`(?i)\b[0-9a-f]{64}\b`)
+	urlPattern          = regexp.MustCompile(`(?i)\b(?:https?|wss?)://[^\s"'<>\\]+`)
+	authSchemePattern   = regexp.MustCompile(`(?i)\b(bearer|basic)\s+[^\s]+`)
+	cookiePattern       = regexp.MustCompile(`(?i)\b(cookie)\s*([:=])\s*[^\r\n]+`)
+	quotedSecretPattern = regexp.MustCompile(`(?i)\b(token|secret|password|authorization|credential|api[-_]key)\s*([:=])\s*(?:"(?:\\.|[^"\\\r\n])*"|'(?:\\.|[^'\\\r\n])*')`)
+	namedSecretPattern  = regexp.MustCompile(`(?i)\b(token|secret|password|authorization|credential|api[-_]key)\s*([:=])\s*[^\s&;,"']+`)
+	hex64Pattern        = regexp.MustCompile(`(?i)\b[0-9a-f]{64}\b`)
 
 	sensitiveKeys = map[string]struct{}{
 		"secret":        {},
@@ -86,6 +88,8 @@ func (r *Redactor) String(value string) string {
 		}
 		return parts[0] + " " + redactedExact
 	})
+	out = cookiePattern.ReplaceAllString(out, "${1}${2}"+redactedExact)
+	out = quotedSecretPattern.ReplaceAllString(out, "${1}${2}"+redactedExact)
 	out = namedSecretPattern.ReplaceAllString(out, "${1}${2}"+redactedExact)
 	out = hex64Pattern.ReplaceAllString(out, redactedExact)
 	return out

--- a/internal/logging/redactor.go
+++ b/internal/logging/redactor.go
@@ -1,0 +1,129 @@
+package logging
+
+import (
+	"log/slog"
+	"regexp"
+	"sort"
+	"strings"
+	"sync/atomic"
+)
+
+const (
+	redactedExact = "***"
+	redactedURL   = "[REDACTED_URL]"
+	minExactLen   = 8
+)
+
+var (
+	urlPattern         = regexp.MustCompile(`(?i)\b(?:https?|wss?)://[^\s"'<>\\]+`)
+	authSchemePattern  = regexp.MustCompile(`(?i)\b(bearer|basic)\s+[^\s]+`)
+	namedSecretPattern = regexp.MustCompile(`(?i)\b(token|secret|password|authorization|credential|api-key)\s*([:=])\s*[^\s&;,"']+`)
+	hex64Pattern       = regexp.MustCompile(`(?i)\b[0-9a-f]{64}\b`)
+
+	sensitiveKeys = map[string]struct{}{
+		"secret":        {},
+		"token":         {},
+		"authorization": {},
+		"password":      {},
+		"credential":    {},
+		"cookie":        {},
+		"api-key":       {},
+	}
+)
+
+type redactionRules struct {
+	exact []string
+}
+
+// Redactor applies immutable exact-secret and generic redaction rules to log text and attrs.
+type Redactor struct {
+	rules atomic.Pointer[redactionRules]
+}
+
+// NewRedactor builds a redactor and registers optional exact secrets.
+func NewRedactor(exact ...string) *Redactor {
+	r := &Redactor{}
+	r.ReplaceExact(exact)
+	return r
+}
+
+// ReplaceExact replaces the exact-secret snapshot. Empty and too-short values are dropped;
+// remaining values are copied and sorted longest-first. Generic regexes are package-level.
+func (r *Redactor) ReplaceExact(values []string) {
+	exact := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if value == "" || len(value) < minExactLen {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		exact = append(exact, value)
+	}
+	sort.Slice(exact, func(i, j int) bool {
+		return len(exact[i]) > len(exact[j])
+	})
+	r.rules.Store(&redactionRules{exact: exact})
+}
+
+// String redacts a free-form text value using the current rules snapshot.
+func (r *Redactor) String(value string) string {
+	rules := r.rules.Load()
+	if rules == nil {
+		rules = &redactionRules{}
+	}
+	out := value
+	for _, exact := range rules.exact {
+		out = strings.ReplaceAll(out, exact, redactedExact)
+	}
+	out = urlPattern.ReplaceAllString(out, redactedURL)
+	out = authSchemePattern.ReplaceAllStringFunc(out, func(match string) string {
+		parts := strings.Fields(match)
+		if len(parts) == 0 {
+			return redactedExact
+		}
+		return parts[0] + " " + redactedExact
+	})
+	out = namedSecretPattern.ReplaceAllString(out, "${1}${2}"+redactedExact)
+	out = hex64Pattern.ReplaceAllString(out, redactedExact)
+	return out
+}
+
+// ReplaceAttr recursively redacts slog attributes. Sensitive keys replace the whole value
+// with ***; strings, errors, and LogValuer results run through String.
+func (r *Redactor) ReplaceAttr(groups []string, attr slog.Attr) slog.Attr {
+	attr.Value = attr.Value.Resolve()
+	switch attr.Value.Kind() {
+	case slog.KindGroup:
+		children := attr.Value.Group()
+		redacted := make([]slog.Attr, len(children))
+		nextGroups := append(append([]string{}, groups...), attr.Key)
+		for i, child := range children {
+			redacted[i] = r.ReplaceAttr(nextGroups, child)
+		}
+		return slog.Attr{Key: attr.Key, Value: slog.GroupValue(redacted...)}
+	}
+
+	if isSensitiveKey(attr.Key) {
+		return slog.String(attr.Key, redactedExact)
+	}
+
+	switch attr.Value.Kind() {
+	case slog.KindString:
+		return slog.String(attr.Key, r.String(attr.Value.String()))
+	case slog.KindAny:
+		if err, ok := attr.Value.Any().(error); ok && err != nil {
+			return slog.String(attr.Key, r.String(err.Error()))
+		}
+	}
+	return attr
+}
+
+func isSensitiveKey(key string) bool {
+	normalized := strings.ToLower(key)
+	normalized = strings.ReplaceAll(normalized, "_", "-")
+	_, ok := sensitiveKeys[normalized]
+	return ok
+}

--- a/internal/logging/redactor.go
+++ b/internal/logging/redactor.go
@@ -91,9 +91,13 @@ func (r *Redactor) String(value string) string {
 	return out
 }
 
-// ReplaceAttr recursively redacts slog attributes. Sensitive keys replace the whole value
-// with ***; strings, errors, and LogValuer results run through String.
+// ReplaceAttr recursively redacts slog attributes. Sensitive keys and sensitive
+// ancestor groups replace values with ***; strings, errors, and LogValuer
+// results run through String.
 func (r *Redactor) ReplaceAttr(groups []string, attr slog.Attr) slog.Attr {
+	if isSensitiveKey(attr.Key) || hasSensitiveGroup(groups) {
+		return slog.String(attr.Key, redactedExact)
+	}
 	attr.Value = attr.Value.Resolve()
 	switch attr.Value.Kind() {
 	case slog.KindGroup:
@@ -106,10 +110,6 @@ func (r *Redactor) ReplaceAttr(groups []string, attr slog.Attr) slog.Attr {
 		return slog.Attr{Key: attr.Key, Value: slog.GroupValue(redacted...)}
 	}
 
-	if isSensitiveKey(attr.Key) {
-		return slog.String(attr.Key, redactedExact)
-	}
-
 	switch attr.Value.Kind() {
 	case slog.KindString:
 		return slog.String(attr.Key, r.String(attr.Value.String()))
@@ -119,6 +119,15 @@ func (r *Redactor) ReplaceAttr(groups []string, attr slog.Attr) slog.Attr {
 		}
 	}
 	return attr
+}
+
+func hasSensitiveGroup(groups []string) bool {
+	for _, group := range groups {
+		if isSensitiveKey(group) {
+			return true
+		}
+	}
+	return false
 }
 
 func isSensitiveKey(key string) bool {

--- a/internal/logging/redactor_test.go
+++ b/internal/logging/redactor_test.go
@@ -126,6 +126,26 @@ func TestRedactor_GenericURLAndAuthAndHex(t *testing.T) {
 			want:  "cfg password:***",
 		},
 		{
+			name:  "snake case api key",
+			input: "cfg api_key=leaked-api-key-value",
+			want:  "cfg api_key=***",
+		},
+		{
+			name:  "quoted token",
+			input: `cfg token="leaked token value"`,
+			want:  "cfg token=***",
+		},
+		{
+			name:  "quoted token with escape",
+			input: `cfg token="leaked \"nested\" value"`,
+			want:  "cfg token=***",
+		},
+		{
+			name:  "cookie header",
+			input: "request Cookie: session=leaked-cookie-value; preference=also-secret",
+			want:  "request Cookie:***",
+		},
+		{
 			name:  "64 hex",
 			input: "secret=" + hex64,
 			want:  "secret=***",
@@ -142,7 +162,7 @@ func TestRedactor_GenericURLAndAuthAndHex(t *testing.T) {
 			if got != test.want {
 				t.Fatalf("String() = %q, want %q", got, test.want)
 			}
-			assertNotContains(t, got, "example.test", "super-bearer-token-value", "dXNlcjpwYXNz", "leaked-token-value", "leaked-password-value", hex64)
+			assertNotContains(t, got, "example.test", "super-bearer-token-value", "dXNlcjpwYXNz", "leaked-token-value", "leaked-password-value", "leaked-api-key-value", "leaked token value", "leaked-cookie-value", "also-secret", hex64)
 		})
 	}
 }
@@ -229,14 +249,9 @@ func TestRedactor_TaxonomyNotCollapsed(t *testing.T) {
 	if !strings.Contains(got, "[REDACTED_URL]") {
 		t.Fatalf("url must use [REDACTED_URL]: %q", got)
 	}
-	if strings.Contains(got, "[REDACTED]") && !strings.Contains(got, "[REDACTED_URL]") {
-		t.Fatalf("must not collapse taxonomy to [REDACTED]: %q", got)
-	}
-	if strings.Count(got, "[REDACTED]") != strings.Count(got, "[REDACTED_URL]") {
-		// bare [REDACTED] without _URL is forbidden
-		if strings.Contains(strings.ReplaceAll(got, "[REDACTED_URL]", ""), "[REDACTED]") {
-			t.Fatalf("bare [REDACTED] present: %q", got)
-		}
+	withoutURLMarker := strings.ReplaceAll(got, "[REDACTED_URL]", "")
+	if strings.Contains(withoutURLMarker, "[REDACTED]") {
+		t.Fatalf("bare [REDACTED] present: %q", got)
 	}
 }
 

--- a/internal/logging/redactor_test.go
+++ b/internal/logging/redactor_test.go
@@ -1,0 +1,250 @@
+package logging
+
+import (
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+const (
+	testControlToken    = "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+	testControllerHex   = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	testWebCredential   = "web-credential-value-not-sixty-four-hex!!"
+	testSubscriptionURL = "https://example.test/sub/abc?token=sub-secret-value"
+)
+
+type sampleLogValuer struct {
+	text string
+}
+
+func (v sampleLogValuer) LogValue() slog.Value {
+	return slog.StringValue(v.text)
+}
+
+func TestRedactor_ExactSecrets(t *testing.T) {
+	redactor := NewRedactor(testControlToken, testWebCredential, testSubscriptionURL)
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "control token",
+			input: "auth failed for " + testControlToken,
+			want:  "auth failed for ***",
+		},
+		{
+			name:  "web credential non-64-hex",
+			input: "login with " + testWebCredential,
+			want:  "login with ***",
+		},
+		{
+			name:  "registered subscription url",
+			input: "refresh " + testSubscriptionURL,
+			want:  "refresh ***",
+		},
+		{
+			name:  "unregistered url uses taxonomy marker",
+			input: "fetch https://cdn.example.test/file.bin?sig=1",
+			want:  "fetch [REDACTED_URL]",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := redactor.String(test.input)
+			if got != test.want {
+				t.Fatalf("String() = %q, want %q", got, test.want)
+			}
+			assertNotContains(t, got, testControlToken, testWebCredential, testSubscriptionURL, "cdn.example.test")
+		})
+	}
+}
+
+func TestRedactor_SensitiveKeys(t *testing.T) {
+	redactor := NewRedactor()
+	keys := []string{"secret", "token", "authorization", "password", "credential", "cookie", "api-key", "API_KEY", "Token"}
+	for _, key := range keys {
+		t.Run(key, func(t *testing.T) {
+			attr := redactor.ReplaceAttr(nil, slog.String(key, "visible-secret-value"))
+			if attr.Value.Kind() != slog.KindString || attr.Value.String() != "***" {
+				t.Fatalf("ReplaceAttr(%q) = %#v, want ***", key, attr)
+			}
+			assertNotContains(t, attr.Value.String(), "visible-secret-value")
+		})
+	}
+}
+
+func TestRedactor_GenericURLAndAuthAndHex(t *testing.T) {
+	redactor := NewRedactor()
+	hex64 := testControllerHex
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "https url",
+			input: "open https://user:pass@example.test/path?x=1",
+			want:  "open [REDACTED_URL]",
+		},
+		{
+			name:  "http url",
+			input: "see http://example.test/a",
+			want:  "see [REDACTED_URL]",
+		},
+		{
+			name:  "ws url",
+			input: "dial ws://example.test/ws",
+			want:  "dial [REDACTED_URL]",
+		},
+		{
+			name:  "wss url",
+			input: "dial wss://example.test/ws",
+			want:  "dial [REDACTED_URL]",
+		},
+		{
+			name:  "bearer",
+			input: "Authorization Bearer super-bearer-token-value",
+			want:  "Authorization Bearer ***",
+		},
+		{
+			name:  "basic",
+			input: "proxy Basic dXNlcjpwYXNz",
+			want:  "proxy Basic ***",
+		},
+		{
+			name:  "token equals",
+			input: "query token=leaked-token-value",
+			want:  "query token=***",
+		},
+		{
+			name:  "password colon",
+			input: "cfg password:leaked-password-value",
+			want:  "cfg password:***",
+		},
+		{
+			name:  "64 hex",
+			input: "secret=" + hex64,
+			want:  "secret=***",
+		},
+		{
+			name:  "standalone 64 hex",
+			input: "id " + hex64 + " ok",
+			want:  "id *** ok",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := redactor.String(test.input)
+			if got != test.want {
+				t.Fatalf("String() = %q, want %q", got, test.want)
+			}
+			assertNotContains(t, got, "example.test", "super-bearer-token-value", "dXNlcjpwYXNz", "leaked-token-value", "leaked-password-value", hex64)
+		})
+	}
+}
+
+func TestRedactor_ShortTokenNotFalsePositive(t *testing.T) {
+	redactor := NewRedactor()
+	input := "status=ok id=ab12 code=1"
+	got := redactor.String(input)
+	if got != input {
+		t.Fatalf("short tokens were altered: got %q", got)
+	}
+}
+
+func TestRedactor_TooShortExactIgnored(t *testing.T) {
+	redactor := NewRedactor("ok", "ab", "", "tok")
+	input := "status=ok ab tok ready"
+	got := redactor.String(input)
+	if got != input {
+		t.Fatalf("too-short exact values must not enter set: got %q", got)
+	}
+}
+
+func TestRedactor_ReplaceExactUpdatesSnapshot(t *testing.T) {
+	redactor := NewRedactor()
+	secret := "registered-later-credential-xyz"
+	if strings.Contains(redactor.String("x "+secret), "***") {
+		t.Fatal("unregistered credential must not redact yet")
+	}
+	redactor.ReplaceExact([]string{"", secret, "no"})
+	got := redactor.String("x " + secret)
+	if got != "x ***" {
+		t.Fatalf("ReplaceExact String() = %q, want %q", got, "x ***")
+	}
+	// "no" is too short / must not wipe normal text
+	if redactor.String("no problem") != "no problem" {
+		t.Fatalf("short exact must stay dropped after ReplaceExact")
+	}
+}
+
+func TestRedactor_ReplaceAttrGroupLogValuerError(t *testing.T) {
+	redactor := NewRedactor(testWebCredential)
+	attr := redactor.ReplaceAttr(nil, slog.Group("auth",
+		slog.String("token", "nested-token-value"),
+		slog.String("note", "user "+testWebCredential),
+		slog.Any("err", errors.New("boom "+testWebCredential)),
+		slog.Any("detail", sampleLogValuer{text: "lv " + testWebCredential}),
+		slog.Int("count", 3),
+		slog.Bool("ok", true),
+	))
+	if attr.Value.Kind() != slog.KindGroup {
+		t.Fatalf("want group, got %v", attr.Value.Kind())
+	}
+	children := attr.Value.Group()
+	byKey := map[string]slog.Value{}
+	for _, child := range children {
+		byKey[child.Key] = child.Value
+	}
+	if byKey["token"].String() != "***" {
+		t.Fatalf("sensitive nested key = %q", byKey["token"].String())
+	}
+	if byKey["note"].String() != "user ***" {
+		t.Fatalf("note = %q", byKey["note"].String())
+	}
+	if byKey["err"].String() != "boom ***" {
+		t.Fatalf("err = %q", byKey["err"].String())
+	}
+	if byKey["detail"].String() != "lv ***" {
+		t.Fatalf("detail = %q", byKey["detail"].String())
+	}
+	if byKey["count"].Int64() != 3 || !byKey["ok"].Bool() {
+		t.Fatalf("non-sensitive number/bool changed: count=%v ok=%v", byKey["count"], byKey["ok"])
+	}
+	for _, child := range children {
+		assertNotContains(t, child.Value.String(), testWebCredential, "nested-token-value")
+	}
+}
+
+func TestRedactor_TaxonomyNotCollapsed(t *testing.T) {
+	redactor := NewRedactor(testWebCredential)
+	got := redactor.String("cred=" + testWebCredential + " url=https://example.test/x")
+	if !strings.Contains(got, "***") {
+		t.Fatalf("exact must use ***: %q", got)
+	}
+	if !strings.Contains(got, "[REDACTED_URL]") {
+		t.Fatalf("url must use [REDACTED_URL]: %q", got)
+	}
+	if strings.Contains(got, "[REDACTED]") && !strings.Contains(got, "[REDACTED_URL]") {
+		t.Fatalf("must not collapse taxonomy to [REDACTED]: %q", got)
+	}
+	if strings.Count(got, "[REDACTED]") != strings.Count(got, "[REDACTED_URL]") {
+		// bare [REDACTED] without _URL is forbidden
+		if strings.Contains(strings.ReplaceAll(got, "[REDACTED_URL]", ""), "[REDACTED]") {
+			t.Fatalf("bare [REDACTED] present: %q", got)
+		}
+	}
+}
+
+func assertNotContains(t *testing.T, haystack string, needles ...string) {
+	t.Helper()
+	for _, needle := range needles {
+		if needle != "" && strings.Contains(haystack, needle) {
+			t.Fatalf("output %q still contains %q", haystack, needle)
+		}
+	}
+}

--- a/internal/logging/rotator.go
+++ b/internal/logging/rotator.go
@@ -1,0 +1,391 @@
+package logging
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/mihari-proxy/mihari/internal/platform"
+)
+
+// testAfterExclusiveLock is invoked after the exclusive advisory lock is held
+// and before directory enumeration. Tests use it for deterministic pauses.
+var testAfterExclusiveLock func()
+
+// RotatorOptions opens a process-safe rotating JSONL writer.
+type RotatorOptions struct {
+	BasePath  string
+	Config    Config
+	PrivateFS *platform.PrivateFS
+	OpenLock  func(*platform.PrivateFS, string) (platform.AdvisoryLock, error)
+	WriteWait time.Duration
+	Reporter  FailureReporter
+}
+
+// RotatingWriter appends full JSONL records with overflow-safe rotation.
+type RotatingWriter struct {
+	mu        sync.Mutex
+	cfg       atomic.Pointer[Config]
+	dropped   atomic.Uint64
+	fs        *platform.PrivateFS
+	basePath  string
+	lock      platform.AdvisoryLock
+	file      *os.File
+	writeWait time.Duration
+	reporter  FailureReporter
+	closed    bool
+}
+
+// OpenRotatingWriter creates the lock, converges archives, and creates the base file.
+// The caller context bounds only the initial lock wait. On failure, acquired
+// resources are closed.
+func OpenRotatingWriter(ctx context.Context, opts RotatorOptions) (*RotatingWriter, error) {
+	if opts.PrivateFS == nil {
+		return nil, fmt.Errorf("rotator private fs is required")
+	}
+	if opts.BasePath == "" {
+		return nil, fmt.Errorf("rotator base path is required")
+	}
+	if opts.OpenLock == nil {
+		opts.OpenLock = platform.OpenAdvisoryLock
+	}
+	if opts.WriteWait <= 0 {
+		opts.WriteWait = writeWaitBound
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := opts.PrivateFS.EnsureDir(filepath.Dir(opts.BasePath)); err != nil {
+		return nil, err
+	}
+	lock, err := opts.OpenLock(opts.PrivateFS, opts.BasePath+".lock")
+	if err != nil {
+		return nil, err
+	}
+	w := &RotatingWriter{
+		fs:        opts.PrivateFS,
+		basePath:  opts.BasePath,
+		lock:      lock,
+		writeWait: opts.WriteWait,
+		reporter:  opts.Reporter,
+	}
+	cfg := opts.Config
+	w.cfg.Store(&cfg)
+	if err := w.lock.Lock(ctx, platform.LockExclusive); err != nil {
+		_ = lock.Close()
+		w.lock = nil
+		return nil, err
+	}
+	if hook := testAfterExclusiveLock; hook != nil {
+		hook()
+	}
+	err = w.convergeLocked()
+	if err == nil {
+		var f *os.File
+		f, err = w.fs.OpenAppend(w.basePath)
+		if err == nil {
+			err = f.Close()
+		}
+	}
+	unlockErr := w.lock.Unlock()
+	if err != nil || unlockErr != nil {
+		_ = lock.Close()
+		w.lock = nil
+		return nil, errors.Join(err, unlockErr)
+	}
+	return w, nil
+}
+
+// Write appends one complete JSONL record. It takes the process mutex, then an
+// exclusive advisory lock (WriteWait, default 250ms). After the lock it opens
+// and Stats the base file. A lock wait failure drops the whole record.
+func (w *RotatingWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return 0, os.ErrClosed
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), w.writeWait)
+	defer cancel()
+	if err := w.lock.Lock(ctx, platform.LockExclusive); err != nil {
+		w.dropped.Add(1)
+		w.report(FailureDropped, errors.New("lock wait exceeded"))
+		return 0, err
+	}
+	defer w.lock.Unlock()
+	if hook := testAfterExclusiveLock; hook != nil {
+		hook()
+	}
+	if err := w.openBaseLocked(); err != nil {
+		w.report(FailureWrite, err)
+		return 0, err
+	}
+	st, err := w.file.Stat()
+	if err != nil {
+		_ = w.closeFile()
+		w.report(FailureWrite, err)
+		return 0, err
+	}
+	cfg := w.config()
+	incoming := int64(len(p))
+	if needRotate(st.Size(), incoming, cfg.MaxSizeBytes) {
+		if err := w.rotateLocked(); err != nil {
+			w.report(FailureRotate, err)
+			if w.file == nil {
+				if openErr := w.openBaseLocked(); openErr != nil {
+					w.report(FailureWrite, openErr)
+					return 0, openErr
+				}
+			}
+		}
+	}
+	n, err := w.file.Write(p)
+	closeErr := w.closeFile()
+	if err != nil {
+		w.report(FailureWrite, err)
+		return n, err
+	}
+	return n, closeErr
+}
+
+// Apply atomically stores cfg, then waits min(ctx deadline, WriteWait) for the
+// exclusive lock and converges archives. Lock timeout or ctx cancel skip
+// maintenance; the swapped config is kept. After the lock is held, ReadDir and
+// Remove are not canceled.
+func (w *RotatingWriter) Apply(ctx context.Context, cfg Config) {
+	copied := cfg
+	w.cfg.Store(&copied)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed || w.lock == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	lockCtx, cancel := context.WithTimeout(ctx, w.writeWait)
+	defer cancel()
+	if err := w.lock.Lock(lockCtx, platform.LockExclusive); err != nil {
+		w.report(FailureCleanup, errors.New("lock wait exceeded"))
+		return
+	}
+	defer w.lock.Unlock()
+	if hook := testAfterExclusiveLock; hook != nil {
+		hook()
+	}
+	if err := w.convergeLocked(); err != nil {
+		w.report(FailureCleanup, err)
+	}
+}
+
+// Dropped returns the number of records dropped because the write lock wait failed.
+func (w *RotatingWriter) Dropped() uint64 {
+	return w.dropped.Load()
+}
+
+// Close closes the current write handle and lock. It does not close PrivateFS.
+func (w *RotatingWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return nil
+	}
+	w.closed = true
+	err := w.closeFile()
+	if w.lock != nil {
+		err = errors.Join(err, w.lock.Close())
+		w.lock = nil
+	}
+	return err
+}
+
+func (w *RotatingWriter) config() Config {
+	if p := w.cfg.Load(); p != nil {
+		return *p
+	}
+	return DefaultConfig()
+}
+
+func (w *RotatingWriter) report(class FailureClass, err error) {
+	if w.reporter == nil || err == nil {
+		return
+	}
+	w.reporter.Report(class, err)
+}
+
+func (w *RotatingWriter) openBaseLocked() error {
+	if err := w.closeFile(); err != nil {
+		return err
+	}
+	f, err := w.fs.OpenAppend(w.basePath)
+	if err != nil {
+		return err
+	}
+	w.file = f
+	return nil
+}
+
+func (w *RotatingWriter) closeFile() error {
+	if w.file == nil {
+		return nil
+	}
+	err := w.file.Close()
+	w.file = nil
+	return err
+}
+
+func (w *RotatingWriter) rotateLocked() error {
+	if err := w.closeFile(); err != nil {
+		return err
+	}
+	if err := w.convergeLocked(); err != nil {
+		return err
+	}
+	cfg := w.config()
+	if cfg.MaxFiles <= 1 {
+		if err := w.fs.ReplaceEmpty(w.basePath); err != nil {
+			return err
+		}
+	} else if err := w.shiftLocked(cfg.MaxFiles); err != nil {
+		return err
+	}
+	return w.openBaseLocked()
+}
+
+func (w *RotatingWriter) convergeLocked() error {
+	dir := filepath.Dir(w.basePath)
+	base := filepath.Base(w.basePath)
+	entries, err := w.fs.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	maxFiles := w.config().MaxFiles
+	if maxFiles < 1 {
+		maxFiles = 1
+	}
+	for _, entry := range entries {
+		n, ok := archiveSuffix(base, entry.Name)
+		if !ok || n < maxFiles {
+			continue
+		}
+		if !entry.Mode.IsRegular() {
+			w.report(FailureCleanup, fmt.Errorf("skip non-regular archive suffix %d", n))
+			continue
+		}
+		if err := w.fs.Remove(w.child(entry.Name)); err != nil {
+			w.report(FailureCleanup, err)
+		}
+	}
+	return nil
+}
+
+func (w *RotatingWriter) shiftLocked(maxFiles int) error {
+	listing, err := w.listLocked()
+	if err != nil {
+		return err
+	}
+	base := filepath.Base(w.basePath)
+	oldest := maxFiles - 1
+	if oldest >= 1 {
+		if err := w.removeIfRegular(listing, archiveName(base, oldest)); err != nil {
+			return err
+		}
+	}
+	for i := oldest - 1; i >= 1; i-- {
+		if err := w.renameIfRegular(listing, archiveName(base, i), archiveName(base, i+1)); err != nil {
+			return err
+		}
+	}
+	return w.renameIfRegular(listing, base, archiveName(base, 1))
+}
+
+func (w *RotatingWriter) listLocked() (map[string]platform.FileEntry, error) {
+	entries, err := w.fs.ReadDir(filepath.Dir(w.basePath))
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]platform.FileEntry, len(entries))
+	for _, entry := range entries {
+		out[entry.Name] = entry
+	}
+	return out, nil
+}
+
+func (w *RotatingWriter) removeIfRegular(listing map[string]platform.FileEntry, name string) error {
+	entry, ok := listing[name]
+	if !ok {
+		return nil
+	}
+	if !entry.Mode.IsRegular() {
+		w.report(FailureRotate, fmt.Errorf("skip non-regular %s", name))
+		return nil
+	}
+	if err := w.fs.Remove(w.child(name)); err != nil {
+		return err
+	}
+	delete(listing, name)
+	return nil
+}
+
+func (w *RotatingWriter) renameIfRegular(listing map[string]platform.FileEntry, oldName, newName string) error {
+	src, ok := listing[oldName]
+	if !ok {
+		return nil
+	}
+	if !src.Mode.IsRegular() {
+		w.report(FailureRotate, fmt.Errorf("skip non-regular %s", oldName))
+		return nil
+	}
+	if dst, exists := listing[newName]; exists {
+		if !dst.Mode.IsRegular() {
+			w.report(FailureRotate, fmt.Errorf("skip rename over non-regular %s", newName))
+			return nil
+		}
+		if err := w.fs.Remove(w.child(newName)); err != nil {
+			return err
+		}
+		delete(listing, newName)
+	}
+	if err := w.fs.Rename(w.child(oldName), w.child(newName)); err != nil {
+		return err
+	}
+	delete(listing, oldName)
+	src.Name = newName
+	listing[newName] = src
+	return nil
+}
+
+func (w *RotatingWriter) child(name string) string {
+	return filepath.Join(filepath.Dir(w.basePath), name)
+}
+
+func archiveName(base string, n int) string {
+	return base + "." + strconv.Itoa(n)
+}
+
+func archiveSuffix(base, name string) (int, bool) {
+	prefix := base + "."
+	if !strings.HasPrefix(name, prefix) {
+		return 0, false
+	}
+	suffix := name[len(prefix):]
+	if suffix == "" || suffix[0] < '1' || suffix[0] > '9' {
+		return 0, false
+	}
+	n, err := strconv.Atoi(suffix)
+	if err != nil || n < 1 || strconv.Itoa(n) != suffix {
+		return 0, false
+	}
+	return n, true
+}
+
+func needRotate(currentSize, incoming, maxSize int64) bool {
+	return incoming > maxSize || (incoming <= maxSize && currentSize > maxSize-incoming)
+}

--- a/internal/logging/rotator.go
+++ b/internal/logging/rotator.go
@@ -113,7 +113,7 @@ func OpenRotatingWriter(ctx context.Context, opts RotatorOptions) (*RotatingWrit
 // Write appends one complete JSONL record. It takes the process mutex, then an
 // exclusive advisory lock (WriteWait, default 250ms). After the lock it opens
 // and Stats the base file. A lock wait failure drops the whole record.
-func (w *RotatingWriter) Write(p []byte) (int, error) {
+func (w *RotatingWriter) Write(p []byte) (n int, err error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.closed {
@@ -126,7 +126,12 @@ func (w *RotatingWriter) Write(p []byte) (int, error) {
 		w.report(FailureDropped, errors.New("lock wait exceeded"))
 		return 0, err
 	}
-	defer w.lock.Unlock()
+	defer func() {
+		if unlockErr := w.lock.Unlock(); unlockErr != nil {
+			w.report(FailureWrite, unlockErr)
+			err = errors.Join(err, unlockErr)
+		}
+	}()
 	if hook := testAfterExclusiveLock; hook != nil {
 		hook()
 	}
@@ -153,7 +158,7 @@ func (w *RotatingWriter) Write(p []byte) (int, error) {
 			}
 		}
 	}
-	n, err := w.file.Write(p)
+	n, err = w.file.Write(p)
 	closeErr := w.closeFile()
 	if err != nil {
 		w.report(FailureWrite, err)
@@ -191,7 +196,11 @@ func (w *RotatingWriter) convergeArchives(ctx context.Context) {
 		w.report(FailureCleanup, errors.New("lock wait exceeded"))
 		return
 	}
-	defer w.lock.Unlock()
+	defer func() {
+		if err := w.lock.Unlock(); err != nil {
+			w.report(FailureCleanup, err)
+		}
+	}()
 	if hook := testAfterExclusiveLock; hook != nil {
 		hook()
 	}

--- a/internal/logging/rotator.go
+++ b/internal/logging/rotator.go
@@ -19,6 +19,10 @@ import (
 // and before directory enumeration. Tests use it for deterministic pauses.
 var testAfterExclusiveLock func()
 
+// testBeforeRemove is invoked after the exclusive lock is held and immediately
+// before archive Remove. Tests use it to prove maintenance ignores cancel.
+var testBeforeRemove func()
+
 // RotatorOptions opens a process-safe rotating JSONL writer.
 type RotatorOptions struct {
 	BasePath  string
@@ -160,8 +164,16 @@ func (w *RotatingWriter) Write(p []byte) (int, error) {
 // maintenance; the swapped config is kept. After the lock is held, ReadDir and
 // Remove are not canceled.
 func (w *RotatingWriter) Apply(ctx context.Context, cfg Config) {
+	w.swapConfig(cfg)
+	w.convergeArchives(ctx)
+}
+
+func (w *RotatingWriter) swapConfig(cfg Config) {
 	copied := cfg
 	w.cfg.Store(&copied)
+}
+
+func (w *RotatingWriter) convergeArchives(ctx context.Context) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.closed || w.lock == nil {
@@ -278,6 +290,9 @@ func (w *RotatingWriter) convergeLocked() error {
 		if !entry.Mode.IsRegular() {
 			w.report(FailureCleanup, fmt.Errorf("skip non-regular archive suffix %d", n))
 			continue
+		}
+		if hook := testBeforeRemove; hook != nil {
+			hook()
 		}
 		if err := w.fs.Remove(w.child(entry.Name)); err != nil {
 			w.report(FailureCleanup, err)

--- a/internal/logging/rotator.go
+++ b/internal/logging/rotator.go
@@ -48,8 +48,8 @@ type RotatingWriter struct {
 }
 
 // OpenRotatingWriter creates the lock, converges archives, and creates the base file.
-// The caller context bounds only the initial lock wait. On failure, acquired
-// resources are closed.
+// The initial lock wait uses the earlier of the caller deadline and the hard
+// write-wait bound. On failure, acquired resources are closed.
 func OpenRotatingWriter(ctx context.Context, opts RotatorOptions) (*RotatingWriter, error) {
 	if opts.PrivateFS == nil {
 		return nil, fmt.Errorf("rotator private fs is required")
@@ -82,7 +82,10 @@ func OpenRotatingWriter(ctx context.Context, opts RotatorOptions) (*RotatingWrit
 	}
 	cfg := opts.Config
 	w.cfg.Store(&cfg)
-	if err := w.lock.Lock(ctx, platform.LockExclusive); err != nil {
+	lockCtx, cancelLock := context.WithTimeout(ctx, writeWaitBound)
+	err = w.lock.Lock(lockCtx, platform.LockExclusive)
+	cancelLock()
+	if err != nil {
 		_ = lock.Close()
 		w.lock = nil
 		return nil, err

--- a/internal/logging/rotator_subprocess_test.go
+++ b/internal/logging/rotator_subprocess_test.go
@@ -33,19 +33,47 @@ type rotatorRecord struct {
 	Seq    int    `json:"seq"`
 }
 
-func TestRotatingWriter_TwoProcessesNoTornRecords(t *testing.T) {
+func TestRotatingWriter_TwoProcessesPreserveAllSequencesAndRotate(t *testing.T) {
 	fs, paths := openTestLogFS(t)
 	base := paths.TUILog
-	cfg := Config{Level: slog.LevelInfo, MaxSizeBytes: 512, MaxFiles: 10}
+	// 16 files of 16 KiB preserve all 4,000 small test records while the
+	// 16 KiB active-file limit still requires several rotations.
+	cfg := Config{Level: slog.LevelInfo, MaxSizeBytes: 16 << 10, MaxFiles: 16}
 
-	a := startRotatorChild(t, paths.Root, base, "write", "A", cfg, 2000)
-	b := startRotatorChild(t, paths.Root, base, "write", "B", cfg, 2000)
+	a := startRotatorChild(t, paths.Root, base, "write-pause", "A", cfg, 2000)
+	if !a.sc.Scan() || a.sc.Text() != "opened" {
+		t.Fatalf("writer A did not open: %q stderr=%s", a.sc.Text(), a.errBuf.String())
+	}
+	b := startRotatorChild(t, paths.Root, base, "write-pause", "B", cfg, 2000)
+	if !b.sc.Scan() || b.sc.Text() != "opened" {
+		t.Fatalf("writer B did not open: %q stderr=%s", b.sc.Text(), b.errBuf.String())
+	}
+	if _, err := io.WriteString(a.stdin, "go\n"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.WriteString(b.stdin, "go\n"); err != nil {
+		t.Fatal(err)
+	}
 	waitChildExit(t, a)
 	waitChildExit(t, b)
+
+	files := collectLogFiles(t, fs, paths.LogDir, filepath.Base(base))
+	rotations := 0
+	for name := range files {
+		if _, ok := archiveSuffix(filepath.Base(base), name); ok {
+			rotations++
+		}
+	}
+	if rotations < 2 {
+		t.Fatalf("archive files=%d, want evidence of multiple rotations", rotations)
+	}
 
 	lines := readAllJSONL(t, fs, paths.LogDir, filepath.Base(base))
 	if len(lines) == 0 {
 		t.Fatal("merged logs are empty")
+	}
+	if got, want := len(lines), 4000; got != want {
+		t.Fatalf("merged record count=%d want=%d", got, want)
 	}
 	seen := make(map[string]map[int]struct{})
 	for i, line := range lines {
@@ -56,6 +84,9 @@ func TestRotatingWriter_TwoProcessesNoTornRecords(t *testing.T) {
 		if rec.Writer == "" || rec.Seq < 1 {
 			t.Fatalf("line %d missing writer/seq: %+v", i, rec)
 		}
+		if rec.Writer != "A" && rec.Writer != "B" {
+			t.Fatalf("line %d has unexpected writer %q", i, rec.Writer)
+		}
 		if seen[rec.Writer] == nil {
 			seen[rec.Writer] = make(map[int]struct{})
 		}
@@ -63,6 +94,16 @@ func TestRotatingWriter_TwoProcessesNoTornRecords(t *testing.T) {
 			t.Fatalf("duplicate %s seq=%d", rec.Writer, rec.Seq)
 		}
 		seen[rec.Writer][rec.Seq] = struct{}{}
+	}
+	for _, writer := range []string{"A", "B"} {
+		if got, want := len(seen[writer]), 2000; got != want {
+			t.Fatalf("writer %s record count=%d want=%d", writer, got, want)
+		}
+		for seq := 1; seq <= 2000; seq++ {
+			if _, ok := seen[writer][seq]; !ok {
+				t.Fatalf("writer %s missing seq=%d", writer, seq)
+			}
+		}
 	}
 }
 
@@ -255,13 +296,21 @@ func runRotatorChild() int {
 		}
 		fmt.Println("wrote2")
 		return 0
-	default:
+	case "write", "write-pause":
 		w, err := OpenRotatingWriter(context.Background(), RotatorOptions{BasePath: base, Config: cfg, PrivateFS: fs, WriteWait: 30 * time.Second})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "child Open: %v\n", err)
 			return 1
 		}
 		defer func() { _ = w.Close() }()
+		if mode == "write-pause" {
+			fmt.Println("opened")
+			sc := bufio.NewScanner(os.Stdin)
+			if !sc.Scan() {
+				fmt.Fprintf(os.Stderr, "child write-pause stdin: %v\n", sc.Err())
+				return 1
+			}
+		}
 		for i := 1; i <= count; i++ {
 			if err := writeRotatorRecord(w, writer, i); err != nil {
 				fmt.Fprintf(os.Stderr, "child write %d: %v\n", i, err)
@@ -269,6 +318,9 @@ func runRotatorChild() int {
 			}
 		}
 		return 0
+	default:
+		fmt.Fprintf(os.Stderr, "unknown child mode %q\n", mode)
+		return 1
 	}
 }
 

--- a/internal/logging/rotator_subprocess_test.go
+++ b/internal/logging/rotator_subprocess_test.go
@@ -1,0 +1,333 @@
+package logging
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mihari-proxy/mihari/internal/platform"
+)
+
+const rotatorChildEnv = "MIHARI_ROTATOR_CHILD"
+
+func init() {
+	if os.Getenv(rotatorChildEnv) == "" {
+		return
+	}
+	os.Exit(runRotatorChild())
+}
+
+type rotatorRecord struct {
+	Writer string `json:"writer"`
+	Seq    int    `json:"seq"`
+}
+
+func TestRotatingWriter_TwoProcessesNoTornRecords(t *testing.T) {
+	fs, paths := openTestLogFS(t)
+	base := paths.TUILog
+	cfg := Config{Level: slog.LevelInfo, MaxSizeBytes: 512, MaxFiles: 10}
+
+	a := startRotatorChild(t, paths.Root, base, "write", "A", cfg, 2000)
+	b := startRotatorChild(t, paths.Root, base, "write", "B", cfg, 2000)
+	waitChildExit(t, a)
+	waitChildExit(t, b)
+
+	lines := readAllJSONL(t, fs, paths.LogDir, filepath.Base(base))
+	if len(lines) == 0 {
+		t.Fatal("merged logs are empty")
+	}
+	seen := make(map[string]map[int]struct{})
+	for i, line := range lines {
+		var rec rotatorRecord
+		if err := json.Unmarshal(line, &rec); err != nil {
+			t.Fatalf("line %d is not JSON: %s err=%v", i, line, err)
+		}
+		if rec.Writer == "" || rec.Seq < 1 {
+			t.Fatalf("line %d missing writer/seq: %+v", i, rec)
+		}
+		if seen[rec.Writer] == nil {
+			seen[rec.Writer] = make(map[int]struct{})
+		}
+		if _, ok := seen[rec.Writer][rec.Seq]; ok {
+			t.Fatalf("duplicate %s seq=%d", rec.Writer, rec.Seq)
+		}
+		seen[rec.Writer][rec.Seq] = struct{}{}
+	}
+}
+
+func TestRotatingWriter_OpenEnumeratesOnlyAfterLock(t *testing.T) {
+	fs, paths := openTestLogFS(t)
+	mustWriteFile(t, fs, paths.TUILog, []byte("ACTIVE\n"))
+	for i := 1; i <= 2; i++ {
+		mustWriteFile(t, fs, fmt.Sprintf("%s.%d", paths.TUILog, i), []byte(fmt.Sprintf("pre-%d\n", i)))
+	}
+	cfg := Config{Level: slog.LevelInfo, MaxSizeBytes: 1024, MaxFiles: 3}
+	child := startRotatorChild(t, paths.Root, paths.TUILog, "open-pause", "P", cfg, 0)
+	if !child.sc.Scan() || child.sc.Text() != "locked" {
+		t.Fatalf("want locked, got %q stderr=%s", child.sc.Text(), child.errBuf.String())
+	}
+
+	late := paths.TUILog + ".99"
+	mustWriteFile(t, fs, late, []byte("late-enum\n"))
+	if _, err := io.WriteString(child.stdin, "go\n"); err != nil {
+		t.Fatal(err)
+	}
+	if !child.sc.Scan() || child.sc.Text() != "opened" {
+		t.Fatalf("want opened, got %q stderr=%s", child.sc.Text(), child.errBuf.String())
+	}
+	waitChildExit(t, child)
+	if _, err := os.Stat(late); !os.IsNotExist(err) {
+		t.Fatalf("Open used a listing captured before lock; late .99 survived: %v", err)
+	}
+	if got := readLogFile(t, paths.TUILog); string(got) != "ACTIVE\n" {
+		t.Fatalf("Open rewrote active: %q", got)
+	}
+}
+
+func TestRotatingWriter_NoStaleInodeWrite(t *testing.T) {
+	fs, paths := openTestLogFS(t)
+	rec1 := rotatorRecord{Writer: "child", Seq: 1}
+	body1, err := json.Marshal(rec1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body1 = append(body1, '\n')
+	cfg := Config{Level: slog.LevelInfo, MaxSizeBytes: int64(len(body1)), MaxFiles: 3}
+
+	child := startRotatorChild(t, paths.Root, paths.TUILog, "stale", "child", cfg, 0)
+	if !child.sc.Scan() || child.sc.Text() != "wrote1" {
+		t.Fatalf("want wrote1, got %q stderr=%s", child.sc.Text(), child.errBuf.String())
+	}
+
+	parent := openRotatorAt(t, fs, paths.TUILog, cfg)
+	recP := rotatorRecord{Writer: "parent", Seq: 1}
+	bodyP, err := json.Marshal(recP)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bodyP = append(bodyP, '\n')
+	if _, err := parent.Write(bodyP); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.WriteString(child.stdin, "go\n"); err != nil {
+		t.Fatal(err)
+	}
+	if !child.sc.Scan() || child.sc.Text() != "wrote2" {
+		t.Fatalf("want wrote2, got %q stderr=%s", child.sc.Text(), child.errBuf.String())
+	}
+	waitChildExit(t, child)
+
+	files := collectLogFiles(t, fs, paths.LogDir, filepath.Base(paths.TUILog))
+	marker1 := []byte(`"writer":"child","seq":1`)
+	marker2 := []byte(`"writer":"child","seq":2`)
+	for name, body := range files {
+		if bytes.Contains(body, marker1) && bytes.Contains(body, marker2) {
+			t.Fatalf("stale inode %s received both child records:\n%s", name, body)
+		}
+	}
+	merged := bytes.Join(fileValues(files), nil)
+	if !bytes.Contains(merged, marker2) {
+		t.Fatalf("child seq 2 missing from merged logs: %q", merged)
+	}
+}
+
+type rotatorChild struct {
+	stdin  io.WriteCloser
+	sc     *bufio.Scanner
+	cmd    *exec.Cmd
+	errBuf *bytes.Buffer
+}
+
+func startRotatorChild(t *testing.T, root, base, mode, writer string, cfg Config, count int) *rotatorChild {
+	t.Helper()
+	cmd := exec.Command(os.Args[0])
+	cmd.Env = append(os.Environ(),
+		rotatorChildEnv+"="+mode,
+		"MIHARI_ROTATOR_ROOT="+root,
+		"MIHARI_ROTATOR_BASE="+base,
+		"MIHARI_ROTATOR_WRITER="+writer,
+		"MIHARI_ROTATOR_COUNT="+strconv.Itoa(count),
+		"MIHARI_ROTATOR_MAXSIZE="+strconv.FormatInt(cfg.MaxSizeBytes, 10),
+		"MIHARI_ROTATOR_MAXFILES="+strconv.Itoa(cfg.MaxFiles),
+	)
+	errBuf := &bytes.Buffer{}
+	cmd.Stderr = errBuf
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = stdin.Close()
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	})
+	return &rotatorChild{stdin: stdin, sc: bufio.NewScanner(stdout), cmd: cmd, errBuf: errBuf}
+}
+
+func waitChildExit(t *testing.T, child *rotatorChild) {
+	t.Helper()
+	if err := child.stdin.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := child.cmd.Wait(); err != nil {
+		t.Fatalf("child wait: %v stderr=%s", err, child.errBuf.String())
+	}
+	child.cmd.Process = nil
+}
+
+func runRotatorChild() int {
+	root := os.Getenv("MIHARI_ROTATOR_ROOT")
+	base := os.Getenv("MIHARI_ROTATOR_BASE")
+	writer := os.Getenv("MIHARI_ROTATOR_WRITER")
+	mode := os.Getenv(rotatorChildEnv)
+	maxSize, _ := strconv.ParseInt(os.Getenv("MIHARI_ROTATOR_MAXSIZE"), 10, 64)
+	maxFiles, _ := strconv.Atoi(os.Getenv("MIHARI_ROTATOR_MAXFILES"))
+	count, _ := strconv.Atoi(os.Getenv("MIHARI_ROTATOR_COUNT"))
+	fs, err := platform.NewPrivateFS(root)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "child NewPrivateFS: %v\n", err)
+		return 1
+	}
+	defer func() { _ = fs.Close() }()
+	if err := fs.EnsureDir(filepath.Dir(base)); err != nil {
+		fmt.Fprintf(os.Stderr, "child EnsureDir: %v\n", err)
+		return 1
+	}
+	cfg := Config{Level: slog.LevelInfo, MaxSizeBytes: maxSize, MaxFiles: maxFiles}
+	switch mode {
+	case "open-pause":
+		testAfterExclusiveLock = func() {
+			fmt.Println("locked")
+			sc := bufio.NewScanner(os.Stdin)
+			if !sc.Scan() {
+				fmt.Fprintf(os.Stderr, "child pause stdin: %v\n", sc.Err())
+				os.Exit(1)
+			}
+		}
+		w, err := OpenRotatingWriter(context.Background(), RotatorOptions{BasePath: base, Config: cfg, PrivateFS: fs, WriteWait: 30 * time.Second})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "child Open: %v\n", err)
+			return 1
+		}
+		_ = w.Close()
+		fmt.Println("opened")
+		return 0
+	case "stale":
+		w, err := OpenRotatingWriter(context.Background(), RotatorOptions{BasePath: base, Config: cfg, PrivateFS: fs, WriteWait: 30 * time.Second})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "child Open: %v\n", err)
+			return 1
+		}
+		defer func() { _ = w.Close() }()
+		if err := writeRotatorRecord(w, writer, 1); err != nil {
+			fmt.Fprintf(os.Stderr, "child write 1: %v\n", err)
+			return 1
+		}
+		fmt.Println("wrote1")
+		sc := bufio.NewScanner(os.Stdin)
+		if !sc.Scan() {
+			fmt.Fprintf(os.Stderr, "child stale stdin: %v\n", sc.Err())
+			return 1
+		}
+		if err := writeRotatorRecord(w, writer, 2); err != nil {
+			fmt.Fprintf(os.Stderr, "child write 2: %v\n", err)
+			return 1
+		}
+		fmt.Println("wrote2")
+		return 0
+	default:
+		w, err := OpenRotatingWriter(context.Background(), RotatorOptions{BasePath: base, Config: cfg, PrivateFS: fs, WriteWait: 30 * time.Second})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "child Open: %v\n", err)
+			return 1
+		}
+		defer func() { _ = w.Close() }()
+		for i := 1; i <= count; i++ {
+			if err := writeRotatorRecord(w, writer, i); err != nil {
+				fmt.Fprintf(os.Stderr, "child write %d: %v\n", i, err)
+				return 1
+			}
+		}
+		return 0
+	}
+}
+
+func writeRotatorRecord(w *RotatingWriter, writer string, seq int) error {
+	body, err := json.Marshal(rotatorRecord{Writer: writer, Seq: seq})
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(append(body, '\n'))
+	return err
+}
+
+func readAllJSONL(t *testing.T, fs *platform.PrivateFS, dir, baseName string) [][]byte {
+	t.Helper()
+	files := collectLogFiles(t, fs, dir, baseName)
+	var lines [][]byte
+	for _, body := range files {
+		for _, line := range bytes.Split(body, []byte("\n")) {
+			line = bytes.TrimSpace(line)
+			if len(line) == 0 {
+				continue
+			}
+			copied := append([]byte(nil), line...)
+			lines = append(lines, copied)
+		}
+	}
+	return lines
+}
+
+func collectLogFiles(t *testing.T, fs *platform.PrivateFS, dir, baseName string) map[string][]byte {
+	t.Helper()
+	entries, err := fs.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := make(map[string][]byte)
+	for _, e := range entries {
+		if e.Name != baseName && !strings.HasPrefix(e.Name, baseName+".") {
+			continue
+		}
+		if strings.HasSuffix(e.Name, ".lock") {
+			continue
+		}
+		if !e.Mode.IsRegular() {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join(dir, e.Name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		out[e.Name] = body
+	}
+	return out
+}
+
+func fileValues(files map[string][]byte) [][]byte {
+	out := make([][]byte, 0, len(files))
+	for _, body := range files {
+		out = append(out, body)
+	}
+	return out
+}

--- a/internal/logging/rotator_test.go
+++ b/internal/logging/rotator_test.go
@@ -31,8 +31,8 @@ func TestRotatingWriter_DefaultAndBootstrapConfig(t *testing.T) {
 
 func TestRotatingWriter_RotatesWholeRecordBeforeExceedingLimit(t *testing.T) {
 	w, fs, paths := openTestRotator(t, Config{Level: slog.LevelInfo, MaxSizeBytes: 20, MaxFiles: 3})
-	rec1 := []byte(`{"msg":"one"}\n`)
-	rec2 := []byte(`{"msg":"two"}\n`)
+	rec1 := []byte("{\"msg\":\"one\"}\n")
+	rec2 := []byte("{\"msg\":\"two\"}\n")
 	if int64(len(rec1)) > 20 || int64(len(rec1)+len(rec2)) <= 20 {
 		t.Fatalf("fixture sizes rec1=%d rec2=%d", len(rec1), len(rec2))
 	}
@@ -79,7 +79,7 @@ func TestRotatingWriter_OpenConvergesArchivesWithoutRewritingActive(t *testing.T
 		t.Fatalf(".1 rewritten: %q", got)
 	}
 
-	rec := []byte(`{"msg":"next"}\n`)
+	rec := []byte("{\"msg\":\"next\"}\n")
 	if _, err := w.Write(rec); err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +122,7 @@ func TestRotatingWriter_MaxFilesOneRotateReplacesInode(t *testing.T) {
 		t.Fatalf("Open replaced active inode: %q", got)
 	}
 
-	rec := []byte(`{"msg":"fresh"}\n`)
+	rec := []byte("{\"msg\":\"fresh\"}\n")
 	if _, err := w.Write(rec); err != nil {
 		t.Fatal(err)
 	}
@@ -207,7 +207,7 @@ func TestRotatingWriter_SkipsNonRegularAndIllegalSuffix(t *testing.T) {
 		t.Fatalf("active rewritten: %q", got)
 	}
 
-	if _, err := w.Write([]byte(`{"x":1}\n`)); err != nil {
+	if _, err := w.Write([]byte("{\"x\":1}\n")); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(dirName); err != nil {
@@ -243,10 +243,6 @@ func TestRotatingWriter_OverflowSafeDecision(t *testing.T) {
 		got := needRotate(tc.current, tc.incoming, tc.maxSize)
 		if got != tc.want {
 			t.Fatalf("needRotate(%d,%d,%d)=%v want %v", tc.current, tc.incoming, tc.maxSize, got, tc.want)
-		}
-		if tc.incoming <= tc.maxSize {
-			// The unsafe form current+incoming overflows for MaxInt64 cases.
-			_ = tc.current + tc.incoming
 		}
 	}
 }
@@ -290,6 +286,41 @@ func TestRotatingWriter_FailureStormRateLimitedRedacted(t *testing.T) {
 	}
 }
 
+func TestFailureReporter_RedactsPathsContainingSpaces(t *testing.T) {
+	var buf bytes.Buffer
+	reporter := NewFailureReporter(&buf, NewRedactor(), func() time.Time {
+		return time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	})
+	fullPath := `C:\Users\Jane Doe\Mihari Data\logs\mihari-tui.log`
+
+	reporter.Report(FailureWrite, fmt.Errorf("open %s: access denied", fullPath))
+
+	got := buf.String()
+	if strings.Contains(got, fullPath) || strings.Contains(got, "Jane Doe") || strings.Contains(got, "Mihari Data") {
+		t.Fatalf("path with spaces leaked: %q", got)
+	}
+	if !strings.Contains(got, "open [path]: access denied") {
+		t.Fatalf("failure report = %q, want sanitized path and stable detail", got)
+	}
+}
+
+func TestFailureReporter_ReplacesCRLFWithoutInjectingLines(t *testing.T) {
+	var buf bytes.Buffer
+	reporter := NewFailureReporter(&buf, NewRedactor(), func() time.Time {
+		return time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	})
+
+	reporter.Report(FailureWrite, errors.New("disk failed\r\nlogging: cleanup: forged"))
+
+	got := buf.String()
+	if strings.Count(got, "\n") != 1 || !strings.HasSuffix(got, "\n") {
+		t.Fatalf("failure report injected physical lines: %q", got)
+	}
+	if strings.Contains(got, "\r") {
+		t.Fatalf("failure report retained carriage return: %q", got)
+	}
+}
+
 func TestRotatingWriter_WriteDropsWhenLockTimesOut(t *testing.T) {
 	w, _, _ := openTestRotator(t, Config{Level: slog.LevelInfo, MaxSizeBytes: 1024, MaxFiles: 3})
 	w.writeWait = 20 * time.Millisecond
@@ -297,7 +328,7 @@ func TestRotatingWriter_WriteDropsWhenLockTimesOut(t *testing.T) {
 		t.Fatal(err)
 	}
 	w.lock = neverLock{}
-	n, err := w.Write([]byte(`{"msg":"drop-me"}\n`))
+	n, err := w.Write([]byte("{\"msg\":\"drop-me\"}\n"))
 	if n != 0 {
 		t.Fatalf("n=%d, want 0", n)
 	}

--- a/internal/logging/rotator_test.go
+++ b/internal/logging/rotator_test.go
@@ -309,6 +309,24 @@ func TestRotatingWriter_WriteDropsWhenLockTimesOut(t *testing.T) {
 	}
 }
 
+func TestRotatingWriter_WriteReturnsUnlockFailure(t *testing.T) {
+	w, _, _ := openTestRotator(t, Config{Level: slog.LevelInfo, MaxSizeBytes: 1024, MaxFiles: 3})
+	if err := w.lock.Close(); err != nil {
+		t.Fatal(err)
+	}
+	wantErr := errors.New("release test lock")
+	w.lock = &unlockErrorLock{err: wantErr}
+	record := []byte("{\"msg\":\"written\"}\n")
+
+	n, err := w.Write(record)
+	if n != len(record) {
+		t.Fatalf("Write n=%d, want %d", n, len(record))
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Write error=%v, want unlock error", err)
+	}
+}
+
 func TestRotatingWriter_OpenCancelClosesResources(t *testing.T) {
 	fs, paths := openTestLogFS(t)
 	var spy *closeSpyLock
@@ -464,6 +482,23 @@ func TestRotatingWriter_ApplyCleanupIgnoresCancelAfterLock(t *testing.T) {
 	}
 }
 
+func TestRotatingWriter_ApplyReportsUnlockFailure(t *testing.T) {
+	w, _, _ := openTestRotator(t, Config{Level: slog.LevelInfo, MaxSizeBytes: 1024, MaxFiles: 3})
+	if err := w.lock.Close(); err != nil {
+		t.Fatal(err)
+	}
+	w.lock = &unlockErrorLock{err: errors.New("release test lock")}
+	var output bytes.Buffer
+	w.reporter = NewFailureReporter(&output, nil, func() time.Time {
+		return time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	})
+
+	w.Apply(context.Background(), Config{Level: slog.LevelInfo, MaxSizeBytes: 1024, MaxFiles: 3})
+	if got := output.String(); !strings.Contains(got, "logging: cleanup: release test lock") {
+		t.Fatalf("failure report=%q, want unlock failure", got)
+	}
+}
+
 func openTestRotator(t *testing.T, cfg Config) (*RotatingWriter, *platform.PrivateFS, platform.Paths) {
 	t.Helper()
 	fs, paths := openTestLogFS(t)
@@ -582,6 +617,14 @@ type closeSpyLock struct {
 type contextCaptureLock struct {
 	lockContext context.Context
 }
+
+type unlockErrorLock struct {
+	err error
+}
+
+func (*unlockErrorLock) Lock(context.Context, platform.LockMode) error { return nil }
+func (l *unlockErrorLock) Unlock() error                               { return l.err }
+func (*unlockErrorLock) Close() error                                  { return nil }
 
 func (l *contextCaptureLock) Lock(ctx context.Context, _ platform.LockMode) error {
 	l.lockContext = ctx

--- a/internal/logging/rotator_test.go
+++ b/internal/logging/rotator_test.go
@@ -3,6 +3,7 @@ package logging
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -338,6 +339,95 @@ func TestRotatingWriter_OpenCancelClosesResources(t *testing.T) {
 	}
 }
 
+func TestRotatingWriter_OpenBackgroundContextHasHardLockCap(t *testing.T) {
+	fs, paths := openTestLogFS(t)
+	held, err := platform.OpenAdvisoryLock(fs, paths.TUILog+".lock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = held.Close() })
+	if err := held.Lock(context.Background(), platform.LockExclusive); err != nil {
+		t.Fatal(err)
+	}
+
+	type openResult struct {
+		writer  *RotatingWriter
+		err     error
+		elapsed time.Duration
+	}
+	result := make(chan openResult, 1)
+	started := time.Now()
+	go func() {
+		writer, openErr := OpenRotatingWriter(context.Background(), RotatorOptions{
+			BasePath:  paths.TUILog,
+			Config:    Config{Level: slog.LevelInfo, MaxSizeBytes: 1024, MaxFiles: 3},
+			PrivateFS: fs,
+			WriteWait: 5 * time.Second,
+		})
+		result <- openResult{writer: writer, err: openErr, elapsed: time.Since(started)}
+	}()
+
+	select {
+	case got := <-result:
+		if got.writer != nil {
+			_ = got.writer.Close()
+		}
+		if !errors.Is(got.err, context.DeadlineExceeded) {
+			t.Fatalf("Open error=%v, want deadline exceeded", got.err)
+		}
+		if got.elapsed < 150*time.Millisecond || got.elapsed > 1500*time.Millisecond {
+			t.Fatalf("Open elapsed=%v, want approximately the 250ms hard cap", got.elapsed)
+		}
+	case <-time.After(2 * time.Second):
+		if err := held.Unlock(); err != nil {
+			t.Fatal(err)
+		}
+		got := <-result
+		if got.writer != nil {
+			_ = got.writer.Close()
+		}
+		t.Fatalf("Open remained blocked past the 250ms hard cap; returned after %v with error %v", got.elapsed, got.err)
+	}
+}
+
+func TestRotatingWriter_OpenCancelsLockContextBeforeMaintenance(t *testing.T) {
+	fs, paths := openTestLogFS(t)
+	lock := &contextCaptureLock{}
+	lockContextCanceled := false
+	maintenanceStarted := false
+	t.Cleanup(func() { testAfterExclusiveLock = nil })
+	testAfterExclusiveLock = func() {
+		maintenanceStarted = true
+		select {
+		case <-lock.lockContext.Done():
+			lockContextCanceled = true
+		default:
+		}
+	}
+
+	w, err := OpenRotatingWriter(context.Background(), RotatorOptions{
+		BasePath:  paths.TUILog,
+		Config:    Config{Level: slog.LevelInfo, MaxSizeBytes: 1024, MaxFiles: 3},
+		PrivateFS: fs,
+		OpenLock: func(*platform.PrivateFS, string) (platform.AdvisoryLock, error) {
+			return lock, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = w.Close() })
+	if !maintenanceStarted {
+		t.Fatal("Open did not start post-lock maintenance")
+	}
+	if !lockContextCanceled {
+		t.Fatal("Open kept the lock-acquisition context alive during local maintenance")
+	}
+	if _, err := os.Stat(paths.TUILog); err != nil {
+		t.Fatalf("post-lock maintenance did not create base log: %v", err)
+	}
+}
+
 func TestRotatingWriter_ApplySwapsConfigBeforeLockWait(t *testing.T) {
 	w, _, paths := openTestRotator(t, Config{Level: slog.LevelInfo, MaxSizeBytes: 1000, MaxFiles: 3})
 	rec := bytes.Repeat([]byte("a"), 40)
@@ -488,6 +578,18 @@ type closeSpyLock struct {
 	platform.AdvisoryLock
 	closed atomic.Bool
 }
+
+type contextCaptureLock struct {
+	lockContext context.Context
+}
+
+func (l *contextCaptureLock) Lock(ctx context.Context, _ platform.LockMode) error {
+	l.lockContext = ctx
+	return nil
+}
+
+func (*contextCaptureLock) Unlock() error { return nil }
+func (*contextCaptureLock) Close() error  { return nil }
 
 func (s *closeSpyLock) Close() error {
 	s.closed.Store(true)

--- a/internal/logging/rotator_test.go
+++ b/internal/logging/rotator_test.go
@@ -1,0 +1,498 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mihari-proxy/mihari/internal/platform"
+)
+
+func TestRotatingWriter_DefaultAndBootstrapConfig(t *testing.T) {
+	got := DefaultConfig()
+	if got.Level != slog.LevelInfo || got.MaxSizeBytes != 10<<20 || got.MaxFiles != 3 {
+		t.Fatalf("DefaultConfig() = %+v", got)
+	}
+	got = BootstrapConfig()
+	if got.Level != slog.LevelDebug || got.MaxSizeBytes != 100<<20 || got.MaxFiles != 10 {
+		t.Fatalf("BootstrapConfig() = %+v", got)
+	}
+}
+
+func TestRotatingWriter_RotatesWholeRecordBeforeExceedingLimit(t *testing.T) {
+	w, fs, paths := openTestRotator(t, Config{Level: slog.LevelInfo, MaxSizeBytes: 20, MaxFiles: 3})
+	rec1 := []byte(`{"msg":"one"}\n`)
+	rec2 := []byte(`{"msg":"two"}\n`)
+	if int64(len(rec1)) > 20 || int64(len(rec1)+len(rec2)) <= 20 {
+		t.Fatalf("fixture sizes rec1=%d rec2=%d", len(rec1), len(rec2))
+	}
+	if _, err := w.Write(rec1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write(rec2); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	base := readLogFile(t, paths.TUILog)
+	if string(base) != string(rec2) {
+		t.Fatalf("active file = %q, want %q", base, rec2)
+	}
+	archived := readLogFile(t, paths.TUILog+".1")
+	if string(archived) != string(rec1) {
+		t.Fatalf(".1 = %q, want %q", archived, rec1)
+	}
+	assertLogNames(t, fs, paths.LogDir, filepath.Base(paths.TUILog), filepath.Base(paths.TUILog)+".1", filepath.Base(paths.TUILog)+".lock")
+}
+
+func TestRotatingWriter_OpenConvergesArchivesWithoutRewritingActive(t *testing.T) {
+	fs, paths := openTestLogFS(t)
+	active := []byte("ACTIVE-CONTENT\n")
+	mustWriteFile(t, fs, paths.TUILog, active)
+	for i := 1; i <= 9; i++ {
+		mustWriteFile(t, fs, fmt.Sprintf("%s.%d", paths.TUILog, i), []byte(fmt.Sprintf("old-%d\n", i)))
+	}
+
+	w := openRotatorAt(t, fs, paths.TUILog, Config{Level: slog.LevelInfo, MaxSizeBytes: int64(len(active)), MaxFiles: 3})
+	assertLogNames(t, fs, paths.LogDir,
+		filepath.Base(paths.TUILog),
+		filepath.Base(paths.TUILog)+".1",
+		filepath.Base(paths.TUILog)+".2",
+		filepath.Base(paths.TUILog)+".lock",
+	)
+	if got := readLogFile(t, paths.TUILog); !bytes.Equal(got, active) {
+		t.Fatalf("Open rewrote active file: %q", got)
+	}
+	if got := readLogFile(t, paths.TUILog+".1"); string(got) != "old-1\n" {
+		t.Fatalf(".1 rewritten: %q", got)
+	}
+
+	rec := []byte(`{"msg":"next"}\n`)
+	if _, err := w.Write(rec); err != nil {
+		t.Fatal(err)
+	}
+	assertLogNames(t, fs, paths.LogDir,
+		filepath.Base(paths.TUILog),
+		filepath.Base(paths.TUILog)+".1",
+		filepath.Base(paths.TUILog)+".2",
+		filepath.Base(paths.TUILog)+".lock",
+	)
+	if got := readLogFile(t, paths.TUILog); !bytes.Equal(got, rec) {
+		t.Fatalf("base after rotate = %q", got)
+	}
+	if got := readLogFile(t, paths.TUILog+".1"); !bytes.Equal(got, active) {
+		t.Fatalf(".1 after rotate = %q, want active snapshot", got)
+	}
+	if got := readLogFile(t, paths.TUILog+".2"); string(got) != "old-1\n" {
+		t.Fatalf(".2 after rotate = %q", got)
+	}
+}
+
+func TestRotatingWriter_MaxFilesOneRotateReplacesInode(t *testing.T) {
+	fs, paths := openTestLogFS(t)
+	oldBody := []byte("OLD-INODE\n")
+	mustWriteFile(t, fs, paths.TUILog, oldBody)
+	mustWriteFile(t, fs, paths.TUILog+".1", []byte("archive-1\n"))
+	mustWriteFile(t, fs, paths.TUILog+".2", []byte("archive-2\n"))
+
+	id := identityOf(t, fs, paths.LogDir, filepath.Base(paths.TUILog))
+	old, err := fs.OpenReadChecked(paths.TUILog, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = old.Close() })
+
+	w := openRotatorAt(t, fs, paths.TUILog, Config{Level: slog.LevelInfo, MaxSizeBytes: int64(len(oldBody)), MaxFiles: 1})
+	if _, err := os.Stat(paths.TUILog + ".1"); !os.IsNotExist(err) {
+		t.Fatalf("Open with max-files=1 left archive: %v", err)
+	}
+	if got := readLogFile(t, paths.TUILog); !bytes.Equal(got, oldBody) {
+		t.Fatalf("Open replaced active inode: %q", got)
+	}
+
+	rec := []byte(`{"msg":"fresh"}\n`)
+	if _, err := w.Write(rec); err != nil {
+		t.Fatal(err)
+	}
+	gotOld, err := io.ReadAll(old)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(gotOld, oldBody) {
+		t.Fatalf("old handle contents = %q, want %q", gotOld, oldBody)
+	}
+	if got := readLogFile(t, paths.TUILog); !bytes.Equal(got, rec) {
+		t.Fatalf("new base = %q, want %q", got, rec)
+	}
+	for _, name := range []string{paths.TUILog + ".1", paths.TUILog + ".2"} {
+		if _, err := os.Stat(name); !os.IsNotExist(err) {
+			t.Fatalf("archive %s still present: %v", name, err)
+		}
+	}
+	newID := identityOf(t, fs, paths.LogDir, filepath.Base(paths.TUILog))
+	if newID == id {
+		t.Fatal("max-files=1 rotate did not replace the active inode")
+	}
+}
+
+func TestRotatingWriter_ApplyShrinkDeletesArchivesOnly(t *testing.T) {
+	fs, paths := openTestLogFS(t)
+	active := []byte("keep-active\n")
+	mustWriteFile(t, fs, paths.TUILog, active)
+	mustWriteFile(t, fs, paths.TUILog+".1", []byte("a1\n"))
+	mustWriteFile(t, fs, paths.TUILog+".2", []byte("a2\n"))
+	id := identityOf(t, fs, paths.LogDir, filepath.Base(paths.TUILog))
+
+	w := openRotatorAt(t, fs, paths.TUILog, Config{Level: slog.LevelInfo, MaxSizeBytes: 1024, MaxFiles: 3})
+	w.Apply(context.Background(), Config{Level: slog.LevelWarn, MaxSizeBytes: 512, MaxFiles: 1})
+
+	if got := readLogFile(t, paths.TUILog); !bytes.Equal(got, active) {
+		t.Fatalf("Apply emptied or rewrote active file: %q", got)
+	}
+	if identityOf(t, fs, paths.LogDir, filepath.Base(paths.TUILog)) != id {
+		t.Fatal("Apply shrink replaced the active inode")
+	}
+	for _, name := range []string{paths.TUILog + ".1", paths.TUILog + ".2"} {
+		if _, err := os.Stat(name); !os.IsNotExist(err) {
+			t.Fatalf("archive %s survived Apply shrink: %v", name, err)
+		}
+	}
+}
+
+func TestRotatingWriter_SkipsNonRegularAndIllegalSuffix(t *testing.T) {
+	fs, paths := openTestLogFS(t)
+	mustWriteFile(t, fs, paths.TUILog, []byte("base\n"))
+	mustWriteFile(t, fs, paths.TUILog+".2", []byte("keep-regular-2\n"))
+	mustWriteFile(t, fs, paths.TUILog+".7", []byte("delete-me\n"))
+	mustWriteFile(t, fs, paths.TUILog+".bad", []byte("illegal\n"))
+	mustWriteFile(t, fs, filepath.Join(paths.LogDir, "other.log.3"), []byte("other\n"))
+	dirName := paths.TUILog + ".1"
+	if err := os.Mkdir(dirName, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	linkName := paths.TUILog + ".4"
+	linkOK := os.Symlink(paths.TUILog+".bad", linkName) == nil
+
+	w := openRotatorAt(t, fs, paths.TUILog, Config{Level: slog.LevelInfo, MaxSizeBytes: 8, MaxFiles: 3})
+	if _, err := os.Stat(paths.TUILog + ".7"); !os.IsNotExist(err) {
+		t.Fatalf("regular suffix 7 should be deleted: %v", err)
+	}
+	if _, err := os.Stat(dirName); err != nil {
+		t.Fatalf("directory suffix should be skipped: %v", err)
+	}
+	if _, err := os.Stat(paths.TUILog + ".bad"); err != nil {
+		t.Fatalf("illegal suffix should be skipped: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(paths.LogDir, "other.log.3")); err != nil {
+		t.Fatalf("foreign basename should be skipped: %v", err)
+	}
+	if linkOK {
+		if _, err := os.Lstat(linkName); err != nil {
+			t.Fatalf("symlink suffix should be skipped: %v", err)
+		}
+	}
+	if got := readLogFile(t, paths.TUILog); string(got) != "base\n" {
+		t.Fatalf("active rewritten: %q", got)
+	}
+
+	if _, err := w.Write([]byte(`{"x":1}\n`)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(dirName); err != nil {
+		t.Fatalf("rotate followed directory: %v", err)
+	}
+	if linkOK {
+		if _, err := os.Lstat(linkName); err != nil {
+			t.Fatalf("rotate followed symlink: %v", err)
+		}
+	}
+}
+
+func TestRotatingWriter_OverflowSafeDecision(t *testing.T) {
+	max := int64(math.MaxInt64)
+	tests := []struct {
+		current, incoming, maxSize int64
+		want                       bool
+	}{
+		{0, 10, 10, false},
+		{10, 1, 10, true},
+		{5, 5, 10, false},
+		{6, 5, 10, true},
+		{0, 11, 10, true},
+		{max, 1, max, true},
+		{max, max, max, true},
+		{0, max, max, false},
+		{1, max, max, true},
+		{max - 1, 2, max, true},
+		{max - 1, 1, max, false},
+		{max, 0, max, false},
+	}
+	for _, tc := range tests {
+		got := needRotate(tc.current, tc.incoming, tc.maxSize)
+		if got != tc.want {
+			t.Fatalf("needRotate(%d,%d,%d)=%v want %v", tc.current, tc.incoming, tc.maxSize, got, tc.want)
+		}
+		if tc.incoming <= tc.maxSize {
+			// The unsafe form current+incoming overflows for MaxInt64 cases.
+			_ = tc.current + tc.incoming
+		}
+	}
+}
+
+func TestRotatingWriter_FailureStormRateLimitedRedacted(t *testing.T) {
+	var buf bytes.Buffer
+	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	secret := "super-secret-token-value"
+	redactor := NewRedactor(secret)
+	reporter := NewFailureReporter(&buf, redactor, func() time.Time { return now })
+
+	fullPath := `C:\Users\Kinema\Documents\mihari\logs\mihari-tui.log`
+	err := fmt.Errorf("write %s token=%s", fullPath, secret)
+	for i := 0; i < 50; i++ {
+		reporter.Report(FailureWrite, err)
+		reporter.Report(FailureRotate, err)
+		reporter.Report(FailureDropped, err)
+		reporter.Report(FailureCleanup, err)
+	}
+	first := buf.String()
+	for _, class := range []FailureClass{FailureWrite, FailureRotate, FailureDropped, FailureCleanup} {
+		token := "logging: " + string(class)
+		if strings.Count(first, token) != 1 {
+			t.Fatalf("class %s count=%d in %q", class, strings.Count(first, token), first)
+		}
+	}
+	if strings.Contains(first, secret) {
+		t.Fatalf("secret leaked: %q", first)
+	}
+	if strings.Contains(first, "***") == false {
+		t.Fatalf("expected redacted secret in %q", first)
+	}
+	if strings.Contains(first, fullPath) || strings.Contains(first, `C:\Users`) {
+		t.Fatalf("full path leaked: %q", first)
+	}
+
+	now = now.Add(2 * time.Second)
+	reporter.Report(FailureWrite, err)
+	if strings.Count(buf.String(), "logging: "+string(FailureWrite)) != 2 {
+		t.Fatalf("rate limit did not lift: %q", buf.String())
+	}
+}
+
+func TestRotatingWriter_WriteDropsWhenLockTimesOut(t *testing.T) {
+	w, _, _ := openTestRotator(t, Config{Level: slog.LevelInfo, MaxSizeBytes: 1024, MaxFiles: 3})
+	w.writeWait = 20 * time.Millisecond
+	if err := w.lock.Close(); err != nil {
+		t.Fatal(err)
+	}
+	w.lock = neverLock{}
+	n, err := w.Write([]byte(`{"msg":"drop-me"}\n`))
+	if n != 0 {
+		t.Fatalf("n=%d, want 0", n)
+	}
+	if err == nil {
+		t.Fatal("expected drop error")
+	}
+	if w.Dropped() != 1 {
+		t.Fatalf("Dropped()=%d, want 1", w.Dropped())
+	}
+}
+
+func TestRotatingWriter_OpenCancelClosesResources(t *testing.T) {
+	fs, paths := openTestLogFS(t)
+	var spy *closeSpyLock
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := OpenRotatingWriter(ctx, RotatorOptions{
+		BasePath:  paths.TUILog,
+		Config:    Config{Level: slog.LevelInfo, MaxSizeBytes: 1024, MaxFiles: 3},
+		PrivateFS: fs,
+		OpenLock: func(fs *platform.PrivateFS, path string) (platform.AdvisoryLock, error) {
+			inner, err := platform.OpenAdvisoryLock(fs, path)
+			if err != nil {
+				return nil, err
+			}
+			spy = &closeSpyLock{AdvisoryLock: inner}
+			return spy, nil
+		},
+		WriteWait: 20 * time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("expected Open to fail on canceled context")
+	}
+	if spy == nil {
+		t.Fatal("OpenLock was not called")
+	}
+	if !spy.closed.Load() {
+		t.Fatal("canceled Open left lock open")
+	}
+}
+
+func TestRotatingWriter_ApplySwapsConfigBeforeLockWait(t *testing.T) {
+	w, _, paths := openTestRotator(t, Config{Level: slog.LevelInfo, MaxSizeBytes: 1000, MaxFiles: 3})
+	rec := bytes.Repeat([]byte("a"), 40)
+	rec = append(rec, '\n')
+	if _, err := w.Write(rec); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	w.Apply(ctx, Config{Level: slog.LevelError, MaxSizeBytes: 20, MaxFiles: 3})
+	if _, err := w.Write(rec); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(paths.TUILog + ".1"); err != nil {
+		t.Fatalf("expected rotate under swapped max-size: %v", err)
+	}
+}
+
+func TestRotatingWriter_ApplyCleanupIgnoresCancelAfterLock(t *testing.T) {
+	fs, paths := openTestLogFS(t)
+	mustWriteFile(t, fs, paths.TUILog, []byte("active\n"))
+	mustWriteFile(t, fs, paths.TUILog+".1", []byte("archive\n"))
+	w := openRotatorAt(t, fs, paths.TUILog, Config{Level: slog.LevelInfo, MaxSizeBytes: 1024, MaxFiles: 3})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { testAfterExclusiveLock = nil })
+	testAfterExclusiveLock = func() { cancel() }
+	w.Apply(ctx, Config{Level: slog.LevelInfo, MaxSizeBytes: 1024, MaxFiles: 1})
+	if _, err := os.Stat(paths.TUILog + ".1"); !os.IsNotExist(err) {
+		t.Fatalf("cleanup should finish after cancel: %v", err)
+	}
+	if got := readLogFile(t, paths.TUILog); string(got) != "active\n" {
+		t.Fatalf("active rewritten during Apply: %q", got)
+	}
+}
+
+func openTestRotator(t *testing.T, cfg Config) (*RotatingWriter, *platform.PrivateFS, platform.Paths) {
+	t.Helper()
+	fs, paths := openTestLogFS(t)
+	return openRotatorAt(t, fs, paths.TUILog, cfg), fs, paths
+}
+
+func openTestLogFS(t *testing.T) (*platform.PrivateFS, platform.Paths) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "data")
+	fs, err := platform.NewPrivateFS(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = fs.Close() })
+	paths := platform.NewPaths(root)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	return fs, paths
+}
+
+func openRotatorAt(t *testing.T, fs *platform.PrivateFS, base string, cfg Config) *RotatingWriter {
+	t.Helper()
+	w, err := OpenRotatingWriter(context.Background(), RotatorOptions{
+		BasePath:  base,
+		Config:    cfg,
+		PrivateFS: fs,
+		WriteWait: 50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = w.Close() })
+	return w
+}
+
+func mustWriteFile(t *testing.T, fs *platform.PrivateFS, path string, body []byte) {
+	t.Helper()
+	f, err := fs.OpenAppend(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(body); err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readLogFile(t *testing.T, path string) []byte {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func assertLogNames(t *testing.T, fs *platform.PrivateFS, dir string, want ...string) {
+	t.Helper()
+	entries, err := fs.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make(map[string]struct{}, len(entries))
+	for _, e := range entries {
+		got[e.Name] = struct{}{}
+	}
+	for _, name := range want {
+		if _, ok := got[name]; !ok {
+			t.Fatalf("missing %s in %v", name, got)
+		}
+	}
+	wantSet := make(map[string]struct{}, len(want))
+	for _, name := range want {
+		wantSet[name] = struct{}{}
+	}
+	for name := range got {
+		if _, ok := wantSet[name]; !ok {
+			t.Fatalf("unexpected %s in %v", name, got)
+		}
+	}
+}
+
+func identityOf(t *testing.T, fs *platform.PrivateFS, dir, name string) platform.FileIdentity {
+	t.Helper()
+	entries, err := fs.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Name == name {
+			return e.Identity
+		}
+	}
+	t.Fatalf("missing %s", name)
+	return platform.FileIdentity{}
+}
+
+type neverLock struct{}
+
+func (neverLock) Lock(ctx context.Context, _ platform.LockMode) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+func (neverLock) Unlock() error { return nil }
+func (neverLock) Close() error  { return nil }
+
+type closeSpyLock struct {
+	platform.AdvisoryLock
+	closed atomic.Bool
+}
+
+func (s *closeSpyLock) Close() error {
+	s.closed.Store(true)
+	if s.AdvisoryLock == nil {
+		return nil
+	}
+	return s.AdvisoryLock.Close()
+}

--- a/internal/logging/runtime.go
+++ b/internal/logging/runtime.go
@@ -105,6 +105,7 @@ func (r *Runtime) convergeArchives(ctx context.Context) {
 
 // Group applies one config to multiple runtimes (daemon and mihomo).
 type Group struct {
+	applyMu sync.Mutex
 	mu      sync.Mutex
 	dir     string
 	cfg     Config
@@ -121,6 +122,16 @@ func NewGroup(dir string, config Config, targets ...*Runtime) *Group {
 // Apply swaps config on every target, then converges archives one by one.
 // It must not call Runtime.Apply per target.
 func (g *Group) Apply(ctx context.Context, cfg Config) {
+	g.apply(ctx, cfg, nil)
+}
+
+func (g *Group) apply(ctx context.Context, cfg Config, beforeLock func()) {
+	if beforeLock != nil {
+		beforeLock()
+	}
+	g.applyMu.Lock()
+	defer g.applyMu.Unlock()
+
 	g.mu.Lock()
 	g.cfg = cfg
 	targets := g.targets

--- a/internal/logging/runtime.go
+++ b/internal/logging/runtime.go
@@ -1,0 +1,153 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"github.com/mihari-proxy/mihari/internal/platform"
+)
+
+// RuntimeOptions opens a component-scoped JSONL logging runtime.
+type RuntimeOptions struct {
+	BasePath  string
+	Component string
+	Config    Config
+	PrivateFS *platform.PrivateFS
+	OpenLock  func(*platform.PrivateFS, string) (platform.AdvisoryLock, error)
+	Redactor  *Redactor
+	Reporter  FailureReporter
+}
+
+// Runtime owns a slog logger, LevelVar, and rotating writer for one log file.
+type Runtime struct {
+	rotator *RotatingWriter
+	level   *slog.LevelVar
+	logger  *slog.Logger
+}
+
+// Open creates the base log file and returns a runtime. ctx cancel aborts the
+// initial lock wait. The shared PrivateFS is not owned by the runtime.
+func Open(ctx context.Context, opts RuntimeOptions) (*Runtime, error) {
+	rotator, err := OpenRotatingWriter(ctx, RotatorOptions{
+		BasePath:  opts.BasePath,
+		Config:    opts.Config,
+		PrivateFS: opts.PrivateFS,
+		OpenLock:  opts.OpenLock,
+		Reporter:  opts.Reporter,
+	})
+	if err != nil {
+		return nil, err
+	}
+	level := &slog.LevelVar{}
+	level.Set(opts.Config.Level)
+	handler := NewJSONHandler(rotator, level, opts.Component, opts.Redactor)
+	return &Runtime{
+		rotator: rotator,
+		level:   level,
+		logger:  slog.New(handler),
+	}, nil
+}
+
+// Logger returns the runtime slog logger.
+func (r *Runtime) Logger() *slog.Logger {
+	if r == nil {
+		return nil
+	}
+	return r.logger
+}
+
+// Apply swaps level and rotator limits, then converges archives. A canceled
+// context still completes the in-memory swap.
+func (r *Runtime) Apply(ctx context.Context, cfg Config) {
+	r.swapConfig(cfg)
+	r.convergeArchives(ctx)
+}
+
+// Config returns the current logging config.
+func (r *Runtime) Config() Config {
+	if r == nil || r.rotator == nil {
+		return DefaultConfig()
+	}
+	return r.rotator.config()
+}
+
+// Close closes the rotator, lock, and current write handle. It does not close
+// the shared PrivateFS.
+func (r *Runtime) Close() error {
+	if r == nil || r.rotator == nil {
+		return nil
+	}
+	return r.rotator.Close()
+}
+
+// EnterRecordMutex locks the process-local record mutex and returns unlock.
+func (r *Runtime) EnterRecordMutex() func() {
+	r.rotator.mu.Lock()
+	return func() { r.rotator.mu.Unlock() }
+}
+
+func (r *Runtime) swapConfig(cfg Config) {
+	copied := cfg
+	if r.level != nil {
+		r.level.Set(copied.Level)
+	}
+	if r.rotator != nil {
+		r.rotator.swapConfig(copied)
+	}
+}
+
+func (r *Runtime) convergeArchives(ctx context.Context) {
+	if r.rotator != nil {
+		r.rotator.convergeArchives(ctx)
+	}
+}
+
+// Group applies one config to multiple runtimes (daemon and mihomo).
+type Group struct {
+	mu      sync.Mutex
+	dir     string
+	cfg     Config
+	targets []*Runtime
+}
+
+// NewGroup stores dir, the initial config, and the given targets.
+func NewGroup(dir string, config Config, targets ...*Runtime) *Group {
+	copied := make([]*Runtime, len(targets))
+	copy(copied, targets)
+	return &Group{dir: dir, cfg: config, targets: copied}
+}
+
+// Apply swaps config on every target, then converges archives one by one.
+// It must not call Runtime.Apply per target.
+func (g *Group) Apply(ctx context.Context, cfg Config) {
+	g.mu.Lock()
+	g.cfg = cfg
+	targets := g.targets
+	g.mu.Unlock()
+	for _, t := range targets {
+		if t != nil {
+			t.swapConfig(cfg)
+		}
+	}
+	for _, t := range targets {
+		if t != nil {
+			t.convergeArchives(ctx)
+		}
+	}
+}
+
+// Config returns the last applied group config.
+func (g *Group) Config() Config {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.cfg
+}
+
+// Dir returns the log directory associated with the group.
+func (g *Group) Dir() string {
+	if g == nil {
+		return ""
+	}
+	return g.dir
+}

--- a/internal/logging/runtime_test.go
+++ b/internal/logging/runtime_test.go
@@ -263,6 +263,89 @@ func TestGroup_ApplySwapsAllTargetsBeforeConverge(t *testing.T) {
 	}
 }
 
+func TestGroup_ApplySerializesConcurrentCalls(t *testing.T) {
+	fs, paths := openTestLogFS(t)
+	initial := Config{Level: slog.LevelInfo, MaxSizeBytes: 1024, MaxFiles: 3}
+	blocked := make(chan struct{})
+	first, err := Open(context.Background(), RuntimeOptions{
+		BasePath:  paths.DaemonLog,
+		Component: "daemon",
+		Config:    initial,
+		PrivateFS: fs,
+		OpenLock: func(fs *platform.PrivateFS, path string) (platform.AdvisoryLock, error) {
+			inner, err := platform.OpenAdvisoryLock(fs, path)
+			if err != nil {
+				return nil, err
+			}
+			return &blockAfterOpenLock{AdvisoryLock: inner, blocked: blocked}, nil
+		},
+		Redactor: NewRedactor(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = first.Close() })
+	second := openTestRuntime(t, fs, paths.MihomoLog, "mihomo", initial)
+	g := NewGroup(paths.LogDir, initial, first, second)
+
+	firstCfg := Config{Level: slog.LevelWarn, MaxSizeBytes: 512, MaxFiles: 2}
+	firstCtx, cancelFirst := context.WithCancel(context.Background())
+	defer cancelFirst()
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		g.Apply(firstCtx, firstCfg)
+	}()
+	select {
+	case <-blocked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first Apply did not reach archive maintenance")
+	}
+
+	secondCfg := Config{Level: slog.LevelError, MaxSizeBytes: 256, MaxFiles: 1}
+	secondCtx, cancelSecond := context.WithCancel(context.Background())
+	cancelSecond()
+	secondEntered := make(chan struct{})
+	secondDone := make(chan struct{})
+	go func() {
+		defer close(secondDone)
+		g.apply(secondCtx, secondCfg, func() { close(secondEntered) })
+	}()
+	select {
+	case <-secondEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second Apply did not reach the serialization gate")
+	}
+	if got := g.Config(); got == secondCfg {
+		t.Fatal("second Apply became observable while the first Apply was still running")
+	}
+	select {
+	case <-secondDone:
+		t.Fatal("second Apply overlapped the first Apply")
+	default:
+	}
+
+	cancelFirst()
+	select {
+	case <-firstDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first Apply did not return after cancel")
+	}
+	select {
+	case <-secondDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("queued Apply did not return")
+	}
+	if got := g.Config(); got != secondCfg {
+		t.Fatalf("Group.Config()=%+v, want final %+v", got, secondCfg)
+	}
+	for name, target := range map[string]*Runtime{"daemon": first, "mihomo": second} {
+		if got := target.Config(); got != secondCfg {
+			t.Fatalf("%s config=%+v, want final %+v", name, got, secondCfg)
+		}
+	}
+}
+
 type blockAfterOpenLock struct {
 	platform.AdvisoryLock
 	armed   atomic.Bool

--- a/internal/logging/runtime_test.go
+++ b/internal/logging/runtime_test.go
@@ -1,0 +1,305 @@
+package logging
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mihari-proxy/mihari/internal/platform"
+)
+
+func TestRuntime_OpenCreatesBaseFile(t *testing.T) {
+	fs, paths := openTestLogFS(t)
+	rt := openTestRuntime(t, fs, paths.DaemonLog, "daemon", DefaultConfig())
+	st, err := os.Stat(paths.DaemonLog)
+	if err != nil {
+		t.Fatalf("Open did not create base file: %v", err)
+	}
+	if st.IsDir() {
+		t.Fatal("base path is a directory")
+	}
+	if rt.Logger() == nil {
+		t.Fatal("Logger() is nil")
+	}
+	if rt.Config() != DefaultConfig() {
+		t.Fatalf("Config()=%+v", rt.Config())
+	}
+}
+
+func TestRuntime_OpenCancelAbortsLockWait(t *testing.T) {
+	fs, paths := openTestLogFS(t)
+	var spy *closeSpyLock
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := Open(ctx, RuntimeOptions{
+		BasePath:  paths.DaemonLog,
+		Component: "daemon",
+		Config:    DefaultConfig(),
+		PrivateFS: fs,
+		OpenLock: func(fs *platform.PrivateFS, path string) (platform.AdvisoryLock, error) {
+			inner, err := platform.OpenAdvisoryLock(fs, path)
+			if err != nil {
+				return nil, err
+			}
+			spy = &closeSpyLock{AdvisoryLock: inner}
+			return spy, nil
+		},
+		Redactor: NewRedactor(),
+	})
+	if err == nil {
+		t.Fatal("expected Open to fail on canceled context")
+	}
+	if spy == nil {
+		t.Fatal("OpenLock was not called")
+	}
+	if !spy.closed.Load() {
+		t.Fatal("canceled Open left lock open")
+	}
+}
+
+func TestRuntime_ApplySwapsConfigWithCanceledContext(t *testing.T) {
+	fs, paths := openTestLogFS(t)
+	cfg := Config{Level: slog.LevelInfo, MaxSizeBytes: 1000, MaxFiles: 3}
+	rt := openTestRuntime(t, fs, paths.DaemonLog, "daemon", cfg)
+	rt.Logger().Info("seed-record")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	next := Config{Level: slog.LevelError, MaxSizeBytes: 20, MaxFiles: 3}
+	rt.Apply(ctx, next)
+	if got := rt.Config(); got != next {
+		t.Fatalf("Config()=%+v want %+v after canceled Apply", got, next)
+	}
+	if rt.Logger().Handler().Enabled(context.Background(), slog.LevelInfo) {
+		t.Fatal("LevelVar still enables INFO after swap to ERROR")
+	}
+	if !rt.Logger().Handler().Enabled(context.Background(), slog.LevelError) {
+		t.Fatal("ERROR must stay enabled")
+	}
+
+	rt.Logger().Info("filtered")
+	rt.Logger().Error(strings.Repeat("a", 40))
+	if _, err := os.Stat(paths.DaemonLog + ".1"); err != nil {
+		t.Fatalf("expected rotate under swapped max-size: %v", err)
+	}
+}
+
+func TestRuntime_ApplyCleanupIgnoresCancelAfterLock(t *testing.T) {
+	fs, paths := openTestLogFS(t)
+	mustWriteFile(t, fs, paths.DaemonLog, []byte("active\n"))
+	mustWriteFile(t, fs, paths.DaemonLog+".1", []byte("archive\n"))
+	rt := openTestRuntime(t, fs, paths.DaemonLog, "daemon", Config{Level: slog.LevelInfo, MaxSizeBytes: 1024, MaxFiles: 3})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var removeSawCancel atomic.Bool
+	t.Cleanup(func() {
+		testAfterExclusiveLock = nil
+		testBeforeRemove = nil
+	})
+	testAfterExclusiveLock = func() { cancel() }
+	testBeforeRemove = func() {
+		if ctx.Err() == nil {
+			t.Error("Remove started before cancel")
+			return
+		}
+		removeSawCancel.Store(true)
+	}
+	rt.Apply(ctx, Config{Level: slog.LevelInfo, MaxSizeBytes: 1024, MaxFiles: 1})
+	if _, err := os.Stat(paths.DaemonLog + ".1"); !os.IsNotExist(err) {
+		t.Fatalf("cleanup should finish after cancel: %v", err)
+	}
+	if !removeSawCancel.Load() {
+		t.Fatal("Remove did not observe the already-canceled context")
+	}
+	if got := readLogFile(t, paths.DaemonLog); string(got) != "active\n" {
+		t.Fatalf("active rewritten during Apply: %q", got)
+	}
+}
+
+func TestRuntime_CloseIdempotentDoesNotClosePrivateFS(t *testing.T) {
+	fs, paths := openTestLogFS(t)
+	rt, err := Open(context.Background(), RuntimeOptions{
+		BasePath:  paths.DaemonLog,
+		Component: "daemon",
+		Config:    DefaultConfig(),
+		PrivateFS: fs,
+		Redactor:  NewRedactor(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fs.ReadDir(paths.LogDir); err != nil {
+		t.Fatalf("Close closed shared PrivateFS: %v", err)
+	}
+	lock, err := platform.OpenAdvisoryLock(fs, paths.DaemonLog+".lock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = lock.Close() })
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := lock.Lock(ctx, platform.LockExclusive); err != nil {
+		t.Fatalf("Close left lock held: %v", err)
+	}
+	if err := lock.Unlock(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRuntime_JSONComponent(t *testing.T) {
+	fs, paths := openTestLogFS(t)
+	for _, component := range []string{"daemon", "tui", "mihomo"} {
+		t.Run(component, func(t *testing.T) {
+			base := filepath.Join(paths.LogDir, "mihari-"+component+".log")
+			rt := openTestRuntime(t, fs, base, component, DefaultConfig())
+			rt.Logger().Info("hello")
+			body := strings.TrimSpace(string(readLogFile(t, base)))
+			var rec map[string]any
+			if err := json.Unmarshal([]byte(body), &rec); err != nil {
+				t.Fatalf("json: %v in %q", err, body)
+			}
+			if rec["component"] != component {
+				t.Fatalf("component=%v want %s", rec["component"], component)
+			}
+			if rec["msg"] != "hello" {
+				t.Fatalf("msg=%v", rec["msg"])
+			}
+			if _, ok := rec["source"]; ok {
+				t.Fatalf("source present: %v", rec)
+			}
+		})
+	}
+}
+
+func TestRuntime_EnterRecordMutex(t *testing.T) {
+	fs, paths := openTestLogFS(t)
+	rt := openTestRuntime(t, fs, paths.DaemonLog, "daemon", DefaultConfig())
+	unlock := rt.EnterRecordMutex()
+	unlock()
+	unlock = rt.EnterRecordMutex()
+	unlock()
+}
+
+func TestGroup_ApplySwapsAllTargetsBeforeConverge(t *testing.T) {
+	fs, paths := openTestLogFS(t)
+	old := Config{Level: slog.LevelInfo, MaxSizeBytes: 1024, MaxFiles: 3}
+	mustWriteFile(t, fs, paths.DaemonLog, []byte("daemon-active\n"))
+	mustWriteFile(t, fs, paths.DaemonLog+".1", []byte("daemon-archive\n"))
+	mustWriteFile(t, fs, paths.MihomoLog, []byte("mihomo-active\n"))
+	mustWriteFile(t, fs, paths.MihomoLog+".1", []byte("mihomo-archive\n"))
+
+	blocked := make(chan struct{})
+	first, err := Open(context.Background(), RuntimeOptions{
+		BasePath:  paths.DaemonLog,
+		Component: "daemon",
+		Config:    old,
+		PrivateFS: fs,
+		OpenLock: func(fs *platform.PrivateFS, path string) (platform.AdvisoryLock, error) {
+			inner, err := platform.OpenAdvisoryLock(fs, path)
+			if err != nil {
+				return nil, err
+			}
+			return &blockAfterOpenLock{AdvisoryLock: inner, blocked: blocked}, nil
+		},
+		Redactor: NewRedactor(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = first.Close() })
+	second := openTestRuntime(t, fs, paths.MihomoLog, "mihomo", old)
+
+	g := NewGroup(paths.LogDir, old, first, second)
+	if g.Dir() != paths.LogDir {
+		t.Fatalf("Dir()=%q", g.Dir())
+	}
+	if g.Config() != old {
+		t.Fatalf("Config()=%+v", g.Config())
+	}
+
+	next := Config{Level: slog.LevelError, MaxSizeBytes: 512, MaxFiles: 1}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		g.Apply(ctx, next)
+	}()
+
+	select {
+	case <-blocked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first target did not block on lock")
+	}
+	if got := second.Config(); got != next {
+		t.Fatalf("second still has old config %+v while first lock blocked", got)
+	}
+	if got := first.Config(); got != next {
+		t.Fatalf("first still has old config %+v while lock blocked", got)
+	}
+	if g.Config() != next {
+		t.Fatalf("Group.Config()=%+v", g.Config())
+	}
+	if second.Logger().Handler().Enabled(context.Background(), slog.LevelInfo) {
+		t.Fatal("second LevelVar was not swapped before first converge")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Apply did not return after cancel")
+	}
+}
+
+type blockAfterOpenLock struct {
+	platform.AdvisoryLock
+	armed   atomic.Bool
+	blocked chan struct{}
+}
+
+func (l *blockAfterOpenLock) Lock(ctx context.Context, mode platform.LockMode) error {
+	if l.armed.Load() {
+		select {
+		case <-l.blocked:
+		default:
+			close(l.blocked)
+		}
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	return l.AdvisoryLock.Lock(ctx, mode)
+}
+
+func (l *blockAfterOpenLock) Unlock() error {
+	err := l.AdvisoryLock.Unlock()
+	l.armed.Store(true)
+	return err
+}
+
+func openTestRuntime(t *testing.T, fs *platform.PrivateFS, base, component string, cfg Config) *Runtime {
+	t.Helper()
+	rt, err := Open(context.Background(), RuntimeOptions{
+		BasePath:  base,
+		Component: component,
+		Config:    cfg,
+		PrivateFS: fs,
+		Redactor:  NewRedactor(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = rt.Close() })
+	return rt
+}

--- a/internal/platform/filelock.go
+++ b/internal/platform/filelock.go
@@ -49,7 +49,6 @@ type advisoryLock struct {
 	file   *os.File
 	closed bool
 	held   bool
-	mode   LockMode
 	plat   lockPlatform
 }
 
@@ -69,7 +68,7 @@ func (l *advisoryLock) Lock(ctx context.Context, mode LockMode) error {
 		if l.closed || l.file == nil {
 			return false, fmt.Errorf("advisory lock: %w", os.ErrClosed)
 		}
-		l.mode = mode
+		l.plat.mode = mode
 		busy, err = l.tryLock()
 		if err != nil {
 			return false, err

--- a/internal/platform/filelock.go
+++ b/internal/platform/filelock.go
@@ -1,0 +1,144 @@
+package platform
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+const lockRetryTick = 5 * time.Millisecond
+
+// LockMode selects a shared or exclusive advisory lock.
+type LockMode uint8
+
+const (
+	// LockShared allows concurrent shared holders.
+	LockShared LockMode = iota
+	// LockExclusive denies concurrent holders.
+	LockExclusive
+)
+
+// AdvisoryLock is a closeable OS advisory lock on a lock file.
+type AdvisoryLock interface {
+	Lock(context.Context, LockMode) error
+	Unlock() error
+	Close() error
+}
+
+type lockTimer interface {
+	C() <-chan time.Time
+	Stop() bool
+}
+
+type stdLockTimer struct {
+	t *time.Timer
+}
+
+func (t stdLockTimer) C() <-chan time.Time { return t.t.C }
+func (t stdLockTimer) Stop() bool          { return t.t.Stop() }
+
+var newLockTimer = func(d time.Duration) lockTimer {
+	return stdLockTimer{t: time.NewTimer(d)}
+}
+
+type advisoryLock struct {
+	mu     sync.Mutex
+	file   *os.File
+	closed bool
+	held   bool
+	mode   LockMode
+	plat   lockPlatform
+}
+
+// OpenAdvisoryLock opens path via fs.OpenAppend and returns an advisory lock.
+func OpenAdvisoryLock(fs *PrivateFS, path string) (AdvisoryLock, error) {
+	f, err := fs.OpenAppend(path)
+	if err != nil {
+		return nil, fmt.Errorf("open advisory lock: %w", err)
+	}
+	return &advisoryLock{file: f}, nil
+}
+
+func (l *advisoryLock) Lock(ctx context.Context, mode LockMode) error {
+	return waitLock(ctx, func() (busy bool, err error) {
+		l.mu.Lock()
+		defer l.mu.Unlock()
+		if l.closed || l.file == nil {
+			return false, fmt.Errorf("advisory lock: %w", os.ErrClosed)
+		}
+		l.mode = mode
+		busy, err = l.tryLock()
+		if err != nil {
+			return false, err
+		}
+		if !busy {
+			l.held = true
+		}
+		return busy, nil
+	})
+}
+
+func (l *advisoryLock) Unlock() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.closed || l.file == nil {
+		return fmt.Errorf("advisory lock: %w", os.ErrClosed)
+	}
+	if !l.held {
+		return nil
+	}
+	if err := l.unlock(); err != nil {
+		return fmt.Errorf("unlock advisory lock: %w", err)
+	}
+	l.held = false
+	return nil
+}
+
+func (l *advisoryLock) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.closed {
+		return nil
+	}
+	l.closed = true
+	var errs []error
+	if l.held {
+		if err := l.unlock(); err != nil {
+			errs = append(errs, err)
+		}
+		l.held = false
+	}
+	if l.file != nil {
+		if err := l.file.Close(); err != nil {
+			errs = append(errs, err)
+		}
+		l.file = nil
+	}
+	return errors.Join(errs...)
+}
+
+func waitLock(ctx context.Context, tryLock func() (busy bool, err error)) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		busy, err := tryLock()
+		if err != nil {
+			return err
+		}
+		if !busy {
+			return nil
+		}
+		timer := newLockTimer(lockRetryTick)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C():
+			timer.Stop()
+		}
+	}
+}

--- a/internal/platform/filelock_subprocess_test.go
+++ b/internal/platform/filelock_subprocess_test.go
@@ -1,0 +1,147 @@
+package platform
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+const filelockChildEnv = "MIHARI_FILELOCK_CHILD"
+
+func init() {
+	if os.Getenv(filelockChildEnv) == "1" {
+		os.Exit(runFilelockChild())
+	}
+}
+
+func TestAdvisoryLock_SubprocessExitReleases(t *testing.T) {
+	fs, paths := openTestPrivateFS(t)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(paths.LogDir, "mihari-tui.log.lock")
+	stdin, _, cmd, errBuf := startFilelockChild(t, paths.Root, path, LockExclusive)
+
+	lock := openAdvisoryLockAt(t, fs, path)
+	waitForWaiter, tick := installLockTicks(t)
+	acquired := make(chan error, 1)
+	go func() {
+		acquired <- lock.Lock(context.Background(), LockExclusive)
+	}()
+	waitForWaiter(t, acquired)
+
+	if _, err := io.WriteString(stdin, "exit\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := stdin.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("child wait: %v stderr=%s", err, errBuf.String())
+	}
+	cmd.Process = nil
+	tick()
+	if err := <-acquired; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func startFilelockChild(t *testing.T, root, path string, mode LockMode) (io.WriteCloser, *bufio.Scanner, *exec.Cmd, *bytes.Buffer) {
+	t.Helper()
+	modeName := "exclusive"
+	if mode == LockShared {
+		modeName = "shared"
+	}
+	cmd := exec.Command(os.Args[0])
+	cmd.Env = append(os.Environ(),
+		filelockChildEnv+"=1",
+		"MIHARI_FILELOCK_ROOT="+root,
+		"MIHARI_FILELOCK_PATH="+path,
+		"MIHARI_FILELOCK_MODE="+modeName,
+	)
+	errBuf := &bytes.Buffer{}
+	cmd.Stderr = errBuf
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = stdin.Close()
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	})
+	sc := bufio.NewScanner(stdout)
+	if !sc.Scan() || sc.Text() != "locked" {
+		_ = cmd.Wait()
+		cmd.Process = nil
+		t.Fatalf("child locked line=%q stderr=%s scan=%v", sc.Text(), errBuf.String(), sc.Err())
+	}
+	return stdin, sc, cmd, errBuf
+}
+
+func runFilelockChild() int {
+	root := os.Getenv("MIHARI_FILELOCK_ROOT")
+	path := os.Getenv("MIHARI_FILELOCK_PATH")
+	mode := LockExclusive
+	if os.Getenv("MIHARI_FILELOCK_MODE") == "shared" {
+		mode = LockShared
+	}
+	fs, err := NewPrivateFS(root)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "child NewPrivateFS: %v\n", err)
+		return 1
+	}
+	defer func() { _ = fs.Close() }()
+	lock, err := OpenAdvisoryLock(fs, path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "child OpenAdvisoryLock: %v\n", err)
+		return 1
+	}
+	if err := lock.Lock(context.Background(), mode); err != nil {
+		fmt.Fprintf(os.Stderr, "child Lock: %v\n", err)
+		return 1
+	}
+	fmt.Println("locked")
+	sc := bufio.NewScanner(os.Stdin)
+	for sc.Scan() {
+		switch sc.Text() {
+		case "exit":
+			return 0
+		case "unlock":
+			if err := lock.Unlock(); err != nil {
+				fmt.Fprintf(os.Stderr, "child Unlock: %v\n", err)
+				return 1
+			}
+			fmt.Println("unlocked")
+		case "close":
+			if err := lock.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "child Close: %v\n", err)
+				return 1
+			}
+			fmt.Println("closed")
+		default:
+			fmt.Fprintf(os.Stderr, "child unknown command %q\n", sc.Text())
+			return 1
+		}
+	}
+	if err := sc.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "child stdin: %v\n", err)
+		return 1
+	}
+	return 0
+}

--- a/internal/platform/filelock_test.go
+++ b/internal/platform/filelock_test.go
@@ -1,0 +1,228 @@
+package platform
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestAdvisoryLock_ExclusiveMutex(t *testing.T) {
+	fs, path, a := openTestAdvisoryLock(t)
+	b := openAdvisoryLockAt(t, fs, path)
+
+	if err := a.Lock(context.Background(), LockExclusive); err != nil {
+		t.Fatal(err)
+	}
+
+	waitForWaiter, tick := installLockTicks(t)
+	acquired := make(chan error, 1)
+	go func() {
+		acquired <- b.Lock(context.Background(), LockExclusive)
+	}()
+	waitForWaiter(t, acquired)
+
+	if err := a.Unlock(); err != nil {
+		t.Fatal(err)
+	}
+	tick()
+	if err := <-acquired; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAdvisoryLock_SharedCoexist(t *testing.T) {
+	fs, path, a := openTestAdvisoryLock(t)
+	b := openAdvisoryLockAt(t, fs, path)
+
+	if err := a.Lock(context.Background(), LockShared); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Lock(context.Background(), LockShared); err != nil {
+		t.Fatal(err)
+	}
+
+	c := openAdvisoryLockAt(t, fs, path)
+	waitForWaiter, tick := installLockTicks(t)
+	acquired := make(chan error, 1)
+	go func() {
+		acquired <- c.Lock(context.Background(), LockExclusive)
+	}()
+	waitForWaiter(t, acquired)
+
+	if err := a.Unlock(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-acquired:
+		t.Fatalf("exclusive lock acquired with remaining shared holder: %v", err)
+	default:
+	}
+	if err := b.Unlock(); err != nil {
+		t.Fatal(err)
+	}
+	tick()
+	if err := <-acquired; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAdvisoryLock_ContextCanceled(t *testing.T) {
+	fs, path, a := openTestAdvisoryLock(t)
+	b := openAdvisoryLockAt(t, fs, path)
+
+	if err := a.Lock(context.Background(), LockExclusive); err != nil {
+		t.Fatal(err)
+	}
+
+	waitForWaiter, _ := installLockTicks(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- b.Lock(ctx, LockExclusive)
+	}()
+	waitForWaiter(t, done)
+	cancel()
+	err := <-done
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Lock cancel: %v", err)
+	}
+}
+
+func TestAdvisoryLock_ContextDeadlineExceeded(t *testing.T) {
+	_, _, lock := openTestAdvisoryLock(t)
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	err := lock.Lock(ctx, LockExclusive)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Lock deadline: %v", err)
+	}
+}
+
+func TestAdvisoryLock_UnlockThenReacquire(t *testing.T) {
+	fs, path, lock := openTestAdvisoryLock(t)
+	if err := lock.Lock(context.Background(), LockExclusive); err != nil {
+		t.Fatal(err)
+	}
+	if err := lock.Unlock(); err != nil {
+		t.Fatal(err)
+	}
+	assertLockFileExists(t, fs, path)
+	if err := lock.Lock(context.Background(), LockExclusive); err != nil {
+		t.Fatal(err)
+	}
+	if err := lock.Unlock(); err != nil {
+		t.Fatal(err)
+	}
+	assertLockFileExists(t, fs, path)
+}
+
+func TestAdvisoryLock_CloseReleases(t *testing.T) {
+	fs, path, a := openTestAdvisoryLock(t)
+	if err := a.Lock(context.Background(), LockExclusive); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.Lock(context.Background(), LockExclusive); !errors.Is(err, os.ErrClosed) {
+		t.Fatalf("Lock after Close: %v", err)
+	}
+	if err := a.Unlock(); !errors.Is(err, os.ErrClosed) {
+		t.Fatalf("Unlock after Close: %v", err)
+	}
+	assertLockFileExists(t, fs, path)
+
+	b := openAdvisoryLockAt(t, fs, path)
+	if err := b.Lock(context.Background(), LockExclusive); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAdvisoryLock_ExistingFileIsNotHeld(t *testing.T) {
+	fs, paths := openTestPrivateFS(t)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(paths.LogDir, "mihari-tui.log.lock")
+	f, err := fs.OpenAppend(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	assertLockFileExists(t, fs, path)
+
+	lock := openAdvisoryLockAt(t, fs, path)
+	if err := lock.Lock(context.Background(), LockExclusive); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func openTestAdvisoryLock(t *testing.T) (*PrivateFS, string, AdvisoryLock) {
+	t.Helper()
+	fs, paths := openTestPrivateFS(t)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(paths.LogDir, "mihari-tui.log.lock")
+	return fs, path, openAdvisoryLockAt(t, fs, path)
+}
+
+func openAdvisoryLockAt(t *testing.T, fs *PrivateFS, path string) AdvisoryLock {
+	t.Helper()
+	lock, err := OpenAdvisoryLock(fs, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = lock.Close() })
+	return lock
+}
+
+func assertLockFileExists(t *testing.T, fs *PrivateFS, path string) {
+	t.Helper()
+	entries, err := fs.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsFile(entries, filepath.Base(path)) {
+		t.Fatalf("lock file missing after release: %s", filepath.Base(path))
+	}
+}
+
+type chanLockTimer struct {
+	c <-chan time.Time
+}
+
+func (t chanLockTimer) C() <-chan time.Time { return t.c }
+func (t chanLockTimer) Stop() bool          { return true }
+
+func installLockTicks(t *testing.T) (waitForWaiter func(*testing.T, <-chan error), tick func()) {
+	t.Helper()
+	waiting := make(chan struct{}, 16)
+	ticks := make(chan time.Time)
+	prev := newLockTimer
+	t.Cleanup(func() { newLockTimer = prev })
+	newLockTimer = func(time.Duration) lockTimer {
+		select {
+		case waiting <- struct{}{}:
+		default:
+		}
+		return chanLockTimer{c: ticks}
+	}
+	waitForWaiter = func(t *testing.T, acquired <-chan error) {
+		t.Helper()
+		select {
+		case <-waiting:
+		case err := <-acquired:
+			t.Fatalf("lock acquired while it should block: %v", err)
+		}
+	}
+	return waitForWaiter, func() { ticks <- time.Time{} }
+}

--- a/internal/platform/filelock_unix.go
+++ b/internal/platform/filelock_unix.go
@@ -9,11 +9,13 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-type lockPlatform struct{}
+type lockPlatform struct {
+	mode LockMode
+}
 
 func (l *advisoryLock) tryLock() (busy bool, err error) {
 	how := unix.LOCK_NB
-	switch l.mode {
+	switch l.plat.mode {
 	case LockShared:
 		how |= unix.LOCK_SH
 	default:

--- a/internal/platform/filelock_unix.go
+++ b/internal/platform/filelock_unix.go
@@ -1,0 +1,37 @@
+//go:build unix
+
+package platform
+
+import (
+	"errors"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+)
+
+type lockPlatform struct{}
+
+func (l *advisoryLock) tryLock() (busy bool, err error) {
+	how := unix.LOCK_NB
+	switch l.mode {
+	case LockShared:
+		how |= unix.LOCK_SH
+	default:
+		how |= unix.LOCK_EX
+	}
+	err = unix.Flock(int(l.file.Fd()), how)
+	runtime.KeepAlive(l.file)
+	if err == nil {
+		return false, nil
+	}
+	if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+		return true, nil
+	}
+	return false, err
+}
+
+func (l *advisoryLock) unlock() error {
+	err := unix.Flock(int(l.file.Fd()), unix.LOCK_UN)
+	runtime.KeepAlive(l.file)
+	return err
+}

--- a/internal/platform/filelock_windows.go
+++ b/internal/platform/filelock_windows.go
@@ -10,12 +10,13 @@ import (
 )
 
 type lockPlatform struct {
+	mode       LockMode
 	overlapped windows.Overlapped
 }
 
 func (l *advisoryLock) tryLock() (busy bool, err error) {
 	flags := uint32(windows.LOCKFILE_FAIL_IMMEDIATELY)
-	if l.mode != LockShared {
+	if l.plat.mode != LockShared {
 		flags |= windows.LOCKFILE_EXCLUSIVE_LOCK
 	}
 	err = windows.LockFileEx(windows.Handle(l.file.Fd()), flags, 0, 1, 0, &l.plat.overlapped)

--- a/internal/platform/filelock_windows.go
+++ b/internal/platform/filelock_windows.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+package platform
+
+import (
+	"errors"
+	"runtime"
+
+	"golang.org/x/sys/windows"
+)
+
+type lockPlatform struct {
+	overlapped windows.Overlapped
+}
+
+func (l *advisoryLock) tryLock() (busy bool, err error) {
+	flags := uint32(windows.LOCKFILE_FAIL_IMMEDIATELY)
+	if l.mode != LockShared {
+		flags |= windows.LOCKFILE_EXCLUSIVE_LOCK
+	}
+	err = windows.LockFileEx(windows.Handle(l.file.Fd()), flags, 0, 1, 0, &l.plat.overlapped)
+	runtime.KeepAlive(l.file)
+	if err == nil {
+		return false, nil
+	}
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		return true, nil
+	}
+	return false, err
+}
+
+func (l *advisoryLock) unlock() error {
+	// UnlockFileEx requires the same Overlapped offset used by LockFileEx.
+	err := windows.UnlockFileEx(windows.Handle(l.file.Fd()), 0, 1, 0, &l.plat.overlapped)
+	runtime.KeepAlive(l.file)
+	return err
+}

--- a/internal/platform/paths.go
+++ b/internal/platform/paths.go
@@ -1,6 +1,7 @@
 package platform
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -15,7 +16,11 @@ type Paths struct {
 	RuntimeConfig       string
 	Settings            string
 	Onboarding          string
-	Log                 string
+	LogDir              string
+	DaemonLog           string
+	TUILog              string
+	MihomoLog           string
+	LogExportDir        string
 	Staging             string
 	Subscriptions       string
 	SubscriptionCatalog string
@@ -45,7 +50,11 @@ func NewPaths(root string) Paths {
 		RuntimeConfig:       filepath.Join(root, "runtime", "config.yaml"),
 		Settings:            filepath.Join(root, "mihari.yaml"),
 		Onboarding:          filepath.Join(root, "onboarding.json"),
-		Log:                 filepath.Join(root, "logs", "mihari.log"),
+		LogDir:              filepath.Join(root, "logs"),
+		DaemonLog:           filepath.Join(root, "logs", "mihari-daemon.log"),
+		TUILog:              filepath.Join(root, "logs", "mihari-tui.log"),
+		MihomoLog:           filepath.Join(root, "logs", "mihomo.log"),
+		LogExportDir:        filepath.Join(root, "logs-export"),
 		Staging:             filepath.Join(root, "staging"),
 		Subscriptions:       filepath.Join(root, "subscriptions"),
 		SubscriptionCatalog: filepath.Join(root, "subscriptions", "catalog.yaml"),
@@ -60,6 +69,19 @@ func NewPaths(root string) Paths {
 		WebCredential:       filepath.Join(root, "web", "credential"),
 		PanelStaging:        filepath.Join(root, "staging", "panels"),
 	}
+}
+
+// Absolute resolves Root with filepath.Abs/Clean and rebuilds every derived field
+// via NewPaths. It does not EvalSymlinks; callers that need a trusted data-root
+// identity must open NewPrivateFS on the absolute Root before EnsureDirs or
+// default token IO. --help/--version must not call Absolute. TUI may continue
+// after NewPrivateFS failure; daemon must not continue directory IO after failure.
+func (p Paths) Absolute() (Paths, error) {
+	absRoot, err := filepath.Abs(p.Root)
+	if err != nil {
+		return Paths{}, fmt.Errorf("resolve absolute data root: %w", err)
+	}
+	return NewPaths(filepath.Clean(absRoot)), nil
 }
 
 // DefaultDataRoot returns MIHARI_DATA when set, otherwise the platform default
@@ -99,9 +121,14 @@ func defaultDataRoot() string {
 }
 
 // EnsureDirs creates the durable directories under this layout.
+// It may pre-create LogDir with MkdirAll but does not harden permissions or
+// reject intermediate symlinks, and it does not create LogExportDir. Callers
+// that need a local data root must establish NewPrivateFS(absolutePaths.Root)
+// before EnsureDirs or default token IO; EnsureDirs is not the root create or
+// harden entrypoint.
 func (p Paths) EnsureDirs() error {
 	for _, path := range []string{
-		p.Root, p.Bin, filepath.Dir(p.RuntimeConfig), filepath.Dir(p.Log), p.Staging,
+		p.Root, p.Bin, filepath.Dir(p.RuntimeConfig), p.LogDir, p.Staging,
 		p.Subscriptions, p.SubscriptionCache, p.SubscriptionStaging,
 		filepath.Dir(p.TUIPreferences), filepath.Dir(p.GeoIPCountry), p.GeoIPStaging,
 		p.WebRoot, p.PanelStaging,

--- a/internal/platform/paths.go
+++ b/internal/platform/paths.go
@@ -74,8 +74,11 @@ func NewPaths(root string) Paths {
 // Absolute resolves Root with filepath.Abs/Clean and rebuilds every derived field
 // via NewPaths. It does not EvalSymlinks; callers that need a trusted data-root
 // identity must open NewPrivateFS on the absolute Root before EnsureDirs or
-// default token IO. --help/--version must not call Absolute. TUI may continue
-// after NewPrivateFS failure; daemon must not continue directory IO after failure.
+// default token IO. --help/--version must not call Absolute. root/LocalSystem
+// missing-root failures fail closed with zero directory IO and must not be
+// written into CLI SetupError; TUI may continue with PrivateFS=nil, daemon must
+// not continue directory IO. Callers reuse one process-level PrivateFS and must
+// not call NewPrivateFS again after EnsureDirs/Settings.
 func (p Paths) Absolute() (Paths, error) {
 	absRoot, err := filepath.Abs(p.Root)
 	if err != nil {
@@ -125,7 +128,8 @@ func defaultDataRoot() string {
 // reject intermediate symlinks, and it does not create LogExportDir. Callers
 // that need a local data root must establish NewPrivateFS(absolutePaths.Root)
 // before EnsureDirs or default token IO; EnsureDirs is not the root create or
-// harden entrypoint.
+// harden entrypoint. The process-level PrivateFS from that call is reused by
+// daemon/TUI; do not call NewPrivateFS again after EnsureDirs/Settings.
 func (p Paths) EnsureDirs() error {
 	for _, path := range []string{
 		p.Root, p.Bin, filepath.Dir(p.RuntimeConfig), p.LogDir, p.Staging,

--- a/internal/platform/paths_test.go
+++ b/internal/platform/paths_test.go
@@ -166,30 +166,6 @@ func TestEnsureDirsCreatesDurableLayout(t *testing.T) {
 	}
 }
 
-func TestNewPathsLoggingLayout(t *testing.T) {
-	root := filepath.Join(t.TempDir(), "mihari-data")
-	paths := NewPaths(root)
-	want := map[string]string{
-		"LogDir":       filepath.Join(root, "logs"),
-		"DaemonLog":    filepath.Join(root, "logs", "mihari-daemon.log"),
-		"TUILog":       filepath.Join(root, "logs", "mihari-tui.log"),
-		"MihomoLog":    filepath.Join(root, "logs", "mihomo.log"),
-		"LogExportDir": filepath.Join(root, "logs-export"),
-	}
-	gots := map[string]string{
-		"LogDir":       paths.LogDir,
-		"DaemonLog":    paths.DaemonLog,
-		"TUILog":       paths.TUILog,
-		"MihomoLog":    paths.MihomoLog,
-		"LogExportDir": paths.LogExportDir,
-	}
-	for name, wantPath := range want {
-		if got := gots[name]; got != wantPath {
-			t.Errorf("%s=%q want=%q", name, got, wantPath)
-		}
-	}
-}
-
 func TestEnsureDirsLoggingLayout(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "ensure-logging")
 	paths := NewPaths(root)

--- a/internal/platform/paths_test.go
+++ b/internal/platform/paths_test.go
@@ -22,7 +22,11 @@ func TestNewPathsBuildsRuntimeLayout(t *testing.T) {
 		"runtime config":  filepath.Join(root, "runtime", "config.yaml"),
 		"settings":        filepath.Join(root, "mihari.yaml"),
 		"onboarding":      filepath.Join(root, "onboarding.json"),
-		"log":             filepath.Join(root, "logs", "mihari.log"),
+		"log dir":         filepath.Join(root, "logs"),
+		"daemon log":      filepath.Join(root, "logs", "mihari-daemon.log"),
+		"tui log":         filepath.Join(root, "logs", "mihari-tui.log"),
+		"mihomo log":      filepath.Join(root, "logs", "mihomo.log"),
+		"log export dir":  filepath.Join(root, "logs-export"),
 		"staging":         filepath.Join(root, "staging"),
 		"subscriptions":   filepath.Join(root, "subscriptions"),
 		"catalog":         filepath.Join(root, "subscriptions", "catalog.yaml"),
@@ -45,7 +49,11 @@ func TestNewPathsBuildsRuntimeLayout(t *testing.T) {
 		"runtime config":  paths.RuntimeConfig,
 		"settings":        paths.Settings,
 		"onboarding":      paths.Onboarding,
-		"log":             paths.Log,
+		"log dir":         paths.LogDir,
+		"daemon log":      paths.DaemonLog,
+		"tui log":         paths.TUILog,
+		"mihomo log":      paths.MihomoLog,
+		"log export dir":  paths.LogExportDir,
 		"staging":         paths.Staging,
 		"subscriptions":   paths.Subscriptions,
 		"catalog":         paths.SubscriptionCatalog,
@@ -137,7 +145,7 @@ func TestEnsureDirsCreatesDurableLayout(t *testing.T) {
 		paths.Root,
 		paths.Bin,
 		filepath.Dir(paths.RuntimeConfig),
-		filepath.Dir(paths.Log),
+		paths.LogDir,
 		paths.Staging,
 		paths.Subscriptions,
 		paths.SubscriptionCache,
@@ -155,5 +163,108 @@ func TestEnsureDirsCreatesDurableLayout(t *testing.T) {
 		if !info.IsDir() {
 			t.Fatalf("%s is not a directory", path)
 		}
+	}
+}
+
+func TestNewPathsLoggingLayout(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "mihari-data")
+	paths := NewPaths(root)
+	want := map[string]string{
+		"LogDir":       filepath.Join(root, "logs"),
+		"DaemonLog":    filepath.Join(root, "logs", "mihari-daemon.log"),
+		"TUILog":       filepath.Join(root, "logs", "mihari-tui.log"),
+		"MihomoLog":    filepath.Join(root, "logs", "mihomo.log"),
+		"LogExportDir": filepath.Join(root, "logs-export"),
+	}
+	gots := map[string]string{
+		"LogDir":       paths.LogDir,
+		"DaemonLog":    paths.DaemonLog,
+		"TUILog":       paths.TUILog,
+		"MihomoLog":    paths.MihomoLog,
+		"LogExportDir": paths.LogExportDir,
+	}
+	for name, wantPath := range want {
+		if got := gots[name]; got != wantPath {
+			t.Errorf("%s=%q want=%q", name, got, wantPath)
+		}
+	}
+}
+
+func TestEnsureDirsLoggingLayout(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "ensure-logging")
+	paths := NewPaths(root)
+	if err := paths.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(paths.LogDir)
+	if err != nil {
+		t.Fatalf("LogDir missing: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("LogDir %q is not a directory", paths.LogDir)
+	}
+	if _, err := os.Stat(paths.LogExportDir); !os.IsNotExist(err) {
+		t.Fatalf("LogExportDir %q should be absent, err=%v", paths.LogExportDir, err)
+	}
+}
+
+func TestPathsAbsoluteRebuildsDerivedFields(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+
+	relative := NewPaths(filepath.Join(".", "relative-data"))
+	abs, err := relative.Absolute()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !filepath.IsAbs(abs.Root) {
+		t.Fatalf("Root=%q want absolute", abs.Root)
+	}
+	wantRoot, err := filepath.Abs(filepath.Join(".", "relative-data"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantRoot = filepath.Clean(wantRoot)
+	if abs.Root != wantRoot {
+		t.Fatalf("Root=%q want=%q", abs.Root, wantRoot)
+	}
+	want := map[string]string{
+		"LogDir":       filepath.Join(wantRoot, "logs"),
+		"DaemonLog":    filepath.Join(wantRoot, "logs", "mihari-daemon.log"),
+		"TUILog":       filepath.Join(wantRoot, "logs", "mihari-tui.log"),
+		"MihomoLog":    filepath.Join(wantRoot, "logs", "mihomo.log"),
+		"LogExportDir": filepath.Join(wantRoot, "logs-export"),
+	}
+	gots := map[string]string{
+		"LogDir":       abs.LogDir,
+		"DaemonLog":    abs.DaemonLog,
+		"TUILog":       abs.TUILog,
+		"MihomoLog":    abs.MihomoLog,
+		"LogExportDir": abs.LogExportDir,
+	}
+	for name, wantPath := range want {
+		if got := gots[name]; got != wantPath {
+			t.Errorf("%s=%q want=%q", name, got, wantPath)
+		}
+	}
+	if relative.Root == abs.Root {
+		t.Fatalf("Absolute mutated original Root: %q", relative.Root)
+	}
+	if relative.LogDir == abs.LogDir {
+		t.Fatalf("Absolute mutated original LogDir: %q", relative.LogDir)
+	}
+
+	absoluteRoot := filepath.Join(t.TempDir(), "abs-data")
+	original := NewPaths(absoluteRoot)
+	roundTrip, err := original.Absolute()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantAbs := NewPaths(filepath.Clean(absoluteRoot))
+	if roundTrip != wantAbs {
+		t.Fatalf("absolute round-trip=%#v want=%#v", roundTrip, wantAbs)
+	}
+	if original.Root != absoluteRoot {
+		t.Fatalf("Absolute mutated absolute original Root: got=%q want=%q", original.Root, absoluteRoot)
 	}
 }

--- a/internal/platform/privatefs.go
+++ b/internal/platform/privatefs.go
@@ -55,7 +55,12 @@ func NewPrivateFS(dataRoot string) (*PrivateFS, error) {
 	if dataRoot == "" || !filepath.IsAbs(dataRoot) {
 		return nil, fmt.Errorf("private fs data root must be absolute")
 	}
-	fs := &PrivateFS{root: filepath.Clean(dataRoot)}
+	root := filepath.Clean(dataRoot)
+	volume := filepath.VolumeName(root)
+	if root == volume || root == volume+string(filepath.Separator) {
+		return nil, fmt.Errorf("private fs data root must not be a filesystem root")
+	}
+	fs := &PrivateFS{root: root}
 	if err := fs.openRoot(); err != nil {
 		return nil, err
 	}

--- a/internal/platform/privatefs.go
+++ b/internal/platform/privatefs.go
@@ -1,0 +1,333 @@
+package platform
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+const (
+	privateLogDirName    = "logs"
+	privateExportDirName = "logs-export"
+)
+
+// ErrIdentityMismatch is returned when OpenReadChecked sees a different identity.
+var ErrIdentityMismatch = errors.New("private fs file identity mismatch")
+
+var errPrivateFSClosed = fmt.Errorf("private fs: %w", os.ErrClosed)
+
+// PrivateFS is a closeable capability over a verified data-root directory.
+type PrivateFS struct {
+	mu     sync.RWMutex
+	dirsMu sync.Mutex
+	closed bool
+	root   string
+	plat   privateFSState
+}
+
+// FileIdentity is an opaque platform identity for a directory entry or open handle.
+type FileIdentity struct {
+	plat fileIdentity
+}
+
+// DirectoryIdentity is a closeable capability over a held directory handle.
+type DirectoryIdentity struct {
+	mu     sync.Mutex
+	closed bool
+	plat   dirIdentityState
+}
+
+// FileEntry is a no-follow directory listing record.
+type FileEntry struct {
+	Name     string
+	Mode     os.FileMode
+	Identity FileIdentity
+}
+
+// NewPrivateFS opens or creates an absolute data root and holds its identity.
+func NewPrivateFS(dataRoot string) (*PrivateFS, error) {
+	if dataRoot == "" || !filepath.IsAbs(dataRoot) {
+		return nil, fmt.Errorf("private fs data root must be absolute")
+	}
+	fs := &PrivateFS{root: filepath.Clean(dataRoot)}
+	if err := fs.openRoot(); err != nil {
+		return nil, err
+	}
+	return fs, nil
+}
+
+// EnsureDir creates or hardens logs/ or logs-export/ relative to the held root.
+func (fs *PrivateFS) EnsureDir(path string) error {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+	if fs.closed {
+		return errPrivateFSClosed
+	}
+	name, err := fs.resolveDir(path)
+	if err != nil {
+		return err
+	}
+	return fs.ensureDirLocked(name)
+}
+
+// OpenAppend opens a log or export file for append-create, no-follow.
+func (fs *PrivateFS) OpenAppend(path string) (*os.File, error) {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+	if fs.closed {
+		return nil, errPrivateFSClosed
+	}
+	dir, name, err := fs.resolveFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return fs.openAppendLocked(dir, name)
+}
+
+// OpenReadChecked opens a file no-follow and requires the handle identity to match.
+func (fs *PrivateFS) OpenReadChecked(path string, expected FileIdentity) (*os.File, error) {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+	if fs.closed {
+		return nil, errPrivateFSClosed
+	}
+	dir, name, err := fs.resolveFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return fs.openReadCheckedLocked(dir, name, expected)
+}
+
+// CreateTemp creates an exclusive temporary file in logs/ or logs-export/.
+func (fs *PrivateFS) CreateTemp(dir, pattern string) (*os.File, error) {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+	if fs.closed {
+		return nil, errPrivateFSClosed
+	}
+	name, err := fs.resolveDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	f, _, err := fs.createTempLocked(name, pattern)
+	return f, err
+}
+
+// ReplaceEmpty replaces path with a new empty inode. The caller must close its write handle first.
+func (fs *PrivateFS) ReplaceEmpty(path string) error {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+	if fs.closed {
+		return errPrivateFSClosed
+	}
+	dir, name, err := fs.resolveFile(path)
+	if err != nil {
+		return err
+	}
+	tmp, tmpName, err := fs.createTempLocked(dir, "mihari-empty-*")
+	if err != nil {
+		return err
+	}
+	removeTmp := true
+	defer func() {
+		if removeTmp {
+			_ = fs.removeLocked(dir, tmpName)
+		}
+	}()
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := fs.renameLocked(dir, tmpName, name, true); err != nil {
+		return err
+	}
+	removeTmp = false
+	return nil
+}
+
+// ReadDir lists no-follow entries of logs/ or logs-export/.
+func (fs *PrivateFS) ReadDir(path string) ([]FileEntry, error) {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+	if fs.closed {
+		return nil, errPrivateFSClosed
+	}
+	name, err := fs.resolveDir(path)
+	if err != nil {
+		return nil, err
+	}
+	return fs.readDirLocked(name)
+}
+
+// OpenDirIdentity duplicates a held logs/ or logs-export/ directory capability.
+func (fs *PrivateFS) OpenDirIdentity(path string) (*DirectoryIdentity, error) {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+	if fs.closed {
+		return nil, errPrivateFSClosed
+	}
+	name, err := fs.resolveDir(path)
+	if err != nil {
+		return nil, err
+	}
+	return fs.openDirIdentityLocked(name)
+}
+
+// Rename renames a file within the same verified logs/ or logs-export/ directory.
+func (fs *PrivateFS) Rename(oldpath, newpath string) error {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+	if fs.closed {
+		return errPrivateFSClosed
+	}
+	oldDir, oldName, err := fs.resolveFile(oldpath)
+	if err != nil {
+		return err
+	}
+	newDir, newName, err := fs.resolveFile(newpath)
+	if err != nil {
+		return err
+	}
+	if oldDir != newDir {
+		return fmt.Errorf("private fs rename must stay in the same directory")
+	}
+	return fs.renameLocked(oldDir, oldName, newName, false)
+}
+
+// Remove unlinks a file in logs/ or logs-export/.
+func (fs *PrivateFS) Remove(path string) error {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+	if fs.closed {
+		return errPrivateFSClosed
+	}
+	dir, name, err := fs.resolveFile(path)
+	if err != nil {
+		return err
+	}
+	return fs.removeLocked(dir, name)
+}
+
+// Close releases held directory handles. Repeat calls return nil.
+func (fs *PrivateFS) Close() error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	if fs.closed {
+		return nil
+	}
+	fs.closed = true
+	return fs.closePlatform()
+}
+
+func (fs *PrivateFS) resolve(path string) (parent, name string, err error) {
+	if path == "" {
+		return "", "", fmt.Errorf("private fs path is empty")
+	}
+	var rel string
+	if filepath.IsAbs(path) {
+		rel, err = filepath.Rel(fs.root, path)
+		if err != nil {
+			return "", "", fmt.Errorf("private fs path is outside data root")
+		}
+	} else {
+		if !isSingleSegment(path) {
+			return "", "", fmt.Errorf("private fs relative path must be a single segment")
+		}
+		rel = path
+	}
+	rel = filepath.Clean(rel)
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", "", fmt.Errorf("private fs path is outside data root")
+	}
+	name = filepath.Base(rel)
+	if !isSingleSegment(name) {
+		return "", "", fmt.Errorf("private fs path final segment is invalid")
+	}
+	parent = filepath.Dir(rel)
+	if parent == "." {
+		parent = ""
+	}
+	return parent, name, nil
+}
+
+func (fs *PrivateFS) resolveDir(path string) (string, error) {
+	parent, name, err := fs.resolve(path)
+	if err != nil {
+		return "", err
+	}
+	if parent != "" {
+		return "", fmt.Errorf("private fs directory must be logs or logs-export")
+	}
+	canon, ok := canonicalChildDir(name)
+	if !ok {
+		return "", fmt.Errorf("private fs directory must be logs or logs-export")
+	}
+	return canon, nil
+}
+
+func (fs *PrivateFS) resolveFile(path string) (dir, name string, err error) {
+	parent, name, err := fs.resolve(path)
+	if err != nil {
+		return "", "", err
+	}
+	canon, ok := canonicalChildDir(parent)
+	if !ok {
+		return "", "", fmt.Errorf("private fs file must be a child of logs or logs-export")
+	}
+	return canon, name, nil
+}
+
+func canonicalChildDir(name string) (string, bool) {
+	switch {
+	case name == privateLogDirName:
+		return privateLogDirName, true
+	case name == privateExportDirName:
+		return privateExportDirName, true
+	case runtime.GOOS == "windows" && strings.EqualFold(name, privateLogDirName):
+		return privateLogDirName, true
+	case runtime.GOOS == "windows" && strings.EqualFold(name, privateExportDirName):
+		return privateExportDirName, true
+	}
+	return "", false
+}
+
+func isSingleSegment(name string) bool {
+	if name == "" || name == "." || name == ".." {
+		return false
+	}
+	if strings.ContainsRune(name, '/') || strings.ContainsRune(name, '\\') {
+		return false
+	}
+	return name == filepath.Base(name)
+}
+
+func randomTempName(pattern string) (string, error) {
+	if strings.ContainsRune(pattern, '/') || strings.ContainsRune(pattern, '\\') {
+		return "", fmt.Errorf("private fs temp pattern must be a single segment")
+	}
+	prefix, suffix := pattern, ""
+	if i := strings.LastIndex(pattern, "*"); i >= 0 {
+		prefix, suffix = pattern[:i], pattern[i+1:]
+	}
+	if pattern == "" {
+		prefix = "tmp"
+	}
+	if prefix == "." || prefix == ".." || suffix == ".." {
+		return "", fmt.Errorf("private fs temp pattern is invalid")
+	}
+	var buf [8]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", err
+	}
+	return prefix + strconv.FormatUint(binary.BigEndian.Uint64(buf[:]), 16) + suffix, nil
+}

--- a/internal/platform/privatefs.go
+++ b/internal/platform/privatefs.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -285,20 +284,6 @@ func (fs *PrivateFS) resolveFile(path string) (dir, name string, err error) {
 		return "", "", fmt.Errorf("private fs file must be a child of logs or logs-export")
 	}
 	return canon, name, nil
-}
-
-func canonicalChildDir(name string) (string, bool) {
-	switch {
-	case name == privateLogDirName:
-		return privateLogDirName, true
-	case name == privateExportDirName:
-		return privateExportDirName, true
-	case runtime.GOOS == "windows" && strings.EqualFold(name, privateLogDirName):
-		return privateLogDirName, true
-	case runtime.GOOS == "windows" && strings.EqualFold(name, privateExportDirName):
-		return privateExportDirName, true
-	}
-	return "", false
 }
 
 func isSingleSegment(name string) bool {

--- a/internal/platform/privatefs_rename_darwin.go
+++ b/internal/platform/privatefs_rename_darwin.go
@@ -1,0 +1,9 @@
+//go:build darwin
+
+package platform
+
+import "golang.org/x/sys/unix"
+
+func renameatNoReplace(dirfd int, oldName, newName string) error {
+	return unix.RenameatxNp(dirfd, oldName, dirfd, newName, unix.RENAME_EXCL)
+}

--- a/internal/platform/privatefs_rename_linux.go
+++ b/internal/platform/privatefs_rename_linux.go
@@ -1,0 +1,9 @@
+//go:build linux
+
+package platform
+
+import "golang.org/x/sys/unix"
+
+func renameatNoReplace(dirfd int, oldName, newName string) error {
+	return unix.Renameat2(dirfd, oldName, dirfd, newName, unix.RENAME_NOREPLACE)
+}

--- a/internal/platform/privatefs_rename_unix_other.go
+++ b/internal/platform/privatefs_rename_unix_other.go
@@ -1,0 +1,9 @@
+//go:build unix && !linux && !darwin
+
+package platform
+
+import "errors"
+
+func renameatNoReplace(dirfd int, oldName, newName string) error {
+	return errors.New("atomic no-replace rename is unsupported on this platform")
+}

--- a/internal/platform/privatefs_test.go
+++ b/internal/platform/privatefs_test.go
@@ -170,7 +170,10 @@ func TestPrivateFS_OpenReadCheckedIdentityMismatch(t *testing.T) {
 		t.Fatal(err)
 	}
 	ident := identityOf(t, entries, filepath.Base(paths.DaemonLog))
-	if err := fs.Remove(paths.DaemonLog); err != nil {
+	// Keep the old inode allocated under another directory entry. Some Unix
+	// filesystems immediately reuse an unlinked inode, which would make this
+	// identity-mismatch fixture nondeterministic.
+	if err := fs.Rename(paths.DaemonLog, paths.TUILog); err != nil {
 		t.Fatal(err)
 	}
 	if err := writeLog(fs, paths.DaemonLog, "second\n"); err != nil {

--- a/internal/platform/privatefs_test.go
+++ b/internal/platform/privatefs_test.go
@@ -2,9 +2,11 @@ package platform
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 )
 
@@ -302,6 +304,58 @@ func TestPrivateFS_RenameRequiresSameDirectory(t *testing.T) {
 	}
 	if !containsFile(entries, filepath.Base(paths.DaemonLog)+".1") {
 		t.Fatal("renamed file missing")
+	}
+}
+
+func TestPrivateFS_ConcurrentReadDirSeesCompleteUniqueNames(t *testing.T) {
+	fs, paths := openTestPrivateFS(t)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	const n = 64
+	want := make(map[string]struct{}, n)
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("entry-%02d.log", i)
+		want[name] = struct{}{}
+		if err := writeLog(fs, filepath.Join(paths.LogDir, name), "x"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	const workers = 8
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			entries, err := fs.ReadDir(paths.LogDir)
+			if err != nil {
+				errs <- err
+				return
+			}
+			got := make(map[string]int, len(entries))
+			for _, entry := range entries {
+				got[entry.Name]++
+			}
+			if len(got) != n {
+				errs <- fmt.Errorf("unique names=%d want=%d", len(got), n)
+				return
+			}
+			for name := range want {
+				if got[name] != 1 {
+					errs <- fmt.Errorf("%s count=%d", name, got[name])
+					return
+				}
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
 	}
 }
 

--- a/internal/platform/privatefs_test.go
+++ b/internal/platform/privatefs_test.go
@@ -1,0 +1,380 @@
+package platform
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPrivateFS_RejectsRelativeDataRoot(t *testing.T) {
+	if _, err := NewPrivateFS("relative-data"); err == nil {
+		t.Fatal("expected relative data root to be rejected")
+	}
+	if _, err := NewPrivateFS(filepath.Join(".", "data")); err == nil {
+		t.Fatal("expected dotted relative data root to be rejected")
+	}
+}
+
+func TestPrivateFS_CreatesMissingDataRoot(t *testing.T) {
+	t.Setenv("MIHARI_CONTROL_CREDENTIAL", filepath.Join(t.TempDir(), "outside.token"))
+	root := filepath.Join(t.TempDir(), "data")
+	fs, err := NewPrivateFS(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = fs.Close() })
+	info, err := os.Stat(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("data root is not a directory: %s", root)
+	}
+}
+
+func TestPrivateFS_ControlCredentialOutsideRootIgnored(t *testing.T) {
+	outside := filepath.Join(t.TempDir(), "control.token")
+	if err := os.WriteFile(outside, []byte("token"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("MIHARI_CONTROL_CREDENTIAL", outside)
+	root := filepath.Join(t.TempDir(), "data")
+	fs, err := NewPrivateFS(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = fs.Close() })
+	if _, err := os.Stat(outside); err != nil {
+		t.Fatalf("outside credential was touched: %v", err)
+	}
+}
+
+func TestPrivateFS_AcceptsAbsoluteAndBasenamePaths(t *testing.T) {
+	fs, paths := openTestPrivateFS(t)
+	for _, dir := range []string{paths.LogDir, "logs", paths.LogExportDir, "logs-export"} {
+		if err := fs.EnsureDir(dir); err != nil {
+			t.Fatalf("EnsureDir(%q): %v", dir, err)
+		}
+	}
+	f, err := fs.OpenAppend(paths.DaemonLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("hello\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	for _, dir := range []string{paths.LogDir, "logs"} {
+		entries, err := fs.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("ReadDir(%q): %v", dir, err)
+		}
+		if !containsFile(entries, filepath.Base(paths.DaemonLog)) {
+			t.Fatalf("ReadDir(%q) missing %s: %+v", dir, filepath.Base(paths.DaemonLog), namesOf(entries))
+		}
+	}
+	tmp, err := fs.CreateTemp(paths.LogExportDir, "export-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tmp.Close(); err != nil {
+		t.Fatal(err)
+	}
+	id, err := fs.OpenDirIdentity("logs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := id.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := id.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPrivateFS_RejectsPathsOutsideDataRoot(t *testing.T) {
+	fs, _ := openTestPrivateFS(t)
+	outside := filepath.Join(t.TempDir(), "outside.log")
+	if err := fs.EnsureDir(outside); err == nil {
+		t.Fatal("expected outside EnsureDir to fail")
+	}
+	if _, err := fs.OpenAppend(outside); err == nil {
+		t.Fatal("expected outside OpenAppend to fail")
+	}
+}
+
+func TestPrivateFS_RejectsDotDotEscape(t *testing.T) {
+	fs, paths := openTestPrivateFS(t)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	escaped := filepath.Join(paths.LogDir, "..", "outside")
+	if err := fs.EnsureDir(escaped); err == nil {
+		t.Fatal("expected logs/../outside EnsureDir to fail")
+	}
+	if _, err := fs.OpenAppend(escaped); err == nil {
+		t.Fatal("expected logs/../outside OpenAppend to fail")
+	}
+	if _, err := fs.OpenAppend(filepath.Join(paths.Root, "outside")); err == nil {
+		t.Fatal("expected data-root sibling OpenAppend to fail")
+	}
+	if _, err := fs.CreateTemp(paths.Root, "tmp-*"); err == nil {
+		t.Fatal("expected CreateTemp on data root to fail")
+	}
+}
+
+func TestPrivateFS_RejectsDotAndDotDotNames(t *testing.T) {
+	fs, paths := openTestPrivateFS(t)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{".", ".."} {
+		if err := fs.EnsureDir(name); err == nil {
+			t.Fatalf("expected EnsureDir(%q) to fail", name)
+		}
+		if _, err := fs.OpenAppend(filepath.Join(paths.LogDir, name)); err == nil {
+			t.Fatalf("expected OpenAppend(%q) to fail", name)
+		}
+	}
+}
+
+func TestPrivateFS_FileOpsRejectDataRootSiblings(t *testing.T) {
+	fs, paths := openTestPrivateFS(t)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fs.OpenAppend(paths.Settings); err == nil {
+		t.Fatal("expected OpenAppend of mihari.yaml to fail")
+	}
+	if _, err := fs.OpenAppend("mihari.yaml"); err == nil {
+		t.Fatal("expected OpenAppend of data-root basename to fail")
+	}
+}
+
+func TestPrivateFS_OpenReadCheckedIdentityMismatch(t *testing.T) {
+	fs, paths := openTestPrivateFS(t)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeLog(fs, paths.DaemonLog, "first\n"); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := fs.ReadDir(paths.LogDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ident := identityOf(t, entries, filepath.Base(paths.DaemonLog))
+	if err := fs.Remove(paths.DaemonLog); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeLog(fs, paths.DaemonLog, "second\n"); err != nil {
+		t.Fatal(err)
+	}
+	f, err := fs.OpenReadChecked(paths.DaemonLog, ident)
+	if err == nil {
+		_ = f.Close()
+		t.Fatal("expected identity mismatch")
+	}
+	if !errors.Is(err, ErrIdentityMismatch) {
+		t.Fatalf("err=%v want ErrIdentityMismatch", err)
+	}
+}
+
+func TestPrivateFS_ReplaceEmptyKeepsOldHandleReadable(t *testing.T) {
+	fs, paths := openTestPrivateFS(t)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeLog(fs, paths.DaemonLog, "keep-me"); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := fs.ReadDir(paths.LogDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ident := identityOf(t, entries, filepath.Base(paths.DaemonLog))
+	old, err := fs.OpenReadChecked(paths.DaemonLog, ident)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = old.Close() })
+	if err := fs.ReplaceEmpty(paths.DaemonLog); err != nil {
+		t.Fatal(err)
+	}
+	got, err := io.ReadAll(old)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "keep-me" {
+		t.Fatalf("old handle got %q", got)
+	}
+	fresh, err := fs.OpenAppend(paths.DaemonLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := fresh.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = fresh.Close()
+	if info.Size() != 0 {
+		t.Fatalf("replaced file size=%d", info.Size())
+	}
+	entries, err = fs.ReadDir(paths.LogDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identityOf(t, entries, filepath.Base(paths.DaemonLog)) == ident {
+		t.Fatal("ReplaceEmpty did not produce a new identity")
+	}
+}
+
+func TestPrivateFS_CloseIdempotentAndBlocksOps(t *testing.T) {
+	fs, paths := openTestPrivateFS(t)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeLog(fs, paths.DaemonLog, "x"); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := fs.ReadDir(paths.LogDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ident := identityOf(t, entries, filepath.Base(paths.DaemonLog))
+	if err := fs.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := fs.Close(); err != nil {
+		t.Fatal(err)
+	}
+	ops := []struct {
+		name string
+		fn   func() error
+	}{
+		{"EnsureDir", func() error { return fs.EnsureDir(paths.LogDir) }},
+		{"OpenAppend", func() error { _, err := fs.OpenAppend(paths.DaemonLog); return err }},
+		{"OpenReadChecked", func() error { _, err := fs.OpenReadChecked(paths.DaemonLog, ident); return err }},
+		{"CreateTemp", func() error { _, err := fs.CreateTemp(paths.LogDir, "tmp-*"); return err }},
+		{"ReplaceEmpty", func() error { return fs.ReplaceEmpty(paths.DaemonLog) }},
+		{"ReadDir", func() error { _, err := fs.ReadDir(paths.LogDir); return err }},
+		{"OpenDirIdentity", func() error { _, err := fs.OpenDirIdentity(paths.LogDir); return err }},
+		{"Rename", func() error {
+			return fs.Rename(paths.DaemonLog, paths.DaemonLog+".1")
+		}},
+		{"Remove", func() error { return fs.Remove(paths.DaemonLog) }},
+	}
+	for _, op := range ops {
+		if err := op.fn(); !errors.Is(err, os.ErrClosed) {
+			t.Errorf("%s after Close: err=%v want os.ErrClosed", op.name, err)
+		}
+	}
+}
+
+func TestPrivateFS_RenameRequiresSameDirectory(t *testing.T) {
+	fs, paths := openTestPrivateFS(t)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := fs.EnsureDir(paths.LogExportDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeLog(fs, paths.DaemonLog, "x"); err != nil {
+		t.Fatal(err)
+	}
+	exportFile := filepath.Join(paths.LogExportDir, "moved.log")
+	if err := fs.Rename(paths.DaemonLog, exportFile); err == nil {
+		t.Fatal("expected cross-directory rename to fail")
+	}
+	if err := fs.Rename(paths.DaemonLog, paths.DaemonLog+".1"); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := fs.ReadDir(paths.LogDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if containsFile(entries, filepath.Base(paths.DaemonLog)) {
+		t.Fatal("original name still present")
+	}
+	if !containsFile(entries, filepath.Base(paths.DaemonLog)+".1") {
+		t.Fatal("renamed file missing")
+	}
+}
+
+func TestPrivateFS_OpenDirIdentityClosed(t *testing.T) {
+	fs, paths := openTestPrivateFS(t)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	id, err := fs.OpenDirIdentity(paths.LogDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := id.identity(); err != nil {
+		t.Fatal(err)
+	}
+	if err := id.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := id.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := id.identity(); !errors.Is(err, os.ErrClosed) {
+		t.Fatalf("identity after Close: %v", err)
+	}
+}
+
+func openTestPrivateFS(t *testing.T) (*PrivateFS, Paths) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "data")
+	fs, err := NewPrivateFS(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = fs.Close() })
+	return fs, NewPaths(root)
+}
+
+func writeLog(fs *PrivateFS, path, body string) error {
+	f, err := fs.OpenAppend(path)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write([]byte(body)); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+func containsFile(entries []FileEntry, name string) bool {
+	for _, entry := range entries {
+		if entry.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func namesOf(entries []FileEntry) []string {
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name)
+	}
+	return names
+}
+
+func identityOf(t *testing.T, entries []FileEntry, name string) FileIdentity {
+	t.Helper()
+	for _, entry := range entries {
+		if entry.Name == name {
+			return entry.Identity
+		}
+	}
+	t.Fatalf("missing entry %q in %v", name, namesOf(entries))
+	return FileIdentity{}
+}

--- a/internal/platform/privatefs_unix.go
+++ b/internal/platform/privatefs_unix.go
@@ -1,0 +1,412 @@
+//go:build unix
+
+package platform
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+var (
+	fstatFn    = unix.Fstat
+	fchownatFn = unix.Fchownat
+)
+
+type privateFSState struct {
+	rootFD int
+	dirs   map[string]int
+	uid    int
+	gid    int
+}
+
+type fileIdentity struct {
+	dev uint64
+	ino uint64
+}
+
+type dirIdentityState struct {
+	fd int
+	id fileIdentity
+}
+
+func (fs *PrivateFS) openRoot() error {
+	path := fs.root
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		if !isUnixNotExist(err) {
+			return fmt.Errorf("open private data root: %w", err)
+		}
+		if effectiveUID() == 0 {
+			return fmt.Errorf("private fs: refuse to create data root as root")
+		}
+		if err := unix.Mkdir(path, 0o700); err != nil && !errors.Is(err, unix.EEXIST) {
+			return fmt.Errorf("create private data root: %w", err)
+		}
+		fd, err = unix.Open(path, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+		if err != nil {
+			return fmt.Errorf("open private data root: %w", err)
+		}
+	}
+	var st unix.Stat_t
+	if err := fstatFn(fd, &st); err != nil {
+		_ = unix.Close(fd)
+		return fmt.Errorf("stat private data root: %w", err)
+	}
+	if st.Mode&unix.S_IFMT != unix.S_IFDIR {
+		_ = unix.Close(fd)
+		return fmt.Errorf("private data root is not a directory")
+	}
+	if err := unix.Fchmod(fd, 0o700); err != nil {
+		_ = unix.Close(fd)
+		return fmt.Errorf("chmod private data root: %w", err)
+	}
+	fs.plat.rootFD = fd
+	fs.plat.dirs = make(map[string]int)
+	fs.plat.uid = int(st.Uid)
+	fs.plat.gid = int(st.Gid)
+	return nil
+}
+
+func (fs *PrivateFS) closePlatform() error {
+	var errs []error
+	fs.dirsMu.Lock()
+	for name, fd := range fs.plat.dirs {
+		if fd >= 0 {
+			errs = append(errs, unix.Close(fd))
+		}
+		delete(fs.plat.dirs, name)
+	}
+	fs.dirsMu.Unlock()
+	if fs.plat.rootFD >= 0 {
+		errs = append(errs, unix.Close(fs.plat.rootFD))
+		fs.plat.rootFD = -1
+	}
+	return errors.Join(errs...)
+}
+
+func (fs *PrivateFS) ensureDirLocked(name string) error {
+	if err := unix.Mkdirat(fs.plat.rootFD, name, 0o700); err != nil && !errors.Is(err, unix.EEXIST) {
+		return fmt.Errorf("mkdir %s: %w", name, err)
+	}
+	fd, err := unix.Openat(fs.plat.rootFD, name, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return fmt.Errorf("open dir %s: %w", name, err)
+	}
+	var st unix.Stat_t
+	if err := fstatFn(fd, &st); err != nil {
+		_ = unix.Close(fd)
+		return fmt.Errorf("stat dir %s: %w", name, err)
+	}
+	if st.Mode&unix.S_IFMT != unix.S_IFDIR {
+		_ = unix.Close(fd)
+		return fmt.Errorf("%s is not a directory", name)
+	}
+	if err := unix.Fchmod(fd, 0o700); err != nil {
+		_ = unix.Close(fd)
+		return fmt.Errorf("chmod dir %s: %w", name, err)
+	}
+	if err := fs.chownat(fs.plat.rootFD, name); err != nil {
+		_ = unix.Close(fd)
+		return err
+	}
+	fs.dirsMu.Lock()
+	if old, ok := fs.plat.dirs[name]; ok {
+		fs.dirsMu.Unlock()
+		_ = unix.Close(fd)
+		_ = old
+		return nil
+	}
+	fs.plat.dirs[name] = fd
+	fs.dirsMu.Unlock()
+	return nil
+}
+
+func (fs *PrivateFS) dirFD(name string) (int, error) {
+	fs.dirsMu.Lock()
+	if fd, ok := fs.plat.dirs[name]; ok {
+		fs.dirsMu.Unlock()
+		return fd, nil
+	}
+	fs.dirsMu.Unlock()
+	fd, err := unix.Openat(fs.plat.rootFD, name, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return -1, fmt.Errorf("open dir %s: %w", name, err)
+	}
+	var st unix.Stat_t
+	if err := fstatFn(fd, &st); err != nil {
+		_ = unix.Close(fd)
+		return -1, err
+	}
+	if st.Mode&unix.S_IFMT != unix.S_IFDIR {
+		_ = unix.Close(fd)
+		return -1, fmt.Errorf("%s is not a directory", name)
+	}
+	fs.dirsMu.Lock()
+	if old, ok := fs.plat.dirs[name]; ok {
+		fs.dirsMu.Unlock()
+		_ = unix.Close(fd)
+		return old, nil
+	}
+	fs.plat.dirs[name] = fd
+	fs.dirsMu.Unlock()
+	return fd, nil
+}
+
+func (fs *PrivateFS) openAppendLocked(dir, name string) (*os.File, error) {
+	dirfd, err := fs.dirFD(dir)
+	if err != nil {
+		return nil, err
+	}
+	fd, err := unix.Openat(dirfd, name, unix.O_WRONLY|unix.O_APPEND|unix.O_CREAT|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open append %s: %w", name, err)
+	}
+	if err := unix.Fchmod(fd, 0o600); err != nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("chmod %s: %w", name, err)
+	}
+	if err := fs.chownat(dirfd, name); err != nil {
+		_ = unix.Close(fd)
+		return nil, err
+	}
+	var st unix.Stat_t
+	if err := fstatFn(fd, &st); err != nil {
+		_ = unix.Close(fd)
+		return nil, err
+	}
+	if st.Mode&unix.S_IFMT != unix.S_IFREG {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("%s is not a regular file", name)
+	}
+	return os.NewFile(uintptr(fd), name), nil
+}
+
+func (fs *PrivateFS) openReadCheckedLocked(dir, name string, expected FileIdentity) (*os.File, error) {
+	dirfd, err := fs.dirFD(dir)
+	if err != nil {
+		return nil, err
+	}
+	fd, err := unix.Openat(dirfd, name, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open read %s: %w", name, err)
+	}
+	var st unix.Stat_t
+	if err := fstatFn(fd, &st); err != nil {
+		_ = unix.Close(fd)
+		return nil, err
+	}
+	if st.Mode&unix.S_IFMT != unix.S_IFREG {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("%s is not a regular file", name)
+	}
+	got := FileIdentity{plat: identFromStat(&st)}
+	if got != expected {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("%w", ErrIdentityMismatch)
+	}
+	return os.NewFile(uintptr(fd), name), nil
+}
+
+func (fs *PrivateFS) createTempLocked(dir, pattern string) (*os.File, string, error) {
+	dirfd, err := fs.dirFD(dir)
+	if err != nil {
+		return nil, "", err
+	}
+	for i := 0; i < 100; i++ {
+		name, err := randomTempName(pattern)
+		if err != nil {
+			return nil, "", err
+		}
+		fd, err := unix.Openat(dirfd, name, unix.O_RDWR|unix.O_CREAT|unix.O_EXCL|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0o600)
+		if err != nil {
+			if errors.Is(err, unix.EEXIST) {
+				continue
+			}
+			return nil, "", fmt.Errorf("create temp %s: %w", name, err)
+		}
+		if err := unix.Fchmod(fd, 0o600); err != nil {
+			_ = unix.Close(fd)
+			_ = unix.Unlinkat(dirfd, name, 0)
+			return nil, "", err
+		}
+		if err := fs.chownat(dirfd, name); err != nil {
+			_ = unix.Close(fd)
+			_ = unix.Unlinkat(dirfd, name, 0)
+			return nil, "", err
+		}
+		return os.NewFile(uintptr(fd), name), name, nil
+	}
+	return nil, "", fmt.Errorf("create temp: exhausted names")
+}
+
+func (fs *PrivateFS) readDirLocked(dir string) ([]FileEntry, error) {
+	dirfd, err := fs.dirFD(dir)
+	if err != nil {
+		return nil, err
+	}
+	dup, err := dupCLOEXEC(dirfd)
+	if err != nil {
+		return nil, err
+	}
+	defer unix.Close(dup)
+	if _, err := unix.Seek(dup, 0, 0); err != nil {
+		return nil, err
+	}
+	names, err := readUnixDirNames(dup)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]FileEntry, 0, len(names))
+	for _, name := range names {
+		var st unix.Stat_t
+		if err := unix.Fstatat(dirfd, name, &st, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+			return nil, fmt.Errorf("stat %s: %w", name, err)
+		}
+		entries = append(entries, FileEntry{
+			Name:     name,
+			Mode:     modeFromStat(&st),
+			Identity: FileIdentity{plat: identFromStat(&st)},
+		})
+	}
+	return entries, nil
+}
+
+func (fs *PrivateFS) openDirIdentityLocked(name string) (*DirectoryIdentity, error) {
+	dirfd, err := fs.dirFD(name)
+	if err != nil {
+		return nil, err
+	}
+	dup, err := dupCLOEXEC(dirfd)
+	if err != nil {
+		return nil, err
+	}
+	var st unix.Stat_t
+	if err := fstatFn(dup, &st); err != nil {
+		_ = unix.Close(dup)
+		return nil, err
+	}
+	return &DirectoryIdentity{plat: dirIdentityState{fd: dup, id: identFromStat(&st)}}, nil
+}
+
+func (fs *PrivateFS) renameLocked(dir, oldName, newName string, replace bool) error {
+	dirfd, err := fs.dirFD(dir)
+	if err != nil {
+		return err
+	}
+	if !replace {
+		var st unix.Stat_t
+		if err := unix.Fstatat(dirfd, newName, &st, unix.AT_SYMLINK_NOFOLLOW); err == nil {
+			return fmt.Errorf("rename %s: %w", newName, os.ErrExist)
+		} else if !isUnixNotExist(err) {
+			return err
+		}
+	}
+	if err := unix.Renameat(dirfd, oldName, dirfd, newName); err != nil {
+		return fmt.Errorf("rename %s: %w", oldName, err)
+	}
+	return nil
+}
+
+func (fs *PrivateFS) removeLocked(dir, name string) error {
+	dirfd, err := fs.dirFD(dir)
+	if err != nil {
+		return err
+	}
+	var st unix.Stat_t
+	if err := unix.Fstatat(dirfd, name, &st, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return fmt.Errorf("remove %s: %w", name, err)
+	}
+	if st.Mode&unix.S_IFMT == unix.S_IFLNK {
+		return fmt.Errorf("remove %s: symlink is not allowed", name)
+	}
+	if err := unix.Unlinkat(dirfd, name, 0); err != nil {
+		return fmt.Errorf("remove %s: %w", name, err)
+	}
+	return nil
+}
+
+func (fs *PrivateFS) chownat(dirfd int, name string) error {
+	if effectiveUID() != 0 {
+		return nil
+	}
+	if err := fchownatFn(dirfd, name, fs.plat.uid, fs.plat.gid, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return fmt.Errorf("chown %s: %w", name, err)
+	}
+	return nil
+}
+
+// Close releases the duplicated directory handle. Repeat calls return nil.
+func (d *DirectoryIdentity) Close() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return nil
+	}
+	d.closed = true
+	if d.plat.fd >= 0 {
+		err := unix.Close(d.plat.fd)
+		d.plat.fd = -1
+		return err
+	}
+	return nil
+}
+
+func (d *DirectoryIdentity) identity() (FileIdentity, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return FileIdentity{}, errPrivateFSClosed
+	}
+	return FileIdentity{plat: d.plat.id}, nil
+}
+
+func identFromStat(st *unix.Stat_t) fileIdentity {
+	return fileIdentity{dev: uint64(st.Dev), ino: uint64(st.Ino)}
+}
+
+func modeFromStat(st *unix.Stat_t) os.FileMode {
+	mode := os.FileMode(st.Mode & 0o777)
+	switch st.Mode & unix.S_IFMT {
+	case unix.S_IFDIR:
+		mode |= os.ModeDir
+	case unix.S_IFLNK:
+		mode |= os.ModeSymlink
+	}
+	return mode
+}
+
+func dupCLOEXEC(fd int) (int, error) {
+	n, err := unix.FcntlInt(uintptr(fd), unix.F_DUPFD_CLOEXEC, 0)
+	if err == nil {
+		return n, nil
+	}
+	dup, err := unix.Dup(fd)
+	if err != nil {
+		return -1, err
+	}
+	unix.CloseOnExec(dup)
+	return dup, nil
+}
+
+func readUnixDirNames(fd int) ([]string, error) {
+	buf := make([]byte, 8192)
+	var names []string
+	for {
+		n, err := unix.ReadDirent(fd, buf)
+		if err != nil {
+			return nil, err
+		}
+		if n == 0 {
+			break
+		}
+		_, _, names = unix.ParseDirent(buf[:n], -1, names)
+	}
+	return names, nil
+}
+
+func isUnixNotExist(err error) bool {
+	return errors.Is(err, unix.ENOENT) || errors.Is(err, os.ErrNotExist)
+}

--- a/internal/platform/privatefs_unix.go
+++ b/internal/platform/privatefs_unix.go
@@ -242,20 +242,27 @@ func (fs *PrivateFS) createTempLocked(dir, pattern string) (*os.File, string, er
 	return nil, "", fmt.Errorf("create temp: exhausted names")
 }
 
+func canonicalChildDir(name string) (string, bool) {
+	switch name {
+	case privateLogDirName:
+		return privateLogDirName, true
+	case privateExportDirName:
+		return privateExportDirName, true
+	}
+	return "", false
+}
+
 func (fs *PrivateFS) readDirLocked(dir string) ([]FileEntry, error) {
 	dirfd, err := fs.dirFD(dir)
 	if err != nil {
 		return nil, err
 	}
-	dup, err := dupCLOEXEC(dirfd)
+	listfd, err := unix.Openat(dirfd, ".", unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("open dir listing %s: %w", dir, err)
 	}
-	defer unix.Close(dup)
-	if _, err := unix.Seek(dup, 0, 0); err != nil {
-		return nil, err
-	}
-	names, err := readUnixDirNames(dup)
+	defer unix.Close(listfd)
+	names, err := readUnixDirNames(listfd)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/platform/privatefs_unix.go
+++ b/internal/platform/privatefs_unix.go
@@ -11,8 +11,9 @@ import (
 )
 
 var (
-	fstatFn    = unix.Fstat
-	fchownatFn = unix.Fchownat
+	fstatFn             = unix.Fstat
+	fchownatFn          = unix.Fchownat
+	renameatNoReplaceFn = renameatNoReplace
 )
 
 type privateFSState struct {
@@ -160,17 +161,9 @@ func (fs *PrivateFS) openAppendLocked(dir, name string) (*os.File, error) {
 	if err != nil {
 		return nil, err
 	}
-	fd, err := unix.Openat(dirfd, name, unix.O_WRONLY|unix.O_APPEND|unix.O_CREAT|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0o600)
+	fd, err := unix.Openat(dirfd, name, unix.O_WRONLY|unix.O_APPEND|unix.O_CREAT|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("open append %s: %w", name, err)
-	}
-	if err := unix.Fchmod(fd, 0o600); err != nil {
-		_ = unix.Close(fd)
-		return nil, fmt.Errorf("chmod %s: %w", name, err)
-	}
-	if err := fs.chownat(dirfd, name); err != nil {
-		_ = unix.Close(fd)
-		return nil, err
 	}
 	var st unix.Stat_t
 	if err := fstatFn(fd, &st); err != nil {
@@ -180,6 +173,18 @@ func (fs *PrivateFS) openAppendLocked(dir, name string) (*os.File, error) {
 	if st.Mode&unix.S_IFMT != unix.S_IFREG {
 		_ = unix.Close(fd)
 		return nil, fmt.Errorf("%s is not a regular file", name)
+	}
+	if err := unix.SetNonblock(fd, false); err != nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("clear nonblocking mode for %s: %w", name, err)
+	}
+	if err := unix.Fchmod(fd, 0o600); err != nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("chmod %s: %w", name, err)
+	}
+	if err := fs.chownat(dirfd, name); err != nil {
+		_ = unix.Close(fd)
+		return nil, err
 	}
 	return os.NewFile(uintptr(fd), name), nil
 }
@@ -307,16 +312,14 @@ func (fs *PrivateFS) renameLocked(dir, oldName, newName string, replace bool) er
 	if err != nil {
 		return err
 	}
-	if !replace {
-		var st unix.Stat_t
-		if err := unix.Fstatat(dirfd, newName, &st, unix.AT_SYMLINK_NOFOLLOW); err == nil {
-			return fmt.Errorf("rename %s: %w", newName, os.ErrExist)
-		} else if !isUnixNotExist(err) {
-			return err
-		}
+	var renameErr error
+	if replace {
+		renameErr = unix.Renameat(dirfd, oldName, dirfd, newName)
+	} else {
+		renameErr = renameatNoReplaceFn(dirfd, oldName, newName)
 	}
-	if err := unix.Renameat(dirfd, oldName, dirfd, newName); err != nil {
-		return fmt.Errorf("rename %s: %w", oldName, err)
+	if renameErr != nil {
+		return fmt.Errorf("rename %s: %w", oldName, renameErr)
 	}
 	return nil
 }
@@ -379,12 +382,27 @@ func identFromStat(st *unix.Stat_t) fileIdentity {
 }
 
 func modeFromStat(st *unix.Stat_t) os.FileMode {
-	mode := os.FileMode(st.Mode & 0o777)
-	switch st.Mode & unix.S_IFMT {
+	return modeFromUnixMode(uint32(st.Mode))
+}
+
+func modeFromUnixMode(statMode uint32) os.FileMode {
+	mode := os.FileMode(statMode & 0o777)
+	switch statMode & unix.S_IFMT {
 	case unix.S_IFDIR:
 		mode |= os.ModeDir
 	case unix.S_IFLNK:
 		mode |= os.ModeSymlink
+	case unix.S_IFIFO:
+		mode |= os.ModeNamedPipe
+	case unix.S_IFSOCK:
+		mode |= os.ModeSocket
+	case unix.S_IFBLK:
+		mode |= os.ModeDevice
+	case unix.S_IFCHR:
+		mode |= os.ModeDevice | os.ModeCharDevice
+	case unix.S_IFREG:
+	default:
+		mode |= os.ModeIrregular
 	}
 	return mode
 }

--- a/internal/platform/privatefs_unix.go
+++ b/internal/platform/privatefs_unix.go
@@ -261,7 +261,11 @@ func (fs *PrivateFS) readDirLocked(dir string) ([]FileEntry, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open dir listing %s: %w", dir, err)
 	}
-	defer unix.Close(listfd)
+	defer func() {
+		// The listing result has already been read; a close failure cannot be
+		// recovered here and is safe to ignore during descriptor cleanup.
+		_ = unix.Close(listfd)
+	}()
 	names, err := readUnixDirNames(listfd)
 	if err != nil {
 		return nil, err

--- a/internal/platform/privatefs_unix_test.go
+++ b/internal/platform/privatefs_unix_test.go
@@ -3,13 +3,29 @@
 package platform
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
+
+func TestPrivateFS_UnixRejectsFilesystemRootBeforeHardening(t *testing.T) {
+	fs, err := NewPrivateFS(string(filepath.Separator))
+	if fs != nil {
+		_ = fs.Close()
+	}
+	if err == nil {
+		t.Fatal("expected filesystem root to be rejected")
+	}
+	if !strings.Contains(err.Error(), "filesystem root") {
+		t.Fatalf("error=%q want filesystem-root validation", err)
+	}
+}
 
 func TestPrivateFS_UnixPermissions(t *testing.T) {
 	fs, paths := openTestPrivateFS(t)
@@ -82,22 +98,22 @@ func TestPrivateFS_UnixRootOwnerFromDataRootFD(t *testing.T) {
 	t.Cleanup(func() {
 		effectiveUID, fstatFn, fchownatFn = origUID, origFstat, origFchownat
 	})
-	t.Setenv("HOME", "/root")
-	t.Setenv("SUDO_USER", "attacker")
 	effectiveUID = func() int { return 0 }
 
 	root := filepath.Join(t.TempDir(), "data")
 	if err := os.Mkdir(root, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	var rootFDs []int
+	var fstatFDs []int
 	fstatFn = func(fd int, st *unix.Stat_t) error {
 		if err := unix.Fstat(fd, st); err != nil {
 			return err
 		}
-		rootFDs = append(rootFDs, fd)
-		st.Uid = 42
-		st.Gid = 43
+		fstatFDs = append(fstatFDs, fd)
+		if len(fstatFDs) == 1 {
+			st.Uid = 42
+			st.Gid = 43
+		}
 		return nil
 	}
 	var chowns []string
@@ -108,9 +124,6 @@ func TestPrivateFS_UnixRootOwnerFromDataRootFD(t *testing.T) {
 		if flags&unix.AT_SYMLINK_NOFOLLOW == 0 {
 			t.Fatal("expected AT_SYMLINK_NOFOLLOW")
 		}
-		if path == "/root" || filepath.Base(path) == "root" {
-			t.Fatalf("fchownat used path %q", path)
-		}
 		chowns = append(chowns, path)
 		return nil
 	}
@@ -120,8 +133,11 @@ func TestPrivateFS_UnixRootOwnerFromDataRootFD(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = fs.Close() })
-	if len(rootFDs) == 0 {
-		t.Fatal("expected fstat of data root fd")
+	if len(fstatFDs) != 1 || fstatFDs[0] != fs.plat.rootFD {
+		t.Fatalf("fstat fds=%v want only root fd %d during construction", fstatFDs, fs.plat.rootFD)
+	}
+	if fs.plat.uid != 42 || fs.plat.gid != 43 {
+		t.Fatalf("owner=%d:%d want 42:43", fs.plat.uid, fs.plat.gid)
 	}
 	paths := NewPaths(root)
 	if err := fs.EnsureDir(paths.LogDir); err != nil {
@@ -255,6 +271,146 @@ func TestPrivateFS_UnixFileSymlinkDoesNotAppendYAML(t *testing.T) {
 	}
 	if string(got) != "keep-yaml" {
 		t.Fatalf("yaml mutated: %q", got)
+	}
+}
+
+func TestPrivateFS_UnixOpenAppendRejectsFIFOWithoutBlockingOrHardening(t *testing.T) {
+	fs, paths := openTestPrivateFS(t)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := unix.Mkfifo(paths.DaemonLog, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(paths.DaemonLog, 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	type result struct {
+		file *os.File
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		f, err := fs.OpenAppend(paths.DaemonLog)
+		done <- result{file: f, err: err}
+	}()
+
+	var got result
+	select {
+	case got = <-done:
+	case <-time.After(250 * time.Millisecond):
+		t.Error("OpenAppend blocked while opening a FIFO")
+		reader, err := unix.Open(paths.DaemonLog, unix.O_RDONLY|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
+		if err != nil {
+			t.Fatalf("open FIFO reader to release blocked OpenAppend: %v", err)
+		}
+		got = <-done
+		if err := unix.Close(reader); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got.file != nil {
+		_ = got.file.Close()
+	}
+	if got.err == nil {
+		t.Fatal("expected FIFO append to be rejected")
+	}
+	info, err := os.Lstat(paths.DaemonLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o640 {
+		t.Fatalf("FIFO permissions=%v want=0640", got)
+	}
+}
+
+func TestPrivateFS_UnixRenameDoesNotReplaceExistingDestination(t *testing.T) {
+	fs, paths := openTestPrivateFS(t)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeLog(fs, paths.DaemonLog, "source"); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeLog(fs, paths.TUILog, "destination"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := fs.Rename(paths.DaemonLog, paths.TUILog)
+	if !errors.Is(err, os.ErrExist) {
+		t.Fatalf("rename error=%v want os.ErrExist", err)
+	}
+	for path, want := range map[string]string{
+		paths.DaemonLog: "source",
+		paths.TUILog:    "destination",
+	} {
+		got, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if string(got) != want {
+			t.Fatalf("%s=%q want=%q", filepath.Base(path), got, want)
+		}
+	}
+}
+
+func TestPrivateFS_UnixRenameUsesAtomicNoReplacePrimitive(t *testing.T) {
+	fs, paths := openTestPrivateFS(t)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeLog(fs, paths.DaemonLog, "source"); err != nil {
+		t.Fatal(err)
+	}
+
+	original := renameatNoReplaceFn
+	t.Cleanup(func() { renameatNoReplaceFn = original })
+	called := false
+	renameatNoReplaceFn = func(dirfd int, oldName, newName string) error {
+		called = true
+		if dirfd != fs.plat.dirs[privateLogDirName] || oldName != filepath.Base(paths.DaemonLog) || newName != filepath.Base(paths.TUILog) {
+			t.Fatalf("rename args=(%d,%q,%q)", dirfd, oldName, newName)
+		}
+		return unix.EEXIST
+	}
+
+	err := fs.Rename(paths.DaemonLog, paths.TUILog)
+	if !called {
+		t.Fatal("atomic no-replace primitive was not called")
+	}
+	if !errors.Is(err, os.ErrExist) {
+		t.Fatalf("rename error=%v want os.ErrExist", err)
+	}
+	if got, readErr := os.ReadFile(paths.DaemonLog); readErr != nil || string(got) != "source" {
+		t.Fatalf("source after failed rename=%q err=%v", got, readErr)
+	}
+	if _, statErr := os.Lstat(paths.TUILog); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("destination after failed rename: %v", statErr)
+	}
+}
+
+func TestModeFromStatPreservesUnixFileTypes(t *testing.T) {
+	tests := []struct {
+		name string
+		mode uint32
+		want os.FileMode
+	}{
+		{name: "regular", mode: unix.S_IFREG | 0o640, want: 0},
+		{name: "directory", mode: unix.S_IFDIR | 0o750, want: os.ModeDir},
+		{name: "symlink", mode: unix.S_IFLNK | 0o777, want: os.ModeSymlink},
+		{name: "fifo", mode: unix.S_IFIFO | 0o600, want: os.ModeNamedPipe},
+		{name: "socket", mode: unix.S_IFSOCK | 0o600, want: os.ModeSocket},
+		{name: "block device", mode: unix.S_IFBLK | 0o600, want: os.ModeDevice},
+		{name: "character device", mode: unix.S_IFCHR | 0o600, want: os.ModeDevice | os.ModeCharDevice},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := modeFromUnixMode(tt.mode)
+			if got.Type() != tt.want {
+				t.Fatalf("type=%v want=%v", got.Type(), tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/platform/privatefs_unix_test.go
+++ b/internal/platform/privatefs_unix_test.go
@@ -1,0 +1,292 @@
+//go:build unix
+
+package platform
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestPrivateFS_UnixPermissions(t *testing.T) {
+	fs, paths := openTestPrivateFS(t)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeLog(fs, paths.DaemonLog, "x"); err != nil {
+		t.Fatal(err)
+	}
+	assertMode(t, paths.LogDir, os.ModeDir|0o700)
+	assertMode(t, paths.DaemonLog, 0o600)
+}
+
+func TestPrivateFS_UnixUmaskStill0600(t *testing.T) {
+	old := unix.Umask(0o022)
+	t.Cleanup(func() { unix.Umask(old) })
+	fs, paths := openTestPrivateFS(t)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeLog(fs, paths.DaemonLog, "x"); err != nil {
+		t.Fatal(err)
+	}
+	assertMode(t, paths.DaemonLog, 0o600)
+	assertMode(t, paths.LogDir, os.ModeDir|0o700)
+}
+
+func TestPrivateFS_UnixTightenWidePermissions(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "data")
+	if err := os.Mkdir(root, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(root, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	fs, err := NewPrivateFS(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = fs.Close() })
+	assertMode(t, root, os.ModeDir|0o700)
+	logs := filepath.Join(root, "logs")
+	if err := os.Mkdir(logs, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(logs, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := fs.EnsureDir(logs); err != nil {
+		t.Fatal(err)
+	}
+	assertMode(t, logs, os.ModeDir|0o700)
+}
+
+func TestPrivateFS_UnixRefuseCreateRootAsRoot(t *testing.T) {
+	orig := effectiveUID
+	t.Cleanup(func() { effectiveUID = orig })
+	effectiveUID = func() int { return 0 }
+	root := filepath.Join(t.TempDir(), "missing")
+	if _, err := NewPrivateFS(root); err == nil {
+		t.Fatal("expected root missing-data-root to fail closed")
+	}
+	if _, err := os.Lstat(root); !os.IsNotExist(err) {
+		t.Fatalf("root created as privileged user: %v", err)
+	}
+}
+
+func TestPrivateFS_UnixRootOwnerFromDataRootFD(t *testing.T) {
+	origUID, origFstat, origFchownat := effectiveUID, fstatFn, fchownatFn
+	t.Cleanup(func() {
+		effectiveUID, fstatFn, fchownatFn = origUID, origFstat, origFchownat
+	})
+	t.Setenv("HOME", "/root")
+	t.Setenv("SUDO_USER", "attacker")
+	effectiveUID = func() int { return 0 }
+
+	root := filepath.Join(t.TempDir(), "data")
+	if err := os.Mkdir(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	var rootFDs []int
+	fstatFn = func(fd int, st *unix.Stat_t) error {
+		if err := unix.Fstat(fd, st); err != nil {
+			return err
+		}
+		rootFDs = append(rootFDs, fd)
+		st.Uid = 42
+		st.Gid = 43
+		return nil
+	}
+	var chowns []string
+	fchownatFn = func(dirfd int, path string, uid, gid, flags int) error {
+		if uid != 42 || gid != 43 {
+			t.Fatalf("fchownat uid=%d gid=%d", uid, gid)
+		}
+		if flags&unix.AT_SYMLINK_NOFOLLOW == 0 {
+			t.Fatal("expected AT_SYMLINK_NOFOLLOW")
+		}
+		if path == "/root" || filepath.Base(path) == "root" {
+			t.Fatalf("fchownat used path %q", path)
+		}
+		chowns = append(chowns, path)
+		return nil
+	}
+
+	fs, err := NewPrivateFS(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = fs.Close() })
+	if len(rootFDs) == 0 {
+		t.Fatal("expected fstat of data root fd")
+	}
+	paths := NewPaths(root)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeLog(fs, paths.DaemonLog, "x"); err != nil {
+		t.Fatal(err)
+	}
+	if len(chowns) == 0 {
+		t.Fatal("expected fchownat from data-root owner")
+	}
+}
+
+func TestPrivateFS_UnixDataRootSymlinkFollowed(t *testing.T) {
+	base := t.TempDir()
+	realRoot := filepath.Join(base, "real")
+	if err := os.Mkdir(realRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	linkRoot := filepath.Join(base, "link")
+	if err := os.Symlink(realRoot, linkRoot); err != nil {
+		t.Fatal(err)
+	}
+	fs, err := NewPrivateFS(linkRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = fs.Close() })
+	paths := NewPaths(linkRoot)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeLog(fs, paths.DaemonLog, "via-link"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(realRoot, "logs", filepath.Base(paths.DaemonLog)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "via-link" {
+		t.Fatalf("got %q", got)
+	}
+
+	id, err := fs.OpenDirIdentity(paths.LogDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = id.Close() })
+	held, err := id.identity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, err := os.Stat(filepath.Join(realRoot, "logs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sys, ok := st.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatal("missing Stat_t")
+	}
+	want := FileIdentity{plat: fileIdentity{dev: uint64(sys.Dev), ino: uint64(sys.Ino)}}
+	if held != want {
+		t.Fatalf("held identity %+v want %+v", held, want)
+	}
+}
+
+func TestPrivateFS_UnixLogDirSymlinkFailClosed(t *testing.T) {
+	fs, paths := openTestPrivateFS(t)
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.Mkdir(outside, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(outside, "marker")
+	if err := os.WriteFile(marker, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := fs.EnsureDir(paths.LogDir); err == nil {
+		t.Fatal("expected EnsureDir on symlink logs to fail")
+	}
+	if _, err := fs.OpenAppend(paths.DaemonLog); err == nil {
+		t.Fatal("expected OpenAppend through symlink logs to fail")
+	}
+	if _, err := fs.ReadDir(paths.LogDir); err == nil {
+		t.Fatal("expected ReadDir through symlink logs to fail")
+	}
+	if err := fs.Rename(paths.DaemonLog, paths.DaemonLog+".1"); err == nil {
+		t.Fatal("expected Rename through symlink logs to fail")
+	}
+	if err := fs.Remove(paths.DaemonLog); err == nil {
+		t.Fatal("expected Remove through symlink logs to fail")
+	}
+	if _, err := fs.OpenReadChecked(paths.DaemonLog, FileIdentity{}); err == nil {
+		t.Fatal("expected OpenReadChecked through symlink logs to fail")
+	}
+	got, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "keep" {
+		t.Fatalf("outside marker mutated: %q", got)
+	}
+	entries, err := os.ReadDir(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "marker" {
+		t.Fatalf("outside dir mutated: %v", entries)
+	}
+}
+
+func TestPrivateFS_UnixFileSymlinkDoesNotAppendYAML(t *testing.T) {
+	fs, paths := openTestPrivateFS(t)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.Settings, []byte("keep-yaml"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(paths.Settings, paths.DaemonLog); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fs.OpenAppend(paths.DaemonLog); err == nil {
+		t.Fatal("expected OpenAppend of symlink to fail")
+	}
+	got, err := os.ReadFile(paths.Settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "keep-yaml" {
+		t.Fatalf("yaml mutated: %q", got)
+	}
+}
+
+func TestPrivateFS_UnixCloseReleasesFDs(t *testing.T) {
+	fs, paths := openTestPrivateFS(t)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	rootFD := fs.plat.rootFD
+	logsFD := fs.plat.dirs[privateLogDirName]
+	if err := fs.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := unix.Fstat(rootFD, &unix.Stat_t{}); err == nil {
+		t.Fatal("root fd still open after Close")
+	}
+	if err := unix.Fstat(logsFD, &unix.Stat_t{}); err == nil {
+		t.Fatal("logs fd still open after Close")
+	}
+}
+
+func assertMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := info.Mode().Perm()
+	if info.IsDir() {
+		got |= os.ModeDir
+	}
+	if got != want {
+		t.Fatalf("%s mode=%v want=%v", path, got, want)
+	}
+}

--- a/internal/platform/privatefs_windows.go
+++ b/internal/platform/privatefs_windows.go
@@ -264,17 +264,27 @@ func (fs *PrivateFS) createTempLocked(dir, pattern string) (*os.File, string, er
 	return nil, "", fmt.Errorf("create temp: exhausted names")
 }
 
+func canonicalChildDir(name string) (string, bool) {
+	switch {
+	case strings.EqualFold(name, privateLogDirName):
+		return privateLogDirName, true
+	case strings.EqualFold(name, privateExportDirName):
+		return privateExportDirName, true
+	}
+	return "", false
+}
+
 func (fs *PrivateFS) readDirLocked(dir string) ([]FileEntry, error) {
 	parent, err := fs.dirHandle(dir)
 	if err != nil {
 		return nil, err
 	}
-	dup, err := dupHandle(parent)
+	list, err := openListingHandle(parent)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("open dir listing %s: %w", dir, err)
 	}
-	defer windows.CloseHandle(dup)
-	ents, err := readWindowsDirents(dup)
+	defer windows.CloseHandle(list)
+	ents, err := readWindowsDirents(list)
 	if err != nil {
 		return nil, err
 	}
@@ -514,6 +524,28 @@ func openNTPath(path string, access, disposition, options, attr uint32, sd *wind
 	err = windows.NtCreateFile(&h, access, &oa, &iosb, nil, attr, privateShare, disposition, options, 0, 0)
 	runtime.KeepAlive(name)
 	runtime.KeepAlive(sd)
+	if err != nil {
+		return 0, err
+	}
+	_ = windows.SetHandleInformation(h, windows.HANDLE_FLAG_INHERIT, 0)
+	return h, nil
+}
+
+func openListingHandle(parent windows.Handle) (windows.Handle, error) {
+	// NT rejects "." as an object name. An empty name with RootDirectory
+	// reopens the same directory as a new FILE_OBJECT (independent enumeration).
+	var empty windows.NTUnicodeString
+	access := uint32(windows.FILE_LIST_DIRECTORY | windows.SYNCHRONIZE | windows.FILE_READ_ATTRIBUTES)
+	oa := windows.OBJECT_ATTRIBUTES{
+		RootDirectory: parent,
+		ObjectName:    &empty,
+		Attributes:    windows.OBJ_CASE_INSENSITIVE,
+	}
+	oa.Length = uint32(unsafe.Sizeof(oa))
+	var h windows.Handle
+	var iosb windows.IO_STATUS_BLOCK
+	err := windows.NtCreateFile(&h, access, &oa, &iosb, nil, windows.FILE_ATTRIBUTE_DIRECTORY, privateShare, windows.FILE_OPEN,
+		windows.FILE_DIRECTORY_FILE|windows.FILE_OPEN_REPARSE_POINT|windows.FILE_SYNCHRONOUS_IO_NONALERT, 0, 0)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/platform/privatefs_windows.go
+++ b/internal/platform/privatefs_windows.go
@@ -1,0 +1,739 @@
+//go:build windows
+
+package platform
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	privateShare                 = windows.FILE_SHARE_READ | windows.FILE_SHARE_WRITE | windows.FILE_SHARE_DELETE
+	dirAccess                    = windows.FILE_GENERIC_READ | windows.FILE_GENERIC_WRITE | windows.FILE_GENERIC_EXECUTE | windows.WRITE_DAC
+	fileRenameInformationExClass = 65
+)
+
+var processIsLocalSystem = currentProcessIsLocalSystem
+
+type privateFSState struct {
+	root  windows.Handle
+	dirs  map[string]windows.Handle
+	owner *windows.SID
+}
+
+type fileIdentity struct {
+	volume uint64
+	fileID [16]byte
+}
+
+type dirIdentityState struct {
+	handle windows.Handle
+	id     fileIdentity
+}
+
+type fileIDInfo struct {
+	VolumeSerialNumber uint64
+	FileID             [16]byte
+}
+
+type fileAttributeTagInfo struct {
+	FileAttributes uint32
+	ReparseTag     uint32
+}
+
+type fileRenameInformationEx struct {
+	Flags          uint32
+	RootDirectory  windows.Handle
+	FileNameLength uint32
+	FileName       [1]uint16
+}
+
+func (fs *PrivateFS) openRoot() error {
+	h, err := openNTPath(fs.root, dirAccess, windows.FILE_OPEN, windows.FILE_DIRECTORY_FILE|windows.FILE_SYNCHRONOUS_IO_NONALERT, windows.FILE_ATTRIBUTE_DIRECTORY, nil)
+	if isWindowsNotFound(err) {
+		privileged, perr := processIsLocalSystem()
+		if perr != nil {
+			return fmt.Errorf("query LocalSystem membership: %w", perr)
+		}
+		if privileged {
+			return fmt.Errorf("private fs: refuse to create data root as LocalSystem")
+		}
+		if err := createDataRoot(fs.root); err != nil && !isWindowsExist(err) {
+			return fmt.Errorf("create private data root: %w", err)
+		}
+		h, err = openNTPath(fs.root, dirAccess, windows.FILE_OPEN, windows.FILE_DIRECTORY_FILE|windows.FILE_SYNCHRONOUS_IO_NONALERT, windows.FILE_ATTRIBUTE_DIRECTORY, nil)
+	}
+	if err != nil {
+		return fmt.Errorf("open private data root: %w", err)
+	}
+	attr, err := handleAttributes(h)
+	if err != nil {
+		_ = windows.CloseHandle(h)
+		return fmt.Errorf("stat private data root: %w", err)
+	}
+	if attr&windows.FILE_ATTRIBUTE_DIRECTORY == 0 {
+		_ = windows.CloseHandle(h)
+		return fmt.Errorf("private data root is not a directory")
+	}
+	if err := fs.loadOwner(h); err != nil {
+		_ = windows.CloseHandle(h)
+		return err
+	}
+	if err := hardenHandle(h, fs.dirSDDL()); err != nil {
+		_ = windows.CloseHandle(h)
+		return fmt.Errorf("harden private data root: %w", err)
+	}
+	fs.plat.root = h
+	fs.plat.dirs = make(map[string]windows.Handle)
+	return nil
+}
+
+func (fs *PrivateFS) closePlatform() error {
+	var errs []error
+	fs.dirsMu.Lock()
+	for name, h := range fs.plat.dirs {
+		if h != 0 {
+			errs = append(errs, windows.CloseHandle(h))
+		}
+		delete(fs.plat.dirs, name)
+	}
+	fs.dirsMu.Unlock()
+	if fs.plat.root != 0 {
+		errs = append(errs, windows.CloseHandle(fs.plat.root))
+		fs.plat.root = 0
+	}
+	return errors.Join(errs...)
+}
+
+func (fs *PrivateFS) ensureDirLocked(name string) error {
+	sd, err := windows.SecurityDescriptorFromString(fs.dirSDDL())
+	if err != nil {
+		return err
+	}
+	h, err := openRelative(fs.plat.root, name, dirAccess, windows.FILE_OPEN_IF,
+		windows.FILE_DIRECTORY_FILE|windows.FILE_OPEN_REPARSE_POINT|windows.FILE_SYNCHRONOUS_IO_NONALERT,
+		windows.FILE_ATTRIBUTE_DIRECTORY, sd)
+	if err != nil {
+		return fmt.Errorf("open dir %s: %w", name, err)
+	}
+	if err := rejectReparse(h, name); err != nil {
+		_ = windows.CloseHandle(h)
+		return err
+	}
+	if err := hardenHandle(h, fs.dirSDDL()); err != nil {
+		_ = windows.CloseHandle(h)
+		return fmt.Errorf("harden dir %s: %w", name, err)
+	}
+	fs.dirsMu.Lock()
+	if old, ok := fs.plat.dirs[name]; ok {
+		fs.dirsMu.Unlock()
+		_ = windows.CloseHandle(h)
+		_ = old
+		return nil
+	}
+	fs.plat.dirs[name] = h
+	fs.dirsMu.Unlock()
+	return nil
+}
+
+func (fs *PrivateFS) dirHandle(name string) (windows.Handle, error) {
+	fs.dirsMu.Lock()
+	if h, ok := fs.plat.dirs[name]; ok {
+		fs.dirsMu.Unlock()
+		return h, nil
+	}
+	fs.dirsMu.Unlock()
+	h, err := openRelative(fs.plat.root, name, dirAccess, windows.FILE_OPEN,
+		windows.FILE_DIRECTORY_FILE|windows.FILE_OPEN_REPARSE_POINT|windows.FILE_SYNCHRONOUS_IO_NONALERT,
+		windows.FILE_ATTRIBUTE_DIRECTORY, nil)
+	if err != nil {
+		return 0, fmt.Errorf("open dir %s: %w", name, err)
+	}
+	if err := rejectReparse(h, name); err != nil {
+		_ = windows.CloseHandle(h)
+		return 0, err
+	}
+	fs.dirsMu.Lock()
+	if old, ok := fs.plat.dirs[name]; ok {
+		fs.dirsMu.Unlock()
+		_ = windows.CloseHandle(h)
+		return old, nil
+	}
+	fs.plat.dirs[name] = h
+	fs.dirsMu.Unlock()
+	return h, nil
+}
+
+func (fs *PrivateFS) openAppendLocked(dir, name string) (*os.File, error) {
+	parent, err := fs.dirHandle(dir)
+	if err != nil {
+		return nil, err
+	}
+	sd, err := windows.SecurityDescriptorFromString(fs.fileSDDL())
+	if err != nil {
+		return nil, err
+	}
+	access := uint32(windows.FILE_APPEND_DATA | windows.FILE_GENERIC_READ | windows.WRITE_DAC | windows.SYNCHRONIZE | windows.FILE_READ_ATTRIBUTES | windows.FILE_WRITE_ATTRIBUTES)
+	h, err := openRelative(parent, name, access, windows.FILE_OPEN_IF,
+		windows.FILE_NON_DIRECTORY_FILE|windows.FILE_OPEN_REPARSE_POINT|windows.FILE_SYNCHRONOUS_IO_NONALERT,
+		windows.FILE_ATTRIBUTE_NORMAL, sd)
+	if err != nil {
+		return nil, fmt.Errorf("open append %s: %w", name, err)
+	}
+	if err := rejectReparse(h, name); err != nil {
+		_ = windows.CloseHandle(h)
+		return nil, err
+	}
+	if err := hardenHandle(h, fs.fileSDDL()); err != nil {
+		_ = windows.CloseHandle(h)
+		return nil, fmt.Errorf("harden %s: %w", name, err)
+	}
+	return os.NewFile(uintptr(h), name), nil
+}
+
+func (fs *PrivateFS) openReadCheckedLocked(dir, name string, expected FileIdentity) (*os.File, error) {
+	parent, err := fs.dirHandle(dir)
+	if err != nil {
+		return nil, err
+	}
+	h, err := openRelative(parent, name, windows.FILE_GENERIC_READ, windows.FILE_OPEN,
+		windows.FILE_NON_DIRECTORY_FILE|windows.FILE_OPEN_REPARSE_POINT|windows.FILE_SYNCHRONOUS_IO_NONALERT,
+		0, nil)
+	if err != nil {
+		return nil, fmt.Errorf("open read %s: %w", name, err)
+	}
+	if err := rejectReparse(h, name); err != nil {
+		_ = windows.CloseHandle(h)
+		return nil, err
+	}
+	id, err := identityFromHandle(h)
+	if err != nil {
+		_ = windows.CloseHandle(h)
+		return nil, err
+	}
+	got := FileIdentity{plat: id}
+	if got != expected {
+		_ = windows.CloseHandle(h)
+		return nil, fmt.Errorf("%w", ErrIdentityMismatch)
+	}
+	return os.NewFile(uintptr(h), name), nil
+}
+
+func (fs *PrivateFS) createTempLocked(dir, pattern string) (*os.File, string, error) {
+	parent, err := fs.dirHandle(dir)
+	if err != nil {
+		return nil, "", err
+	}
+	sd, err := windows.SecurityDescriptorFromString(fs.fileSDDL())
+	if err != nil {
+		return nil, "", err
+	}
+	access := uint32(windows.FILE_GENERIC_READ | windows.FILE_GENERIC_WRITE | windows.DELETE | windows.WRITE_DAC)
+	for i := 0; i < 100; i++ {
+		name, err := randomTempName(pattern)
+		if err != nil {
+			return nil, "", err
+		}
+		h, err := openRelative(parent, name, access, windows.FILE_CREATE,
+			windows.FILE_NON_DIRECTORY_FILE|windows.FILE_OPEN_REPARSE_POINT|windows.FILE_SYNCHRONOUS_IO_NONALERT,
+			windows.FILE_ATTRIBUTE_NORMAL, sd)
+		if err != nil {
+			if isWindowsExist(err) {
+				continue
+			}
+			return nil, "", fmt.Errorf("create temp %s: %w", name, err)
+		}
+		if err := rejectReparse(h, name); err != nil {
+			_ = windows.CloseHandle(h)
+			return nil, "", err
+		}
+		if err := hardenHandle(h, fs.fileSDDL()); err != nil {
+			_ = windows.CloseHandle(h)
+			_ = fs.removeLocked(dir, name)
+			return nil, "", err
+		}
+		return os.NewFile(uintptr(h), name), name, nil
+	}
+	return nil, "", fmt.Errorf("create temp: exhausted names")
+}
+
+func (fs *PrivateFS) readDirLocked(dir string) ([]FileEntry, error) {
+	parent, err := fs.dirHandle(dir)
+	if err != nil {
+		return nil, err
+	}
+	dup, err := dupHandle(parent)
+	if err != nil {
+		return nil, err
+	}
+	defer windows.CloseHandle(dup)
+	ents, err := readWindowsDirents(dup)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]FileEntry, 0, len(ents))
+	for _, ent := range ents {
+		h, err := openRelative(parent, ent.name, windows.FILE_READ_ATTRIBUTES|windows.SYNCHRONIZE, windows.FILE_OPEN,
+			windows.FILE_OPEN_REPARSE_POINT|windows.FILE_SYNCHRONOUS_IO_NONALERT, 0, nil)
+		if err != nil {
+			return nil, fmt.Errorf("stat %s: %w", ent.name, err)
+		}
+		id, err := identityFromHandle(h)
+		attr, attrErr := handleAttributes(h)
+		_ = windows.CloseHandle(h)
+		if err != nil {
+			return nil, err
+		}
+		if attrErr != nil {
+			return nil, attrErr
+		}
+		entries = append(entries, FileEntry{
+			Name:     ent.name,
+			Mode:     modeFromAttributes(attr),
+			Identity: FileIdentity{plat: id},
+		})
+	}
+	return entries, nil
+}
+
+func (fs *PrivateFS) openDirIdentityLocked(name string) (*DirectoryIdentity, error) {
+	h, err := fs.dirHandle(name)
+	if err != nil {
+		return nil, err
+	}
+	dup, err := dupHandle(h)
+	if err != nil {
+		return nil, err
+	}
+	id, err := identityFromHandle(dup)
+	if err != nil {
+		_ = windows.CloseHandle(dup)
+		return nil, err
+	}
+	return &DirectoryIdentity{plat: dirIdentityState{handle: dup, id: id}}, nil
+}
+
+func (fs *PrivateFS) renameLocked(dir, oldName, newName string, replace bool) error {
+	parent, err := fs.dirHandle(dir)
+	if err != nil {
+		return err
+	}
+	h, err := openRelative(parent, oldName, windows.DELETE|windows.SYNCHRONIZE|windows.FILE_READ_ATTRIBUTES, windows.FILE_OPEN,
+		windows.FILE_NON_DIRECTORY_FILE|windows.FILE_OPEN_REPARSE_POINT|windows.FILE_SYNCHRONOUS_IO_NONALERT, 0, nil)
+	if err != nil {
+		return fmt.Errorf("rename %s: %w", oldName, err)
+	}
+	defer windows.CloseHandle(h)
+	if err := rejectReparse(h, oldName); err != nil {
+		return err
+	}
+	flags := uint32(windows.FILE_RENAME_POSIX_SEMANTICS)
+	if replace {
+		flags |= windows.FILE_RENAME_REPLACE_IF_EXISTS
+	}
+	if err := renameHandle(h, parent, newName, flags); err != nil {
+		return fmt.Errorf("rename %s: %w", oldName, err)
+	}
+	return nil
+}
+
+func (fs *PrivateFS) removeLocked(dir, name string) error {
+	parent, err := fs.dirHandle(dir)
+	if err != nil {
+		return err
+	}
+	h, err := openRelative(parent, name, windows.DELETE|windows.SYNCHRONIZE|windows.FILE_READ_ATTRIBUTES, windows.FILE_OPEN,
+		windows.FILE_NON_DIRECTORY_FILE|windows.FILE_OPEN_REPARSE_POINT|windows.FILE_SYNCHRONOUS_IO_NONALERT, 0, nil)
+	if err != nil {
+		return fmt.Errorf("remove %s: %w", name, err)
+	}
+	defer windows.CloseHandle(h)
+	if err := rejectReparse(h, name); err != nil {
+		return err
+	}
+	info := uint32(windows.FILE_DISPOSITION_DELETE | windows.FILE_DISPOSITION_POSIX_SEMANTICS)
+	var iosb windows.IO_STATUS_BLOCK
+	if err := windows.NtSetInformationFile(h, &iosb, (*byte)(unsafe.Pointer(&info)), uint32(unsafe.Sizeof(info)), windows.FileDispositionInformationEx); err != nil {
+		return fmt.Errorf("remove %s: %w", name, err)
+	}
+	return nil
+}
+
+// Close releases the duplicated directory handle. Repeat calls return nil.
+func (d *DirectoryIdentity) Close() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return nil
+	}
+	d.closed = true
+	if d.plat.handle != 0 {
+		err := windows.CloseHandle(d.plat.handle)
+		d.plat.handle = 0
+		return err
+	}
+	return nil
+}
+
+func (d *DirectoryIdentity) identity() (FileIdentity, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return FileIdentity{}, errPrivateFSClosed
+	}
+	return FileIdentity{plat: d.plat.id}, nil
+}
+
+func (fs *PrivateFS) loadOwner(h windows.Handle) error {
+	sd, err := windows.GetSecurityInfo(h, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION)
+	if err != nil {
+		return fmt.Errorf("query data root owner: %w", err)
+	}
+	owner, _, err := sd.Owner()
+	if err != nil || owner == nil {
+		return fmt.Errorf("query data root owner: %w", err)
+	}
+	copied, err := owner.Copy()
+	if err != nil {
+		return err
+	}
+	fs.plat.owner = copied
+	return nil
+}
+
+func (fs *PrivateFS) ownerIsSystem() bool {
+	if fs.plat.owner == nil {
+		return false
+	}
+	system, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	if err != nil {
+		return false
+	}
+	return fs.plat.owner.Equals(system)
+}
+
+func (fs *PrivateFS) dirSDDL() string {
+	if fs.ownerIsSystem() {
+		return "D:P(A;OICI;FA;;;SY)"
+	}
+	return "D:P(A;OICI;FA;;;" + fs.plat.owner.String() + ")(A;OICI;FA;;;SY)"
+}
+
+func (fs *PrivateFS) fileSDDL() string {
+	if fs.ownerIsSystem() {
+		return "D:P(A;;FA;;;SY)"
+	}
+	return "D:P(A;;FA;;;" + fs.plat.owner.String() + ")(A;;FA;;;SY)"
+}
+
+func currentProcessIsLocalSystem() (bool, error) {
+	sid, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	if err != nil {
+		return false, err
+	}
+	return windows.GetCurrentProcessToken().IsMember(sid)
+}
+
+func currentUserSID() (*windows.SID, error) {
+	tu, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		return nil, err
+	}
+	return tu.User.Sid.Copy()
+}
+
+func createDataRoot(path string) error {
+	sid, err := currentUserSID()
+	if err != nil {
+		return err
+	}
+	system, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	if err != nil {
+		return err
+	}
+	sddl := "D:P(A;OICI;FA;;;" + sid.String() + ")(A;OICI;FA;;;SY)"
+	if sid.Equals(system) {
+		sddl = "D:P(A;OICI;FA;;;SY)"
+	}
+	sd, err := windows.SecurityDescriptorFromString(sddl)
+	if err != nil {
+		return err
+	}
+	sa := windows.SecurityAttributes{
+		Length:             uint32(unsafe.Sizeof(windows.SecurityAttributes{})),
+		SecurityDescriptor: sd,
+		InheritHandle:      0,
+	}
+	p, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return err
+	}
+	err = windows.CreateDirectory(p, &sa)
+	runtime.KeepAlive(sd)
+	return err
+}
+
+func hardenHandle(h windows.Handle, sddl string) error {
+	sd, err := windows.SecurityDescriptorFromString(sddl)
+	if err != nil {
+		return err
+	}
+	dacl, _, err := sd.DACL()
+	if err != nil {
+		return err
+	}
+	err = windows.SetSecurityInfo(h, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, nil, nil, dacl, nil)
+	runtime.KeepAlive(sd)
+	return err
+}
+
+func openNTPath(path string, access, disposition, options, attr uint32, sd *windows.SECURITY_DESCRIPTOR) (windows.Handle, error) {
+	nt, err := toNTPath(path)
+	if err != nil {
+		return 0, err
+	}
+	name, err := windows.NewNTUnicodeString(nt)
+	if err != nil {
+		return 0, err
+	}
+	oa := windows.OBJECT_ATTRIBUTES{
+		ObjectName:         name,
+		Attributes:         windows.OBJ_CASE_INSENSITIVE,
+		SecurityDescriptor: sd,
+	}
+	oa.Length = uint32(unsafe.Sizeof(oa))
+	var h windows.Handle
+	var iosb windows.IO_STATUS_BLOCK
+	err = windows.NtCreateFile(&h, access, &oa, &iosb, nil, attr, privateShare, disposition, options, 0, 0)
+	runtime.KeepAlive(name)
+	runtime.KeepAlive(sd)
+	if err != nil {
+		return 0, err
+	}
+	_ = windows.SetHandleInformation(h, windows.HANDLE_FLAG_INHERIT, 0)
+	return h, nil
+}
+
+func openRelative(parent windows.Handle, name string, access, disposition, options, attr uint32, sd *windows.SECURITY_DESCRIPTOR) (windows.Handle, error) {
+	ntName, err := windows.NewNTUnicodeString(name)
+	if err != nil {
+		return 0, err
+	}
+	oa := windows.OBJECT_ATTRIBUTES{
+		RootDirectory:      parent,
+		ObjectName:         ntName,
+		Attributes:         windows.OBJ_CASE_INSENSITIVE,
+		SecurityDescriptor: sd,
+	}
+	oa.Length = uint32(unsafe.Sizeof(oa))
+	var h windows.Handle
+	var iosb windows.IO_STATUS_BLOCK
+	err = windows.NtCreateFile(&h, access, &oa, &iosb, nil, attr, privateShare, disposition, options, 0, 0)
+	runtime.KeepAlive(ntName)
+	runtime.KeepAlive(sd)
+	if err != nil {
+		return 0, err
+	}
+	_ = windows.SetHandleInformation(h, windows.HANDLE_FLAG_INHERIT, 0)
+	return h, nil
+}
+
+func toNTPath(path string) (string, error) {
+	p := path
+	if strings.HasPrefix(p, `\\?\UNC\`) {
+		return `\??\UNC\` + p[len(`\\?\UNC\`):], nil
+	}
+	if strings.HasPrefix(p, `\\?\`) {
+		return `\??\` + p[4:], nil
+	}
+	if strings.HasPrefix(p, `\\`) {
+		return `\??\UNC\` + strings.TrimPrefix(p, `\\`), nil
+	}
+	return `\??\` + p, nil
+}
+
+func rejectReparse(h windows.Handle, name string) error {
+	attr, err := handleAttributes(h)
+	if err != nil {
+		return err
+	}
+	if attr&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+		return fmt.Errorf("%s: reparse point or junction is not allowed", name)
+	}
+	return nil
+}
+
+func handleAttributes(h windows.Handle) (uint32, error) {
+	var info fileAttributeTagInfo
+	if err := windows.GetFileInformationByHandleEx(h, windows.FileAttributeTagInfo, (*byte)(unsafe.Pointer(&info)), uint32(unsafe.Sizeof(info))); err == nil {
+		return info.FileAttributes, nil
+	}
+	var bh windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(h, &bh); err != nil {
+		return 0, err
+	}
+	return bh.FileAttributes, nil
+}
+
+func identityFromHandle(h windows.Handle) (fileIdentity, error) {
+	var info fileIDInfo
+	if err := windows.GetFileInformationByHandleEx(h, windows.FileIdInfo, (*byte)(unsafe.Pointer(&info)), uint32(unsafe.Sizeof(info))); err != nil {
+		return fileIdentity{}, err
+	}
+	return fileIdentity{volume: info.VolumeSerialNumber, fileID: info.FileID}, nil
+}
+
+func dupHandle(h windows.Handle) (windows.Handle, error) {
+	var out windows.Handle
+	err := windows.DuplicateHandle(windows.CurrentProcess(), h, windows.CurrentProcess(), &out, 0, false, windows.DUPLICATE_SAME_ACCESS)
+	if err != nil {
+		return 0, err
+	}
+	_ = windows.SetHandleInformation(out, windows.HANDLE_FLAG_INHERIT, 0)
+	return out, nil
+}
+
+func renameHandle(h, parent windows.Handle, newName string, flags uint32) error {
+	u16, err := windows.UTF16FromString(newName)
+	if err != nil {
+		return err
+	}
+	u16 = u16[:len(u16)-1]
+	nameBytes := len(u16) * 2
+	var dummy fileRenameInformationEx
+	bufSize := int(unsafe.Offsetof(dummy.FileName)) + nameBytes
+	buf := make([]byte, bufSize)
+	info := (*fileRenameInformationEx)(unsafe.Pointer(&buf[0]))
+	info.Flags = flags
+	info.RootDirectory = parent
+	info.FileNameLength = uint32(nameBytes)
+	copy(unsafe.Slice((*uint16)(unsafe.Pointer(&info.FileName[0])), len(u16)), u16)
+	var iosb windows.IO_STATUS_BLOCK
+	err = windows.NtSetInformationFile(h, &iosb, &buf[0], uint32(bufSize), fileRenameInformationExClass)
+	runtime.KeepAlive(buf)
+	return err
+}
+
+type windowsDirent struct {
+	name string
+	attr uint32
+}
+
+func readWindowsDirents(h windows.Handle) ([]windowsDirent, error) {
+	buf := make([]byte, 64*1024)
+	var ents []windowsDirent
+	first := true
+	for {
+		class := uint32(windows.FileFullDirectoryInfo)
+		if first {
+			class = windows.FileFullDirectoryRestartInfo
+			first = false
+		}
+		err := windows.GetFileInformationByHandleEx(h, class, &buf[0], uint32(len(buf)))
+		if err != nil {
+			if errors.Is(err, windows.ERROR_NO_MORE_FILES) || errors.Is(err, windows.ERROR_HANDLE_EOF) {
+				break
+			}
+			if errors.Is(err, windows.ERROR_MORE_DATA) {
+				buf = make([]byte, len(buf)*2)
+				first = true
+				ents = nil
+				continue
+			}
+			return nil, err
+		}
+		ents = append(ents, parseFullDirInfo(buf)...)
+	}
+	return ents, nil
+}
+
+func parseFullDirInfo(buf []byte) []windowsDirent {
+	const nameOffset = 68
+	var ents []windowsDirent
+	off := 0
+	for {
+		if off+nameOffset > len(buf) {
+			break
+		}
+		next := binary.LittleEndian.Uint32(buf[off:])
+		attr := binary.LittleEndian.Uint32(buf[off+56:])
+		nameLen := int(binary.LittleEndian.Uint32(buf[off+60:]))
+		nameOff := off + nameOffset
+		if nameLen < 0 || nameOff+nameLen > len(buf) {
+			break
+		}
+		n := nameLen / 2
+		u16 := unsafe.Slice((*uint16)(unsafe.Pointer(&buf[nameOff])), n)
+		name := windows.UTF16ToString(u16)
+		if name != "." && name != ".." && name != "" {
+			ents = append(ents, windowsDirent{name: name, attr: attr})
+		}
+		if next == 0 {
+			break
+		}
+		off += int(next)
+	}
+	return ents
+}
+
+func modeFromAttributes(attr uint32) os.FileMode {
+	mode := os.FileMode(0o666)
+	if attr&windows.FILE_ATTRIBUTE_READONLY != 0 {
+		mode = 0o444
+	}
+	if attr&windows.FILE_ATTRIBUTE_DIRECTORY != 0 {
+		mode |= os.ModeDir
+	}
+	if attr&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+		mode |= os.ModeSymlink
+	}
+	return mode
+}
+
+func isWindowsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, os.ErrNotExist) || errors.Is(err, windows.ERROR_FILE_NOT_FOUND) || errors.Is(err, windows.ERROR_PATH_NOT_FOUND) {
+		return true
+	}
+	var st windows.NTStatus
+	if errors.As(err, &st) {
+		switch st {
+		case windows.STATUS_OBJECT_NAME_NOT_FOUND, windows.STATUS_OBJECT_PATH_NOT_FOUND:
+			return true
+		}
+		switch st.Errno() {
+		case windows.ERROR_FILE_NOT_FOUND, windows.ERROR_PATH_NOT_FOUND:
+			return true
+		}
+	}
+	return false
+}
+
+func isWindowsExist(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, os.ErrExist) || errors.Is(err, windows.ERROR_ALREADY_EXISTS) || errors.Is(err, windows.ERROR_FILE_EXISTS) {
+		return true
+	}
+	var st windows.NTStatus
+	if errors.As(err, &st) {
+		if st == windows.STATUS_OBJECT_NAME_COLLISION {
+			return true
+		}
+		switch st.Errno() {
+		case windows.ERROR_ALREADY_EXISTS, windows.ERROR_FILE_EXISTS:
+			return true
+		}
+	}
+	return false
+}

--- a/internal/platform/privatefs_windows_test.go
+++ b/internal/platform/privatefs_windows_test.go
@@ -1,0 +1,329 @@
+//go:build windows
+
+package platform
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestPrivateFS_WindowsProtectedDACL(t *testing.T) {
+	fs, paths := openTestPrivateFS(t)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeLog(fs, paths.DaemonLog, "x"); err != nil {
+		t.Fatal(err)
+	}
+	assertOwnerSystemDACL(t, paths.Root, true)
+	assertOwnerSystemDACL(t, paths.LogDir, true)
+	assertOwnerSystemDACL(t, paths.DaemonLog, false)
+}
+
+func TestPrivateFS_WindowsChildFileDACL(t *testing.T) {
+	fs, paths := openTestPrivateFS(t)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeLog(fs, paths.TUILog, "child"); err != nil {
+		t.Fatal(err)
+	}
+	assertOwnerSystemDACL(t, paths.TUILog, false)
+}
+
+func TestPrivateFS_WindowsTightenWideDACL(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "data")
+	if err := os.Mkdir(root, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	setWideDACL(t, root)
+	fs, err := NewPrivateFS(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = fs.Close() })
+	assertOwnerSystemDACL(t, root, true)
+	logs := filepath.Join(root, "logs")
+	if err := os.Mkdir(logs, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	setWideDACL(t, logs)
+	if err := fs.EnsureDir(logs); err != nil {
+		t.Fatal(err)
+	}
+	assertOwnerSystemDACL(t, logs, true)
+}
+
+func TestPrivateFS_WindowsRefuseCreateRootAsLocalSystem(t *testing.T) {
+	orig := processIsLocalSystem
+	t.Cleanup(func() { processIsLocalSystem = orig })
+	processIsLocalSystem = func() (bool, error) { return true, nil }
+	root := filepath.Join(t.TempDir(), "missing")
+	if _, err := NewPrivateFS(root); err == nil {
+		t.Fatal("expected LocalSystem missing-data-root to fail closed")
+	}
+	if _, err := os.Lstat(root); !os.IsNotExist(err) {
+		t.Fatalf("root created as LocalSystem: %v", err)
+	}
+}
+
+func TestPrivateFS_WindowsDataRootJunctionFollowed(t *testing.T) {
+	base := t.TempDir()
+	realRoot := filepath.Join(base, "real")
+	if err := os.Mkdir(realRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	linkRoot := filepath.Join(base, "link")
+	createJunction(t, linkRoot, realRoot)
+	fs, err := NewPrivateFS(linkRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = fs.Close() })
+	paths := NewPaths(linkRoot)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeLog(fs, paths.DaemonLog, "via-junction"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(realRoot, "logs", filepath.Base(paths.DaemonLog)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "via-junction" {
+		t.Fatalf("got %q", got)
+	}
+	id, err := fs.OpenDirIdentity(paths.LogDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = id.Close() })
+	held, err := id.identity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := fileIdentityOfPath(t, filepath.Join(realRoot, "logs"))
+	if held != want {
+		t.Fatalf("held identity %+v want %+v", held, want)
+	}
+}
+
+func TestPrivateFS_WindowsLogDirJunctionFailClosed(t *testing.T) {
+	fs, paths := openTestPrivateFS(t)
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.Mkdir(outside, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(outside, "marker")
+	if err := os.WriteFile(marker, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	outsideDACL := daclString(t, outside)
+	createJunction(t, paths.LogDir, outside)
+	if err := fs.EnsureDir(paths.LogDir); err == nil {
+		t.Fatal("expected EnsureDir on junction logs to fail")
+	}
+	if _, err := fs.OpenAppend(paths.DaemonLog); err == nil {
+		t.Fatal("expected OpenAppend through junction logs to fail")
+	}
+	if _, err := fs.ReadDir(paths.LogDir); err == nil {
+		t.Fatal("expected ReadDir through junction logs to fail")
+	}
+	if err := fs.Rename(paths.DaemonLog, paths.DaemonLog+".1"); err == nil {
+		t.Fatal("expected Rename through junction logs to fail")
+	}
+	if err := fs.Remove(paths.DaemonLog); err == nil {
+		t.Fatal("expected Remove through junction logs to fail")
+	}
+	if _, err := fs.OpenReadChecked(paths.DaemonLog, FileIdentity{}); err == nil {
+		t.Fatal("expected OpenReadChecked through junction logs to fail")
+	}
+	got, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "keep" {
+		t.Fatalf("outside marker mutated: %q", got)
+	}
+	entries, err := os.ReadDir(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "marker" {
+		t.Fatalf("outside dir mutated: %v", entries)
+	}
+	if got := daclString(t, outside); got != outsideDACL {
+		t.Fatalf("outside DACL changed:\n%s\n%s", outsideDACL, got)
+	}
+}
+
+func TestPrivateFS_WindowsFileReparseDoesNotAppendYAML(t *testing.T) {
+	fs, paths := openTestPrivateFS(t)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.Settings, []byte("keep-yaml"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(paths.Settings, paths.DaemonLog); err != nil {
+		t.Skipf("file symlink unavailable: %v", err)
+	}
+	if _, err := fs.OpenAppend(paths.DaemonLog); err == nil {
+		t.Fatal("expected OpenAppend of reparse to fail")
+	}
+	got, err := os.ReadFile(paths.Settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "keep-yaml" {
+		t.Fatalf("yaml mutated: %q", got)
+	}
+}
+
+func TestPrivateFS_WindowsCloseReleasesHandles(t *testing.T) {
+	fs, paths := openTestPrivateFS(t)
+	if err := fs.EnsureDir(paths.LogDir); err != nil {
+		t.Fatal(err)
+	}
+	root := fs.plat.root
+	logs := fs.plat.dirs[privateLogDirName]
+	if err := fs.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(root, &info); err == nil {
+		t.Fatal("root handle still open after Close")
+	}
+	if err := windows.GetFileInformationByHandle(logs, &info); err == nil {
+		t.Fatal("logs handle still open after Close")
+	}
+}
+
+func assertOwnerSystemDACL(t *testing.T, path string, directory bool) {
+	t.Helper()
+	sd, err := windows.GetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		t.Fatal(err)
+	}
+	owner, _, err := sd.Owner()
+	if err != nil || owner == nil {
+		t.Fatalf("owner: %v", err)
+	}
+	dacl, _, err := sd.DACL()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dacl == nil {
+		t.Fatal("empty DACL is fully permissive")
+	}
+	world, err := windows.CreateWellKnownSid(windows.WinWorldSid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	users, err := windows.CreateWellKnownSid(windows.WinBuiltinUsersSid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	anon, err := windows.CreateWellKnownSid(windows.WinAnonymousSid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	system, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sawOwner, sawSystem bool
+	for i := uint16(0); i < dacl.AceCount; i++ {
+		var ace *windows.ACCESS_ALLOWED_ACE
+		if err := windows.GetAce(dacl, uint32(i), &ace); err != nil {
+			t.Fatal(err)
+		}
+		sid := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+		if sid.Equals(world) || sid.Equals(users) || sid.Equals(anon) {
+			t.Fatalf("%s DACL grants %s", path, sid)
+		}
+		if sid.Equals(owner) {
+			sawOwner = true
+		}
+		if sid.Equals(system) {
+			sawSystem = true
+		}
+		if !sid.Equals(owner) && !sid.Equals(system) {
+			t.Fatalf("%s unexpected SID %s", path, sid)
+		}
+	}
+	if owner.Equals(system) {
+		if !sawSystem {
+			t.Fatalf("%s missing SYSTEM ACE", path)
+		}
+		return
+	}
+	if !sawOwner || !sawSystem {
+		t.Fatalf("%s DACL owner=%v system=%v dir=%v", path, sawOwner, sawSystem, directory)
+	}
+}
+
+func setWideDACL(t *testing.T, path string) {
+	t.Helper()
+	world, err := windows.CreateWellKnownSid(windows.WinWorldSid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	acl, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{{
+		AccessPermissions: windows.GENERIC_ALL,
+		AccessMode:        windows.GRANT_ACCESS,
+		Trustee: windows.TRUSTEE{
+			TrusteeForm:  windows.TRUSTEE_IS_SID,
+			TrusteeType:  windows.TRUSTEE_IS_WELL_KNOWN_GROUP,
+			TrusteeValue: windows.TrusteeValueFromSID(world),
+		},
+	}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION, nil, nil, acl, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createJunction(t *testing.T, link, target string) {
+	t.Helper()
+	cmd := exec.Command("cmd", "/c", "mklink", "/J", link, target)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("mklink /J %s %s: %v\n%s", link, target, err, out)
+	}
+}
+
+func daclString(t *testing.T, path string) string {
+	t.Helper()
+	sd, err := windows.GetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sd.String()
+}
+
+func fileIdentityOfPath(t *testing.T, path string) FileIdentity {
+	t.Helper()
+	name, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h, err := windows.CreateFile(name, windows.FILE_READ_ATTRIBUTES, windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE, nil, windows.OPEN_EXISTING, windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer windows.CloseHandle(h)
+	var info fileIDInfo
+	if err := windows.GetFileInformationByHandleEx(h, windows.FileIdInfo, (*byte)(unsafe.Pointer(&info)), uint32(unsafe.Sizeof(info))); err != nil {
+		t.Fatal(err)
+	}
+	return FileIdentity{plat: fileIdentity{volume: info.VolumeSerialNumber, fileID: info.FileID}}
+}

--- a/internal/supervisor/command.go
+++ b/internal/supervisor/command.go
@@ -1,6 +1,7 @@
 package supervisor
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
@@ -38,7 +39,18 @@ type processChild struct{ command *exec.Cmd }
 
 func (c *processChild) PID() int { return c.command.Process.Pid }
 
-func (c *processChild) Wait() error { return c.command.Wait() }
+func (c *processChild) Wait() error {
+	waitErr := c.command.Wait()
+	return errors.Join(waitErr, flushCapture(c.command.Stdout), flushCapture(c.command.Stderr))
+}
+
+func flushCapture(w io.Writer) error {
+	flusher, ok := w.(interface{ Flush() error })
+	if !ok {
+		return nil
+	}
+	return flusher.Flush()
+}
 
 func (c *processChild) Terminate() error { return terminateChild(c.command) }
 

--- a/internal/supervisor/command_test.go
+++ b/internal/supervisor/command_test.go
@@ -1,13 +1,97 @@
 package supervisor
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/mihari-proxy/mihari/internal/logging"
 )
+
+const commandHelperEnv = "MIHARI_COMMAND_HELPER"
+
+func init() {
+	switch os.Getenv(commandHelperEnv) {
+	case "partial-stdout":
+		_, _ = os.Stdout.Write([]byte("partial"))
+		os.Exit(0)
+	case "full-stdout":
+		_, _ = os.Stdout.Write([]byte("full-line\n"))
+		os.Exit(0)
+	}
+}
 
 func TestCommandArgumentsUseManagedDataAndConfig(t *testing.T) {
 	want := []string{"-d", "/managed/data", "-f", "/managed/config.yaml"}
 	if got := commandArguments("/managed/data", "/managed/config.yaml"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("args=%q want=%q", got, want)
 	}
+}
+
+func TestCommandStarter_FlushesCaptureOnWait(t *testing.T) {
+	bin, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	level := &slog.LevelVar{}
+	logger := slog.New(logging.NewJSONHandler(&buf, level, "mihomo", logging.NewRedactor()))
+	capture := logging.NewLineCaptureWriter(logger, slog.LevelInfo, "stdout")
+	t.Cleanup(func() { _ = capture.Close() })
+	starter := CommandStarter{
+		BinaryPath: bin,
+		DataDir:    t.TempDir(),
+		ConfigPath: filepath.Join(t.TempDir(), "config.yaml"),
+		Stdout:     capture,
+		Stderr:     io.Discard,
+	}
+
+	t.Setenv(commandHelperEnv, "partial-stdout")
+	child, err := starter.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := child.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	first := parseHelperJSONL(t, buf.String())
+	if len(first) != 1 || first[0]["msg"] != "partial" {
+		t.Fatalf("after first Wait records=%v", first)
+	}
+
+	t.Setenv(commandHelperEnv, "full-stdout")
+	child, err = starter.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := child.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	second := parseHelperJSONL(t, buf.String())
+	if len(second) != 2 || second[0]["msg"] != "partial" || second[1]["msg"] != "full-line" {
+		t.Fatalf("after second Wait records=%v", second)
+	}
+}
+
+func parseHelperJSONL(t *testing.T, raw string) []map[string]any {
+	t.Helper()
+	lines := strings.Split(strings.TrimSpace(raw), "\n")
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(lines))
+	for i, line := range lines {
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("line %d json: %v in %q", i, err, line)
+		}
+		out = append(out, rec)
+	}
+	return out
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -74,6 +74,7 @@ type Model struct {
 	systemProxyOK bool
 	tunStatus     protocol.TunStatus
 	tunOK         bool
+	loggingHealth LocalLoggingHealth
 }
 
 // networkStatusClient is the minimal control surface for Overview network KPIs.
@@ -231,6 +232,14 @@ func (model *Model) SetServiceController(ctrl systempage.ServiceController) {
 	if page, ok := model.pages[ui.PageSystem].(*systempage.Model); ok {
 		page.SetServiceController(ctrl)
 	}
+}
+
+// SetLoggingHealth injects the local TUI logging availability observed during bootstrap.
+func (model *Model) SetLoggingHealth(health LocalLoggingHealth) {
+	if model == nil {
+		return
+	}
+	model.loggingHealth = health
 }
 
 func (model Model) loadRootServiceStatus() tea.Cmd {

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -114,6 +114,7 @@ func (r *LoggingResources) closeWithSession(closeSession func()) error {
 			privateFSCloser = r.PrivateFS
 		}
 		state = newLoggingResourcesCloseState(runtimeCloser, privateFSCloser)
+		r.closeState = state
 	}
 	state.once.Do(func() {
 		state.err = closeTUILifecycle(closeSession, state.runtime, state.privateFS)

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -9,6 +9,8 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	controlclient "github.com/mihari-proxy/mihari/internal/control/client"
+	"github.com/mihari-proxy/mihari/internal/logging"
+	"github.com/mihari-proxy/mihari/internal/platform"
 	systempage "github.com/mihari-proxy/mihari/internal/tui/pages/system"
 	"github.com/mihari-proxy/mihari/internal/tui/session"
 	"github.com/mihari-proxy/mihari/internal/tui/ui"
@@ -25,25 +27,77 @@ type Options struct {
 	Relaunch       func() error
 	Input          io.Reader
 	Output         io.Writer
+	OpenLogging    LoggingFactory
+	ErrorOutput    io.Writer
 }
+
+// LocalLoggingHealth reports whether the local TUI file logger is available.
+type LocalLoggingHealth interface {
+	Available() bool
+}
+
+// LoggingResources owns the TUI file logging runtime and the shared local data-root capability.
+type LoggingResources struct {
+	Runtime   *logging.Runtime
+	Redactor  *logging.Redactor
+	PrivateFS *platform.PrivateFS
+	Health    LocalLoggingHealth
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// Available reports whether the TUI file logging runtime opened successfully.
+func (r *LoggingResources) Available() bool {
+	return r != nil && r.Runtime != nil
+}
+
+// Close releases the runtime before the shared data-root capability. It is safe to call repeatedly.
+func (r *LoggingResources) Close() error {
+	if r == nil {
+		return nil
+	}
+	r.closeOnce.Do(func() {
+		var errs []error
+		if r.Runtime != nil {
+			errs = append(errs, r.Runtime.Close())
+		}
+		if r.PrivateFS != nil {
+			errs = append(errs, r.PrivateFS.Close())
+		}
+		r.closeErr = errors.Join(errs...)
+	})
+	return r.closeErr
+}
+
+// LoggingFactory opens TUI-local file logging using the Run context.
+type LoggingFactory func(context.Context) (LoggingResources, error)
 
 // Run starts the full-screen Mihari terminal interface and blocks until it exits.
 func Run(ctx context.Context, options Options) error {
+	resources := LoggingResources{}
+	if options.OpenLogging != nil {
+		opened, err := options.OpenLogging(ctx)
+		resources = opened
+		if err != nil {
+			reportTUILoggingBootstrapFailure(options.ErrorOutput, resources.Redactor)
+		}
+	}
+	health := resources.Health
+	if health == nil {
+		health = &resources
+	}
+	if resources.Runtime != nil && resources.Runtime.Logger() != nil {
+		resources.Runtime.Logger().Info("tui started")
+	}
+
 	model := NewModel()
 	var controlSession *session.Session
-	var closeSessionOnce sync.Once
-	closeSession := func() {
-		closeSessionOnce.Do(func() {
-			if controlSession != nil {
-				controlSession.Close()
-			}
-		})
-	}
-	defer closeSession()
 	if options.Client != nil {
 		controlSession = session.New(options.Client, session.Options{})
 		model = newModelWithClientContext(ctx, controlSession.Start(ctx), options.Client)
 	}
+	model.SetLoggingHealth(health)
 	if options.Service != nil {
 		model.SetServiceController(options.Service)
 	}
@@ -55,15 +109,30 @@ func Run(ctx context.Context, options Options) error {
 		tea.WithOutput(options.Output),
 	)
 	final, err := program.Run()
-	return finishRun(final, err, options.Output, options.Relaunch, closeSession)
+	var closeOnce sync.Once
+	var closeErr error
+	cleanup := func(tea.Model) error {
+		closeOnce.Do(func() {
+			if controlSession != nil {
+				controlSession.Close()
+			}
+			closeErr = resources.Close()
+			if closeErr != nil {
+				reportTUILoggingCleanupFailure(options.ErrorOutput, resources.Redactor, closeErr)
+			}
+		})
+		return closeErr
+	}
+	return finishRun(final, err, options.Output, options.Relaunch, cleanup)
 }
 
-func finishRun(final tea.Model, runErr error, warningWriter io.Writer, relaunch func() error, cleanup func()) error {
+func finishRun(final tea.Model, runErr error, warningWriter io.Writer, relaunch func() error, cleanup func(tea.Model) error) error {
+	var cleanupErr error
 	if cleanup != nil {
-		cleanup()
+		cleanupErr = cleanup(final)
 	}
 	if runErr != nil {
-		return runErr
+		return errors.Join(runErr, cleanupErr)
 	}
 	var requested bool
 	var warning string
@@ -76,7 +145,7 @@ func finishRun(final tea.Model, runErr error, warningWriter io.Writer, relaunch 
 		warning = model.RelaunchWarning()
 	}
 	if !requested {
-		return nil
+		return cleanupErr
 	}
 	var warningErr error
 	if warning != "" && warningWriter != nil {
@@ -85,12 +154,34 @@ func finishRun(final tea.Model, runErr error, warningWriter io.Writer, relaunch 
 		}
 	}
 	if relaunch == nil {
-		return errors.Join(warningErr, fmt.Errorf("relaunch updated Mihari: relaunch is unavailable"))
+		return errors.Join(cleanupErr, warningErr, fmt.Errorf("relaunch updated Mihari: relaunch is unavailable"))
 	}
 	if err := relaunch(); err != nil {
-		return errors.Join(warningErr, fmt.Errorf("relaunch updated Mihari: %w", err))
+		return errors.Join(cleanupErr, warningErr, fmt.Errorf("relaunch updated Mihari: %w", err))
 	}
-	return nil
+	return cleanupErr
+}
+
+func reportTUILoggingBootstrapFailure(out io.Writer, redactor *logging.Redactor) {
+	if out == nil {
+		return
+	}
+	message := "TUI file logging is unavailable"
+	if redactor != nil {
+		message = redactor.String(message)
+	}
+	_, _ = fmt.Fprintf(out, "Warning: %s\n", message)
+}
+
+func reportTUILoggingCleanupFailure(out io.Writer, redactor *logging.Redactor, err error) {
+	if out == nil || err == nil {
+		return
+	}
+	message := err.Error()
+	if redactor != nil {
+		message = redactor.String(message)
+	}
+	_, _ = fmt.Fprintf(out, "Warning: TUI file logging cleanup failed: %s\n", message)
 }
 
 // loadingModel is a minimal AltScreen sample used by run_test.go only.

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -44,8 +44,46 @@ type LoggingResources struct {
 	PrivateFS *platform.PrivateFS
 	Health    LocalLoggingHealth
 
-	closeOnce sync.Once
-	closeErr  error
+	closeState *loggingResourcesCloseState
+}
+
+type loggingResourcesCloseState struct {
+	once      sync.Once
+	err       error
+	runtime   io.Closer
+	privateFS io.Closer
+}
+
+type loggingResourcesHealth struct {
+	runtime *logging.Runtime
+}
+
+// NewLoggingResources creates TUI logging resources whose close state and
+// health remain shared when the value is copied by a LoggingFactory caller.
+func NewLoggingResources(runtime *logging.Runtime, redactor *logging.Redactor, privateFS *platform.PrivateFS) LoggingResources {
+	var runtimeCloser io.Closer
+	if runtime != nil {
+		runtimeCloser = runtime
+	}
+	var privateFSCloser io.Closer
+	if privateFS != nil {
+		privateFSCloser = privateFS
+	}
+	return LoggingResources{
+		Runtime:    runtime,
+		Redactor:   redactor,
+		PrivateFS:  privateFS,
+		Health:     &loggingResourcesHealth{runtime: runtime},
+		closeState: newLoggingResourcesCloseState(runtimeCloser, privateFSCloser),
+	}
+}
+
+func newLoggingResourcesCloseState(runtime io.Closer, privateFS io.Closer) *loggingResourcesCloseState {
+	return &loggingResourcesCloseState{runtime: runtime, privateFS: privateFS}
+}
+
+func (h *loggingResourcesHealth) Available() bool {
+	return h != nil && h.runtime != nil
 }
 
 // Available reports whether the TUI file logging runtime opened successfully.
@@ -65,7 +103,8 @@ func (r *LoggingResources) closeWithSession(closeSession func()) error {
 		}
 		return nil
 	}
-	r.closeOnce.Do(func() {
+	state := r.closeState
+	if state == nil {
 		var runtimeCloser io.Closer
 		if r.Runtime != nil {
 			runtimeCloser = r.Runtime
@@ -74,9 +113,12 @@ func (r *LoggingResources) closeWithSession(closeSession func()) error {
 		if r.PrivateFS != nil {
 			privateFSCloser = r.PrivateFS
 		}
-		r.closeErr = closeTUILifecycle(closeSession, runtimeCloser, privateFSCloser)
+		state = newLoggingResourcesCloseState(runtimeCloser, privateFSCloser)
+	}
+	state.once.Do(func() {
+		state.err = closeTUILifecycle(closeSession, state.runtime, state.privateFS)
 	})
-	return r.closeErr
+	return state.err
 }
 
 func closeTUILifecycle(closeSession func(), runtime io.Closer, privateFS io.Closer) error {

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	controlclient "github.com/mihari-proxy/mihari/internal/control/client"
@@ -54,34 +55,106 @@ func (r *LoggingResources) Available() bool {
 
 // Close releases the runtime before the shared data-root capability. It is safe to call repeatedly.
 func (r *LoggingResources) Close() error {
+	return r.closeWithSession(nil)
+}
+
+func (r *LoggingResources) closeWithSession(closeSession func()) error {
 	if r == nil {
+		if closeSession != nil {
+			closeSession()
+		}
 		return nil
 	}
 	r.closeOnce.Do(func() {
-		var errs []error
+		var runtimeCloser io.Closer
 		if r.Runtime != nil {
-			errs = append(errs, r.Runtime.Close())
+			runtimeCloser = r.Runtime
 		}
+		var privateFSCloser io.Closer
 		if r.PrivateFS != nil {
-			errs = append(errs, r.PrivateFS.Close())
+			privateFSCloser = r.PrivateFS
 		}
-		r.closeErr = errors.Join(errs...)
+		r.closeErr = closeTUILifecycle(closeSession, runtimeCloser, privateFSCloser)
 	})
 	return r.closeErr
+}
+
+func closeTUILifecycle(closeSession func(), runtime io.Closer, privateFS io.Closer) error {
+	if closeSession != nil {
+		closeSession()
+	}
+	var errs []error
+	for _, closer := range []io.Closer{runtime, privateFS} {
+		if closer != nil {
+			errs = append(errs, closer.Close())
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // LoggingFactory opens TUI-local file logging using the Run context.
 type LoggingFactory func(context.Context) (LoggingResources, error)
 
+type tuiLoggingFailureKind uint8
+
+const (
+	tuiLoggingBootstrapFailure tuiLoggingFailureKind = iota
+	tuiLoggingCleanupFailure
+	tuiLoggingFailureWindow = time.Second
+)
+
+// tuiLoggingFailureReporter emits rate-limited, stable local logging warnings.
+// It intentionally never includes the underlying error because it may contain
+// sensitive data or an absolute local path.
+type tuiLoggingFailureReporter struct {
+	out      io.Writer
+	redactor *logging.Redactor
+	now      func() time.Time
+
+	mu   sync.Mutex
+	last map[tuiLoggingFailureKind]time.Time
+}
+
+func newTUILoggingFailureReporter(out io.Writer, redactor *logging.Redactor, now func() time.Time) *tuiLoggingFailureReporter {
+	if now == nil {
+		now = time.Now
+	}
+	return &tuiLoggingFailureReporter{out: out, redactor: redactor, now: now, last: make(map[tuiLoggingFailureKind]time.Time)}
+}
+
+func (r *tuiLoggingFailureReporter) report(kind tuiLoggingFailureKind, err error) {
+	if r == nil || r.out == nil || err == nil {
+		return
+	}
+	now := r.now()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if previous, ok := r.last[kind]; ok && now.Sub(previous) < tuiLoggingFailureWindow {
+		return
+	}
+	r.last[kind] = now
+	message := "TUI file logging is unavailable"
+	if kind == tuiLoggingCleanupFailure {
+		message = "TUI file logging cleanup failed"
+	}
+	if r.redactor != nil {
+		message = r.redactor.String(message)
+	}
+	_, _ = fmt.Fprintf(r.out, "Warning: %s\n", message)
+}
+
 // Run starts the full-screen Mihari terminal interface and blocks until it exits.
 func Run(ctx context.Context, options Options) error {
 	resources := LoggingResources{}
+	var openErr error
 	if options.OpenLogging != nil {
 		opened, err := options.OpenLogging(ctx)
 		resources = opened
-		if err != nil {
-			reportTUILoggingBootstrapFailure(options.ErrorOutput, resources.Redactor)
-		}
+		openErr = err
+	}
+	reporter := newTUILoggingFailureReporter(options.ErrorOutput, resources.Redactor, nil)
+	if openErr != nil {
+		reporter.report(tuiLoggingBootstrapFailure, openErr)
 	}
 	health := resources.Health
 	if health == nil {
@@ -91,13 +164,13 @@ func Run(ctx context.Context, options Options) error {
 		resources.Runtime.Logger().Info("tui started")
 	}
 
-	model := NewModel()
 	var controlSession *session.Session
+	var events <-chan session.Event
 	if options.Client != nil {
 		controlSession = session.New(options.Client, session.Options{})
-		model = newModelWithClientContext(ctx, controlSession.Start(ctx), options.Client)
+		events = controlSession.Start(ctx)
 	}
-	model.SetLoggingHealth(health)
+	model := newRunModel(ctx, options.Client, events, health)
 	if options.Service != nil {
 		model.SetServiceController(options.Service)
 	}
@@ -113,17 +186,27 @@ func Run(ctx context.Context, options Options) error {
 	var closeErr error
 	cleanup := func(tea.Model) error {
 		closeOnce.Do(func() {
-			if controlSession != nil {
-				controlSession.Close()
-			}
-			closeErr = resources.Close()
+			closeErr = resources.closeWithSession(func() {
+				if controlSession != nil {
+					controlSession.Close()
+				}
+			})
 			if closeErr != nil {
-				reportTUILoggingCleanupFailure(options.ErrorOutput, resources.Redactor, closeErr)
+				reporter.report(tuiLoggingCleanupFailure, closeErr)
 			}
 		})
 		return closeErr
 	}
 	return finishRun(final, err, options.Output, options.Relaunch, cleanup)
+}
+
+func newRunModel(ctx context.Context, client *controlclient.Client, events <-chan session.Event, health LocalLoggingHealth) Model {
+	model := NewModel()
+	if client != nil {
+		model = newModelWithClientContext(ctx, events, client)
+	}
+	model.SetLoggingHealth(health)
+	return model
 }
 
 func finishRun(final tea.Model, runErr error, warningWriter io.Writer, relaunch func() error, cleanup func(tea.Model) error) error {
@@ -160,28 +243,6 @@ func finishRun(final tea.Model, runErr error, warningWriter io.Writer, relaunch 
 		return errors.Join(cleanupErr, warningErr, fmt.Errorf("relaunch updated Mihari: %w", err))
 	}
 	return cleanupErr
-}
-
-func reportTUILoggingBootstrapFailure(out io.Writer, redactor *logging.Redactor) {
-	if out == nil {
-		return
-	}
-	message := "TUI file logging is unavailable"
-	if redactor != nil {
-		message = redactor.String(message)
-	}
-	_, _ = fmt.Fprintf(out, "Warning: %s\n", message)
-}
-
-func reportTUILoggingCleanupFailure(out io.Writer, redactor *logging.Redactor, err error) {
-	if out == nil || err == nil {
-		return
-	}
-	message := err.Error()
-	if redactor != nil {
-		message = redactor.String(message)
-	}
-	_, _ = fmt.Fprintf(out, "Warning: TUI file logging cleanup failed: %s\n", message)
 }
 
 // loadingModel is a minimal AltScreen sample used by run_test.go only.

--- a/internal/tui/run_test.go
+++ b/internal/tui/run_test.go
@@ -214,7 +214,7 @@ func TestRunNilPrivateFSContinuesWithoutCreatingDataRootLogging(t *testing.T) {
 	}
 }
 
-func TestLoggingResourcesCloseClosesRuntimeBeforePrivateFSAndIsIdempotent(t *testing.T) {
+func TestLoggingResourcesCloseReleasesPrivateFSIdempotently(t *testing.T) {
 	paths, err := platform.NewPaths(filepath.Join(t.TempDir(), "data")).Absolute()
 	if err != nil {
 		t.Fatal(err)
@@ -238,6 +238,22 @@ func TestLoggingResourcesCloseClosesRuntimeBeforePrivateFSAndIsIdempotent(t *tes
 	}
 	if err := fs.EnsureDir(paths.LogDir); err == nil {
 		t.Fatal("PrivateFS remains open after resources Close")
+	}
+}
+
+func TestLoggingResourcesFallbackCloseStateIsPersistent(t *testing.T) {
+	resources := &LoggingResources{}
+	closeSessionCalls := 0
+	closeSession := func() { closeSessionCalls++ }
+
+	if err := resources.closeWithSession(closeSession); err != nil {
+		t.Fatal(err)
+	}
+	if err := resources.closeWithSession(closeSession); err != nil {
+		t.Fatal(err)
+	}
+	if closeSessionCalls != 1 {
+		t.Fatalf("session close calls=%d want=1", closeSessionCalls)
 	}
 }
 

--- a/internal/tui/run_test.go
+++ b/internal/tui/run_test.go
@@ -2,12 +2,16 @@ package tui
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/mihari-proxy/mihari/internal/logging"
+	"github.com/mihari-proxy/mihari/internal/platform"
 )
 
 func TestFinishRunRelaunchesOnlyWhenRequested(t *testing.T) {
@@ -22,7 +26,7 @@ func TestFinishRunRelaunchesOnlyWhenRequested(t *testing.T) {
 			t.Fatal("relaunch ran before warning was written")
 		}
 		return nil
-	}, nil)
+	}, func(tea.Model) error { return nil })
 	if err != nil || calls != 1 {
 		t.Fatalf("calls=%d err=%v", calls, err)
 	}
@@ -31,6 +35,7 @@ func TestFinishRunRelaunchesOnlyWhenRequested(t *testing.T) {
 func TestFinishRunCleansUpSessionBeforeRelaunch(t *testing.T) {
 	model := NewModel()
 	model.relaunchRequested = true
+	model.relaunchWarning = "final model marker"
 	cleaned := false
 
 	err := finishRun(model, nil, io.Discard, func() error {
@@ -38,7 +43,14 @@ func TestFinishRunCleansUpSessionBeforeRelaunch(t *testing.T) {
 			t.Fatal("relaunch ran before control session cleanup")
 		}
 		return nil
-	}, func() { cleaned = true })
+	}, func(final tea.Model) error {
+		got, ok := final.(Model)
+		if !ok || got.RelaunchWarning() != "final model marker" {
+			t.Fatalf("cleanup model=%T did not receive final model", final)
+		}
+		cleaned = true
+		return nil
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,8 +61,9 @@ func TestFinishRunCleansUpSessionBeforeRelaunch(t *testing.T) {
 
 func TestFinishRunNormalExitDoesNotRelaunch(t *testing.T) {
 	calls := 0
-	if err := finishRun(NewModel(), nil, io.Discard, func() error { calls++; return nil }, nil); err != nil || calls != 0 {
-		t.Fatalf("calls=%d err=%v", calls, err)
+	cleanups := 0
+	if err := finishRun(NewModel(), nil, io.Discard, func() error { calls++; return nil }, func(tea.Model) error { cleanups++; return nil }); err != nil || calls != 0 || cleanups != 1 {
+		t.Fatalf("calls=%d cleanups=%d err=%v", calls, cleanups, err)
 	}
 }
 
@@ -59,9 +72,10 @@ func TestFinishRunProgramErrorPreventsRelaunch(t *testing.T) {
 	model.relaunchRequested = true
 	runErr := errors.New("program failed")
 	calls := 0
-	err := finishRun(model, runErr, io.Discard, func() error { calls++; return nil }, nil)
-	if !errors.Is(err, runErr) || calls != 0 {
-		t.Fatalf("calls=%d err=%v", calls, err)
+	cleanups := 0
+	err := finishRun(model, runErr, io.Discard, func() error { calls++; return nil }, func(tea.Model) error { cleanups++; return nil })
+	if !errors.Is(err, runErr) || calls != 0 || cleanups != 1 {
+		t.Fatalf("calls=%d cleanups=%d err=%v", calls, cleanups, err)
 	}
 }
 
@@ -69,7 +83,7 @@ func TestFinishRunReturnsRelaunchError(t *testing.T) {
 	model := NewModel()
 	model.relaunchRequested = true
 	relaunchErr := errors.New("start replacement failed")
-	err := finishRun(model, nil, io.Discard, func() error { return relaunchErr }, nil)
+	err := finishRun(model, nil, io.Discard, func() error { return relaunchErr }, func(tea.Model) error { return nil })
 	if !errors.Is(err, relaunchErr) {
 		t.Fatalf("err=%v", err)
 	}
@@ -89,7 +103,7 @@ func TestFinishRunWarningWriteFailureStillRelaunches(t *testing.T) {
 	err := finishRun(model, nil, failingWriter{err: writeErr}, func() error {
 		calls++
 		return nil
-	}, nil)
+	}, func(tea.Model) error { return nil })
 	if err != nil || calls != 1 {
 		t.Fatalf("calls=%d err=%v", calls, err)
 	}
@@ -102,7 +116,7 @@ func TestFinishRunPreservesWarningAndRelaunchErrors(t *testing.T) {
 	writeErr := errors.New("terminal is closed")
 	relaunchErr := errors.New("start replacement failed")
 
-	err := finishRun(model, nil, failingWriter{err: writeErr}, func() error { return relaunchErr }, nil)
+	err := finishRun(model, nil, failingWriter{err: writeErr}, func() error { return relaunchErr }, func(tea.Model) error { return nil })
 	if !errors.Is(err, writeErr) || !errors.Is(err, relaunchErr) {
 		t.Fatalf("err=%v", err)
 	}
@@ -129,3 +143,82 @@ func TestLoadingModel_QuitKeysStopProgram(t *testing.T) {
 		}
 	}
 }
+
+func TestRunFactoryClosesPartialResourcesLogging(t *testing.T) {
+	paths, err := platform.NewPaths(filepath.Join(t.TempDir(), "data")).Absolute()
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs, err := platform.NewPrivateFS(paths.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var warnings bytes.Buffer
+	called := false
+	err = Run(ctx, Options{
+		OpenLogging: func(got context.Context) (LoggingResources, error) {
+			if got != ctx {
+				t.Fatal("factory did not receive Run context")
+			}
+			called = true
+			return LoggingResources{PrivateFS: fs, Redactor: logging.NewRedactor("tui-bootstrap-token")}, errors.New("open https://example.invalid/?token=tui-bootstrap-token")
+		},
+		ErrorOutput: &warnings,
+		Input:       strings.NewReader("q"),
+		Output:      io.Discard,
+	})
+	if !called {
+		t.Fatal("logging factory was not called")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run error=%v want context cancellation", err)
+	}
+	if err := fs.EnsureDir(paths.LogDir); err == nil {
+		t.Fatal("partial logging PrivateFS was not closed")
+	}
+	if got := warnings.String(); got != "Warning: TUI file logging is unavailable\n" {
+		t.Fatalf("warnings=%q", got)
+	}
+}
+
+func TestLoggingResourcesCloseClosesRuntimeBeforePrivateFSAndIsIdempotent(t *testing.T) {
+	paths, err := platform.NewPaths(filepath.Join(t.TempDir(), "data")).Absolute()
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs, err := platform.NewPrivateFS(paths.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime, err := logging.Open(context.Background(), logging.RuntimeOptions{
+		BasePath: paths.TUILog, Component: "tui", Config: logging.BootstrapConfig(), PrivateFS: fs,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resources := &LoggingResources{Runtime: runtime, PrivateFS: fs}
+	if err := resources.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := resources.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := fs.EnsureDir(paths.LogDir); err == nil {
+		t.Fatal("PrivateFS remains open after resources Close")
+	}
+}
+
+func TestModelSetLoggingHealthKeepsFactoryHealth(t *testing.T) {
+	health := testLoggingHealth{available: true}
+	model := NewModel()
+	model.SetLoggingHealth(health)
+	if model.loggingHealth == nil || !model.loggingHealth.Available() {
+		t.Fatal("model did not retain logging health")
+	}
+}
+
+type testLoggingHealth struct{ available bool }
+
+func (h testLoggingHealth) Available() bool { return h.available }

--- a/internal/tui/run_test.go
+++ b/internal/tui/run_test.go
@@ -5,11 +5,15 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
+	controlclient "github.com/mihari-proxy/mihari/internal/control/client"
 	"github.com/mihari-proxy/mihari/internal/logging"
 	"github.com/mihari-proxy/mihari/internal/platform"
 )
@@ -183,6 +187,33 @@ func TestRunFactoryClosesPartialResourcesLogging(t *testing.T) {
 	}
 }
 
+func TestRunNilPrivateFSContinuesWithoutCreatingDataRootLogging(t *testing.T) {
+	paths, err := platform.NewPaths(filepath.Join(t.TempDir(), "data")).Absolute()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var warnings bytes.Buffer
+	called := false
+	err = Run(context.Background(), Options{
+		OpenLogging: func(context.Context) (LoggingResources, error) {
+			called = true
+			return LoggingResources{Redactor: logging.NewRedactor("tui-bootstrap-token")}, errors.New("private fs unavailable")
+		},
+		ErrorOutput: &warnings,
+		Input:       strings.NewReader("q"),
+		Output:      io.Discard,
+	})
+	if err != nil || !called {
+		t.Fatalf("Run error=%v factory called=%v", err, called)
+	}
+	if _, statErr := os.Stat(paths.Root); !os.IsNotExist(statErr) {
+		t.Fatalf("nil PrivateFS created data root: %v", statErr)
+	}
+	if got, want := warnings.String(), "Warning: TUI file logging is unavailable\n"; got != want {
+		t.Fatalf("warnings=%q want=%q", got, want)
+	}
+}
+
 func TestLoggingResourcesCloseClosesRuntimeBeforePrivateFSAndIsIdempotent(t *testing.T) {
 	paths, err := platform.NewPaths(filepath.Join(t.TempDir(), "data")).Absolute()
 	if err != nil {
@@ -217,6 +248,103 @@ func TestModelSetLoggingHealthKeepsFactoryHealth(t *testing.T) {
 	if model.loggingHealth == nil || !model.loggingHealth.Available() {
 		t.Fatal("model did not retain logging health")
 	}
+}
+
+func TestTUILoggingBootstrapFailureIsRateLimited(t *testing.T) {
+	var warnings bytes.Buffer
+	now := time.Unix(1, 0)
+	reporter := newTUILoggingFailureReporter(&warnings, nil, func() time.Time { return now })
+	reporter.report(tuiLoggingBootstrapFailure, errors.New("open failed"))
+	reporter.report(tuiLoggingBootstrapFailure, errors.New("open failed"))
+	if got, want := warnings.String(), "Warning: TUI file logging is unavailable\n"; got != want {
+		t.Fatalf("warnings=%q want=%q", got, want)
+	}
+	now = now.Add(tuiLoggingFailureWindow)
+	reporter.report(tuiLoggingBootstrapFailure, errors.New("open failed"))
+	if got, want := warnings.String(), "Warning: TUI file logging is unavailable\nWarning: TUI file logging is unavailable\n"; got != want {
+		t.Fatalf("warnings after window=%q want=%q", got, want)
+	}
+}
+
+func TestTUILoggingCleanupFailureNeverLeaksDetails(t *testing.T) {
+	path := filepath.Join("C:", "Users", "operator", "secret-data")
+	for _, redactor := range []*logging.Redactor{nil, logging.NewRedactor("tui-bootstrap-token")} {
+		var warnings bytes.Buffer
+		reporter := newTUILoggingFailureReporter(&warnings, redactor, nil)
+		reporter.report(tuiLoggingCleanupFailure, errors.New("close "+path+" token=tui-bootstrap-token"))
+		if got, want := warnings.String(), "Warning: TUI file logging cleanup failed\n"; got != want {
+			t.Fatalf("warnings=%q want=%q", got, want)
+		}
+	}
+}
+
+func TestFinishRunClosesLifecycleExactlyOnceInEveryExitPath(t *testing.T) {
+	programErr := errors.New("bubble tea failed")
+	for _, test := range []struct {
+		name           string
+		final          tea.Model
+		runErr         error
+		wantCloseErr   error
+		wantRelaunches int
+	}{
+		{name: "normal exit", final: NewModel()},
+		{name: "bubble tea error", final: NewModel(), runErr: programErr, wantCloseErr: programErr},
+		{name: "relaunch", final: requestedRelaunchModel(), wantRelaunches: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var order []string
+			runtime := &orderedCloser{name: "runtime", order: &order}
+			fs := &orderedCloser{name: "fs", order: &order}
+			cleanup := func(tea.Model) error {
+				return closeTUILifecycle(func() { order = append(order, "session") }, runtime, fs)
+			}
+			relaunches := 0
+			err := finishRun(test.final, test.runErr, io.Discard, func() error {
+				relaunches++
+				order = append(order, "relaunch")
+				if !slices.Equal(order, []string{"session", "runtime", "fs", "relaunch"}) {
+					t.Fatalf("relaunch order=%q", order)
+				}
+				return nil
+			}, cleanup)
+			if !errors.Is(err, test.wantCloseErr) || relaunches != test.wantRelaunches {
+				t.Fatalf("err=%v relaunches=%d", err, relaunches)
+			}
+			if want := []string{"session", "runtime", "fs"}; !slices.Equal(order[:3], want) {
+				t.Fatalf("close order=%q want=%q", order, want)
+			}
+			if runtime.calls != 1 || fs.calls != 1 {
+				t.Fatalf("runtime=%d fs=%d", runtime.calls, fs.calls)
+			}
+		})
+	}
+}
+
+func TestNewRunModelInjectsHealthAfterClientModelReplacement(t *testing.T) {
+	health := testLoggingHealth{available: true}
+	client := controlclient.New("unused", "")
+	model := newRunModel(context.Background(), client, nil, health)
+	if model.loggingHealth == nil || !model.loggingHealth.Available() {
+		t.Fatal("final client model lost logging health")
+	}
+}
+
+func requestedRelaunchModel() Model {
+	model := NewModel()
+	model.relaunchRequested = true
+	return model
+}
+
+type orderedCloser struct {
+	name  string
+	order *[]string
+	calls int
+}
+
+func (c *orderedCloser) Close() error {
+	c.calls++
+	*c.order = append(*c.order, c.name)
+	return nil
 }
 
 type testLoggingHealth struct{ available bool }

--- a/internal/tui/run_test.go
+++ b/internal/tui/run_test.go
@@ -241,6 +241,40 @@ func TestLoggingResourcesCloseClosesRuntimeBeforePrivateFSAndIsIdempotent(t *tes
 	}
 }
 
+func TestLoggingResourcesCopiesShareCloseState(t *testing.T) {
+	for _, test := range []struct {
+		name             string
+		runtime          io.Closer
+		privateFS        io.Closer
+		wantRuntimeClose int
+		wantPrivateClose int
+	}{
+		{name: "zero resources"},
+		{name: "partial runtime", runtime: &countingCloser{}, wantRuntimeClose: 1},
+		{name: "partial private fs", privateFS: &countingCloser{}, wantPrivateClose: 1},
+		{name: "runtime and private fs", runtime: &countingCloser{}, privateFS: &countingCloser{}, wantRuntimeClose: 1, wantPrivateClose: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			resources := LoggingResources{closeState: newLoggingResourcesCloseState(test.runtime, test.privateFS)}
+			copied := resources
+
+			if err := resources.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if err := copied.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			if closer, ok := test.runtime.(*countingCloser); ok && closer.calls != test.wantRuntimeClose {
+				t.Fatalf("runtime close calls=%d want=%d", closer.calls, test.wantRuntimeClose)
+			}
+			if closer, ok := test.privateFS.(*countingCloser); ok && closer.calls != test.wantPrivateClose {
+				t.Fatalf("private fs close calls=%d want=%d", closer.calls, test.wantPrivateClose)
+			}
+		})
+	}
+}
+
 func TestModelSetLoggingHealthKeepsFactoryHealth(t *testing.T) {
 	health := testLoggingHealth{available: true}
 	model := NewModel()
@@ -339,6 +373,13 @@ type orderedCloser struct {
 	name  string
 	order *[]string
 	calls int
+}
+
+type countingCloser struct{ calls int }
+
+func (c *countingCloser) Close() error {
+	c.calls++
+	return nil
 }
 
 func (c *orderedCloser) Close() error {


### PR DESCRIPTION
## 变更内容

- 为 daemon、TUI 与 mihomo 增加独立 JSONL 文件日志，并接入进程启动、关闭及 Unix relaunch 生命周期。
- 增加受限 PrivateFS、Unix/Windows owner/ACL 加固、跨进程 advisory lock，以及按大小安全轮转。
- 增加结构化脱敏、mihomo stdout/stderr 行捕获、写锁超时丢弃与限频降级报告。
- 补充用户文档、架构说明和覆盖正常路径、错误路径、并发及生命周期的回归测试。

## 类型

- [x] feat: 新功能
- [x] fix: Bug 修复
- [ ] refactor: 重构
- [x] docs: 文档
- [x] test: 测试
- [ ] chore: 构建/工具

## 检查清单

- [x] go test -race ./... 通过
- [x] go vet ./... 通过
- [x] gofmt -l cmd internal 无输出
- [x] 提交包含 Signed-off-by（DCO 签名）
- [x] 未修改 CHANGELOG.md
- [x] 跨平台影响已在下方说明；未修改 internal/control/protocol 稳定契约或新增 CLI 命令

## 验证

- go test -count=1 ./...
- go test -count=1 -race ./...
- go vet ./...
- gofmt -l .
- git diff --check
- CGO_ENABLED=0 交叉编译：Windows、Linux、macOS 的 amd64/arm64

## 兼容性与范围

- PR 目标为 dev；不新增 /v1/logging，不修改 config.Settings、稳定控制协议或 CHANGELOG.md。
- daemon/mihomo 使用 info、10 MiB、3 files；TUI bootstrap 使用 debug、100 MiB、10 files。
- daemon/mihomo 日志初始化失败会阻止启动；TUI 初始化失败时继续运行，并向 stderr 输出限频且脱敏的稳定错误。
- 当前主机为 Windows；Unix 已通过无 CGO 交叉编译，原生 Unix 运行验证交由 CI 完成。

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mihari-proxy/mihari/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

