### PR TITLE
fix: 修复 dev.3 更新后 Windows 服务无法启动

### DIFF
--- a/internal/platform/privatefs_identity_windows_test.go
+++ b/internal/platform/privatefs_identity_windows_test.go
@@ -1,0 +1,65 @@
+//go:build windows
+
+package platform
+
+import (
+	"golang.org/x/sys/windows"
+	"testing"
+)
+
+func TestCurrentProcessIsLocalSystem_UsesPrimaryToken(t *testing.T) {
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := user.User.Sid.String() == "S-1-5-18"
+	got, err := currentProcessIsLocalSystem()
+	if err != nil {
+		t.Fatalf("query process identity: %v", err)
+	}
+	if got != want {
+		t.Fatalf("LocalSystem=%v want %v", got, want)
+	}
+}
+
+func TestPrivateDataPrincipal_SystemAccountTypeDependsOnCaller(t *testing.T) {
+	// Synthetic personal SID keeps the fixture valid even under a SYSTEM runner.
+	user, err := windows.StringToSid("S-1-5-21-1-2-3-1001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	admins, err := windows.CreateWellKnownSid(windows.WinBuiltinAdministratorsSid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldLookup, oldSystem := privateAccountKind, processIsLocalSystem
+	t.Cleanup(func() { privateAccountKind, processIsLocalSystem = oldLookup, oldSystem })
+	processIsLocalSystem = func() (bool, error) { return true, nil }
+	for _, kind := range []uint32{windows.SidTypeUser, windows.SidTypeWellKnownGroup} {
+		privateAccountKind = func(sid *windows.SID) (uint32, error) {
+			if sid.String() == "S-1-5-18" {
+				return kind, nil
+			}
+			if sid.Equals(user) {
+				return windows.SidTypeUser, nil
+			}
+			return oldLookup(sid)
+		}
+		for _, explicitUser := range []bool{true, false} {
+			sddl := "O:BAD:P(A;;FA;;;SY)(A;;FA;;;BA)"
+			want := admins
+			if explicitUser {
+				sddl += "(A;;FA;;;" + user.String() + ")"
+				want = user
+			}
+			sd, err := windows.SecurityDescriptorFromString(sddl)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := privateDataPrincipal(sd)
+			if err != nil || got == nil || !got.Equals(want) {
+				t.Errorf("SYSTEM kind=%d explicitUser=%v got=%v err=%v want=%v", kind, explicitUser, got, err, want)
+			}
+		}
+	}
+}

--- a/internal/platform/privatefs_windows.go
+++ b/internal/platform/privatefs_windows.go
@@ -28,6 +28,11 @@ var privateRootSecurity = func(h windows.Handle) (*windows.SECURITY_DESCRIPTOR, 
 }
 var privateHardenHandle = hardenHandle
 
+var privateAccountKind = func(sid *windows.SID) (uint32, error) {
+	_, _, kind, err := sid.LookupAccount("")
+	return kind, err
+}
+
 type privateFSState struct {
 	root  windows.Handle
 	dirs  map[string]windows.Handle
@@ -525,7 +530,13 @@ func privateDataPrincipal(sd *windows.SECURITY_DESCRIPTOR) (*windows.SID, error)
 			continue
 		}
 		sid := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
-		_, _, kind, lookupErr := sid.LookupAccount("")
+		// LookupAccount reports SYSTEM as SidTypeUser when called by SYSTEM,
+		// but as SidTypeWellKnownGroup for an interactive caller. It is never
+		// the individual data user, regardless of that context-sensitive result.
+		if sid.String() == "S-1-5-18" {
+			continue
+		}
+		kind, lookupErr := privateAccountKind(sid)
 		if lookupErr != nil {
 			return nil, fmt.Errorf("resolve private data principal: %w", lookupErr)
 		}


### PR DESCRIPTION
## 变更内容

修复 v0.9.2-dev.3 中 Windows LocalSystem 服务启动即退出、TUI 显示 Service stopped 的回归。

数据根由 Administrators 所有且 DACL 含个人用户与 SYSTEM 时，真实 SYSTEM 进程将自身 S-1-5-18 解析为 SidTypeUser (1)，普通用户进程则得到 SidTypeWellKnownGroup (5)。#202 按账户类型挑选个人用户，因此服务误判为多个个人用户，NewPrivateFS 失败；daemon 最终只显示 create mihari data directories。

授权主体解析现在在账户类型查询前按固定 SID 排除 SYSTEM。保留无个人授权时的 BA fallback、并发迁移复查以及 deny/未知 ACL 的拒绝策略。

## 验证

- 新回归覆盖 SYSTEM 类型 1/5 × 有/无个人授权。修复前类型 1 两种场景均失败，修复后通过。个人账户使用合成 SID，测试不依赖调用身份。
- 经用户授权创建临时 SYSTEM 只读诊断任务，确认了真实身份下的类型差异；随后使用修复后的生产解析函数，正确选中个人用户。任务已删除，没有修改实际目录 ACL、启动服务或更改其他代理。
- 全仓 go test -race ./...、go vet ./...、golangci-lint 均通过；Windows/Linux/macOS amd64/arm64 六平台 CGO_ENABLED=0 编译通过；gofmt、diff check 通过。
- 前一轮升级集成测试使用提权交互用户并 mock SYSTEM 判断，没有覆盖真实 SYSTEM 的 LookupAccount 返回类型。这是此前验证缺口，本 PR 用本机原生证据及可稳定复现的回归补上。

## 类型

- [x] fix: Bug 修复

## 检查清单

- [x] go test -race ./... 通过
- [x] go vet ./... 通过
- [x] 修改文件 gofmt 通过
- [x] DCO sign-off
- [x] 未修改 CHANGELOG.md
- [x] 未修改协议、配置格式或 CLI 退出码

修复 #202 引入的问题；替代 v0.9.2-dev.3 的修复版发布后，还需用户升级并启动服务确认真实运行恢复。

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mihari-proxy/mihari/pull/203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

