### PR TITLE
fix: 修复 systemd 自动重启等待状态阻塞服务恢复

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -25,6 +25,8 @@ mihari service uninstall
 
 Unix 的 install/reinstall/update/start/stop/uninstall 走统一安装用例，未完成事务须显式恢复；Windows 保持原服务行为。Unix 自动化入口为 `mihari service apply --request /absolute/request.json`（严格版本化 JSON，请求文件 root0600）；operation=recover 用于恢复，不会隐式导入旧树。卸载保留数据与旧日志。
 
+Linux 服务启动失败后，systemd 可能显示 `activating (auto-restart)`。如果此时主进程已退出（`MainPID=0`），`mihari service status` 返回 `stopped`，仍允许进入服务停止或重装流程；这不表示 systemd 已取消自动重启。升级旧版本后若日志提示 `existing data requires recovery or migration`，应使用包含此修复的版本执行 `sudo mihari service reinstall`，由安装事务处理旧数据和服务定义，而不是直接修改 unit 的启动参数。重装失败时保留报错和 `journalctl -u mihari` 日志继续排查。
+
 守护进程本身可手动在前台运行(OS 服务与 TUI 的 System 页面使用同一入口);正常使用无需手动执行,且前台运行时关闭终端会停止守护进程:
 
 ```console

--- a/internal/app/install_activation_adapter_test.go
+++ b/internal/app/install_activation_adapter_test.go
@@ -75,6 +75,19 @@ type barrierValidation struct {
 	check func()
 }
 
+// restartWaitRunner models the legacy service repeatedly exiting before the
+// installer replaces its definition. Masking still stops its restart job.
+type restartWaitRunner struct{ barrierRunner }
+
+func (r restartWaitRunner) Run(ctx context.Context, args []string) (service.CommandResult, error) {
+	result, err := r.barrierRunner.Run(ctx, args)
+	unit := r.store.files[service.DefaultSystemdPaths().UnitFile]
+	if err == nil && strings.Contains(string(result.Stdout), "LoadState=loaded") && !strings.Contains(string(unit.Bytes), "Restart=on-failure") {
+		result.Stdout = []byte(strings.NewReplacer("ActiveState=inactive", "ActiveState=activating", "SubState=dead", "SubState=auto-restart").Replace(string(result.Stdout)))
+	}
+	return result, err
+}
+
 func (v barrierValidation) ReapValidation(ctx context.Context, id ProcessStartIdentity, j InstallJournal) error {
 	return v.ValidationChild.(*FakeValidationChild).ReapValidation(ctx, id, j)
 }
@@ -84,8 +97,17 @@ func (v barrierValidation) Start(ctx context.Context, s ValidationStart) (Valida
 }
 
 func TestInstallActivation_RealAdapterKeepsMaskUntilAuthority(t *testing.T) {
-	for _, failed := range []bool{false, true} {
-		t.Run(map[bool]string{false: "activation", true: "source recovery"}[failed], func(t *testing.T) {
+	for _, scenario := range []struct {
+		name                string
+		failed, restartWait bool
+	}{
+		{"activation", false, false},
+		{"source recovery", true, false},
+		{"auto-restart activation", false, true},
+		{"auto-restart source recovery", true, true},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			failed := scenario.failed
 			h := newInstallHarness(t, InstallDataRetain)
 			h.art.OldRunning = false
 			h.art.OldEnabled = false
@@ -97,7 +119,11 @@ func TestInstallActivation_RealAdapterKeepsMaskUntilAuthority(t *testing.T) {
 			target := old
 			target.Bytes = append(append([]byte{}, old.Bytes...), []byte("Restart=on-failure\n")...)
 			store := &barrierStore{files: map[string]service.DefinitionFile{path: old}, links: map[string]string{}}
-			adapter := service.NewSystemdAdapterWithConfig(service.SystemdConfig{Runner: barrierRunner{store}, Files: store, Hook: h.tx.journaledHook})
+			var runner service.CommandRunner = barrierRunner{store}
+			if scenario.restartWait {
+				runner = restartWaitRunner{barrierRunner{store}}
+			}
+			adapter := service.NewSystemdAdapterWithConfig(service.SystemdConfig{Runner: runner, Files: store, Hook: h.tx.journaledHook})
 			h.tx.Service = adapter
 			oldDef := service.Definition{Status: service.StatusStopped, Binary: "/usr/local/lib/mihari/mihari", Files: []service.DefinitionFile{old}}
 			targetDef := oldDef

--- a/internal/service/definition_systemd.go
+++ b/internal/service/definition_systemd.go
@@ -130,6 +130,13 @@ func (a *SystemdAdapter) definitionFromShow(ctx context.Context, props map[strin
 		running = true
 	case "inactive", "failed":
 		running = false
+	case "activating":
+		// A failed service waiting for RestartSec has no main process, but
+		// its definition must remain available for stop/reinstall recovery.
+		// Other activating states may still be starting a process.
+		if props["SubState"] != "auto-restart" || props["MainPID"] != "0" {
+			return Definition{}, invalidServiceState("service status is unknown")
+		}
 	default:
 		return Definition{}, invalidServiceState("service status is unknown")
 	}

--- a/internal/service/definition_systemd_test.go
+++ b/internal/service/definition_systemd_test.go
@@ -106,6 +106,60 @@ func systemdMaskedShow() string {
 	}, "\n") + "\n"
 }
 
+func TestSystemdInspect_AutoRestartIsInstalledButNotRunning(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		t.Run(stateName(false, enabled), func(t *testing.T) {
+			h := newSystemdHarness(t, false, enabled, trustedUnitFile(t))
+			h.show = strings.NewReplacer("ActiveState=inactive", "ActiveState=activating", "SubState=dead", "SubState=auto-restart").Replace(h.show)
+			got, err := h.adapter.InspectDefinition(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Status != StatusStopped || got.Running || got.Enabled != enabled || got.Binary != "/usr/local/lib/mihari/mihari" {
+				t.Fatalf("unexpected restart-wait definition: %+v", got)
+			}
+			if len(h.hook.kinds) != 0 {
+				t.Fatal("inspection mutated the service")
+			}
+		})
+	}
+}
+
+func TestSystemdInspect_RejectsOtherActivatingStates(t *testing.T) {
+	for _, state := range []struct{ sub, pid string }{
+		{"start", "0"}, {"start-pre", "0"}, {"unknown", "0"},
+		{"auto-restart", "4242"}, {"auto-restart", "invalid"},
+	} {
+		t.Run(state.sub+"-"+state.pid, func(t *testing.T) {
+			h := newSystemdHarness(t, false, true, trustedUnitFile(t))
+			h.show = strings.NewReplacer("ActiveState=inactive", "ActiveState=activating", "SubState=dead", "SubState="+state.sub, "MainPID=0", "MainPID="+state.pid).Replace(h.show)
+			_, err := h.adapter.InspectDefinition(context.Background())
+			if err == nil {
+				t.Fatal("accepted an unverified activating state")
+			}
+			requireInvalidState(t, err)
+		})
+	}
+}
+
+func TestSystemdDisableAutostartAndStop_AutoRestart(t *testing.T) {
+	h := newSystemdHarness(t, false, true, trustedUnitFile(t))
+	h.show = strings.NewReplacer("ActiveState=inactive", "ActiveState=activating", "SubState=dead", "SubState=auto-restart").Replace(h.show)
+	if err := h.adapter.DisableAutostartAndStop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	assertSystemdStopSequence(t, h.runner.calls)
+	if !h.files.masked(defaultSystemdUnitFile) {
+		t.Fatal("restart loop was not masked")
+	}
+	if _, err := h.files.ReadLink(context.Background(), DefaultSystemdPaths().WantsLink); !os.IsNotExist(err) {
+		t.Fatalf("autostart link remains: %v", err)
+	}
+	if err := h.adapter.WaitOwnedTreeExit(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestSystemdInspect_RejectsSymlinkDropins(t *testing.T) {
 	for _, target := range []string{defaultDevNull, "/other/config.conf"} {
 		dropin := trustedDropinFile(t)


### PR DESCRIPTION
## 变更内容

Ubuntu 上 Mihari 启动失败后，systemd 会在 `activating / auto-restart`、`MainPID=0` 状态等待下一次重试。现有适配器将其判为未知状态，使状态查询以及重装/恢复流程提前退出。

仅将该精确组合识别为已安装但当前未运行（`stopped`）。其他启动中状态仍拒绝，定义校验、mask → reload → stop 和 cgroup 退出检查保持有效。补充状态识别、停止、安装激活与失败回滚回归测试，并说明旧版本升级后应通过重装事务处理数据和服务定义。

基于 `dev` / `v0.9.3-dev.1`（3b71c19）。本 PR 修复恢复入口的阻塞；不代表已完成本机旧数据迁移或修复全部历史启动失败原因。

## 类型

- [x] fix: Bug 修复

## 验证

使用 Go 1.26.5：

- `go test ./internal/service ./internal/platform ./internal/app ./internal/cli` 通过。
- `go test -race ./internal/service ./internal/app` 通过。
- `go vet ./internal/service ./internal/app` 通过。
- Linux amd64、Windows amd64、macOS amd64 的 `CGO_ENABLED=0` 构建通过。
- 回归测试在移除生产修复后按预期失败，恢复修复后通过。
- 本机只读核验：systemd 保持 `activating / auto-restart / MainPID=0`，新构建 `service status --json` 返回 `stopped`；未执行真实服务停止、重装或数据迁移。
- 独立代码审查未发现 actionable findings。

验证使用一次性受限权限源码副本：原工作区祖先目录组可写，导致可信目录测试拒绝夹具。

`go test ./internal/integration` 未全部通过：`TestUnixSnapshotContract_LayoutClientAssembleFixture` 和 `TestUnixSnapshotContract_FakeCompleteAndEarlyEOFNeverPublish` 因日志导出暂存目录残留失败。使用未修改生产代码的基线 overlay 重跑这两项，复现相同失败；本 PR 未扩展修改日志导出。

GitHub CI 的三平台全仓 unit、race、vet-format，以及六平台构建已通过；上述日志导出失败仅在本机复现。Cubic bot 审查未发现问题。

## 检查清单

- [x] `go test -race ./...` 通过（GitHub CI 三平台）
- [x] `go vet ./...` 通过（GitHub CI 三平台）
- [x] 修改过的 Go 文件 gofmt 无输出，`git diff --check` 通过
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] 未修改 `CHANGELOG.md`
- [x] CLI 状态影响已说明：自动重启等待且无主进程时返回既有 `stopped`，未新增协议字段或退出码
