### PR TITLE
fix: 增加日志导出路径复制成功提示

### DIFF
--- a/internal/tui/ui/exportlogs.go
+++ b/internal/tui/ui/exportlogs.go
@@ -142,6 +142,7 @@ type ExportLogsModel struct {
 	cursors                               map[exportFocus]int
 	resultPath, message                   string
 	warning                               bool
+	copySucceeded                         bool
 	editing, discardOpen, discardSelected bool
 	editValue                             string
 	editRange                             logging.RangeKind
@@ -184,6 +185,7 @@ func (m *ExportLogsModel) Open() {
 	m.cursors = map[exportFocus]int{exportFocusFrom: TextCursorEnd(m.from), exportFocusTo: TextCursorEnd(m.to), exportFocusOutput: TextCursorEnd(m.output)}
 	m.resultPath, m.message, m.closed = "", "", false
 	m.warning = false
+	m.copySucceeded = false
 	m.editing, m.discardOpen, m.discardSelected = false, false, false
 	m.clockGeneration++
 }
@@ -233,7 +235,8 @@ func (m *ExportLogsModel) Update(message tea.Msg) (tea.Cmd, bool) {
 		}
 		switch key.String() {
 		case "enter":
-			if m.options.WriteClipboard(m.resultPath) != nil {
+			m.copySucceeded = m.options.WriteClipboard(m.resultPath) == nil
+			if !m.copySucceeded {
 				m.message = ExportCopyFailed
 			} else {
 				m.message = ExportPathCopied
@@ -373,6 +376,7 @@ func (m *ExportLogsModel) submit() tea.Cmd {
 	}
 	m.pending, m.message = true, ""
 	m.warning = false
+	m.copySucceeded = false
 	return func() tea.Msg { return <-results }
 }
 
@@ -495,7 +499,7 @@ func (m *ExportLogsModel) View(width, height int) string {
 		body += "\n\n" + ExportSuccessHelp
 		if m.message != "" {
 			style := theme.Danger
-			if m.message == ExportPathCopied {
+			if m.copySucceeded {
 				style = theme.Success
 			}
 			body += "\n\n" + style.Render(m.message)

--- a/internal/tui/ui/exportlogs.go
+++ b/internal/tui/ui/exportlogs.go
@@ -236,7 +236,7 @@ func (m *ExportLogsModel) Update(message tea.Msg) (tea.Cmd, bool) {
 			if m.options.WriteClipboard(m.resultPath) != nil {
 				m.message = ExportCopyFailed
 			} else {
-				m.message = ""
+				m.message = ExportPathCopied
 			}
 			return nil, true
 		case "esc":
@@ -492,10 +492,14 @@ func (m *ExportLogsModel) View(width, height int) string {
 		if m.warning {
 			body += "\n\n" + exportWarningNotice
 		}
-		if m.message != "" {
-			body += "\n" + theme.Danger.Render(m.message)
-		}
 		body += "\n\n" + ExportSuccessHelp
+		if m.message != "" {
+			style := theme.Danger
+			if m.message == ExportPathCopied {
+				style = theme.Success
+			}
+			body += "\n\n" + style.Render(m.message)
+		}
 		return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, theme.Dialog.Width(min(84, max(36, width-4))).Render(body))
 	}
 	line := func(field exportFocus, label, value string) string {

--- a/internal/tui/ui/exportlogs_test.go
+++ b/internal/tui/ui/exportlogs_test.go
@@ -432,3 +432,39 @@ func TestExportLogsModel_QuitKeysAreNotConsumedOutsideText(t *testing.T) {
 		t.Fatal("text q not edited")
 	}
 }
+
+func TestExportLogsModel_CopyShowsSuccessBelowHelp(t *testing.T) {
+	const notice = "Log File Directory Copied！"
+	var copied string
+	var copyErr error
+	m := NewExportLogsModel(ExportLogsOptions{Now: exportTestNow, DefaultDir: t.TempDir(), WriteClipboard: func(path string) error { copied = path; return copyErr }})
+	m.Open()
+	m.pending = true
+	m.Update(exportResultMsg{Generation: m.generation, Result: logging.ExportResult{Path: "C:/logs/export.zip"}})
+	if strings.Contains(m.View(120, 30), notice) {
+		t.Fatal("copy notice shown before copying")
+	}
+	m.Update(key(tea.KeyEnter, ""))
+	view := m.View(120, 30)
+	if copied != "C:/logs/export.zip" || !strings.Contains(view, DefaultTheme().Success.Render(notice)) {
+		t.Fatalf("copy feedback missing: %s", view)
+	}
+	if strings.Index(view, notice) < strings.Index(view, ExportSuccessHelp) {
+		t.Fatal("notice must be below help")
+	}
+	copyErr = errors.New("clipboard unavailable")
+	m.Update(key(tea.KeyEnter, ""))
+	view = m.View(120, 30)
+	if strings.Contains(view, notice) || !strings.Contains(view, ExportCopyFailed) {
+		t.Fatal("failed retry retained success feedback")
+	}
+	copyErr = nil
+	m.Update(key(tea.KeyEnter, ""))
+	if !strings.Contains(m.View(120, 30), notice) {
+		t.Fatal("successful retry did not clear failure")
+	}
+	m.Open()
+	if strings.Contains(m.View(120, 30), notice) {
+		t.Fatal("reopened dialog retained copy feedback")
+	}
+}

--- a/internal/tui/ui/exportlogs_test.go
+++ b/internal/tui/ui/exportlogs_test.go
@@ -434,7 +434,7 @@ func TestExportLogsModel_QuitKeysAreNotConsumedOutsideText(t *testing.T) {
 }
 
 func TestExportLogsModel_CopyShowsSuccessBelowHelp(t *testing.T) {
-	const notice = "Log File Directory Copied！"
+	const notice = "Log file path copied!"
 	var copied string
 	var copyErr error
 	m := NewExportLogsModel(ExportLogsOptions{Now: exportTestNow, DefaultDir: t.TempDir(), WriteClipboard: func(path string) error { copied = path; return copyErr }})
@@ -451,6 +451,11 @@ func TestExportLogsModel_CopyShowsSuccessBelowHelp(t *testing.T) {
 	}
 	if strings.Index(view, notice) < strings.Index(view, ExportSuccessHelp) {
 		t.Fatal("notice must be below help")
+	}
+	// Presentation follows the copy outcome even if the message wording changes.
+	m.message = "Copied to clipboard"
+	if !strings.Contains(m.View(120, 30), DefaultTheme().Success.Render(m.message)) {
+		t.Fatal("success style depends on message text")
 	}
 	copyErr = errors.New("clipboard unavailable")
 	m.Update(key(tea.KeyEnter, ""))

--- a/internal/tui/ui/strings.go
+++ b/internal/tui/ui/strings.go
@@ -17,7 +17,7 @@ const (
 	ExportComplete       = "Export complete"
 	ExportCancelled      = "Export cancelled"
 	ExportCopyFailed     = "Could not copy path"
-	ExportPathCopied     = "Log File Directory Copied！"
+	ExportPathCopied     = "Log file path copied!"
 	ExportNoLogLines     = "No log lines in the selected range"
 	ExportTargetInvalid  = "Invalid export destination"
 	ExportTargetExists   = "Export file already exists"

--- a/internal/tui/ui/strings.go
+++ b/internal/tui/ui/strings.go
@@ -17,6 +17,7 @@ const (
 	ExportComplete       = "Export complete"
 	ExportCancelled      = "Export cancelled"
 	ExportCopyFailed     = "Could not copy path"
+	ExportPathCopied     = "Log File Directory Copied！"
 	ExportNoLogLines     = "No log lines in the selected range"
 	ExportTargetInvalid  = "Invalid export destination"
 	ExportTargetExists   = "Export file already exists"


### PR DESCRIPTION
## 变更内容

导出完成页按 Enter 复制路径成功后，原先没有任何可见反馈。现在在底部快捷键说明下方绿色显示 `Log file path copied!`；复制失败显示错误，重试成功及重新打开对话框时更新或清除反馈。成功颜色由独立 copySucceeded 状态控制，不再依赖文案匹配。

## 类型

- [x] fix: Bug 修复

## 验证

- 新增回归覆盖复制前无提示、成功提示位置与绿色样式、失败重试、成功重试及重新打开时清除提示；先验证失败，再实现通过。
- `go test ./internal/tui/... ./cmd/mihari` 通过。
- `go test -race ./internal/tui/ui ./internal/tui ./cmd/mihari` 通过。
- `go vet ./internal/tui/ui ./internal/tui ./cmd/mihari` 通过。
- 修改文件 gofmt、git diff --check 通过。

## 检查清单

- [x] 提交包含 DCO Signed-off-by
- [x] 未修改 CHANGELOG.md
- [x] 未修改控制协议、配置格式或 CLI 退出码

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mihari-proxy/mihari/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

