### PR TITLE
fix: 使用已校验新版执行在线安装事务

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
         run: python scripts/install/test_parallel_download.py -v
       - name: Test install channel resolution
         run: python -m pytest scripts/install/test_install_channel.py -q
+      - name: Test installer bootstrap and generated bridge
+        run: python -m pytest scripts/install/test_root_apply_entry.py scripts/install/test_root_apply_generated.py -q
       - name: Test isolated security runner without privileges
         run: python -m pytest scripts/test/test_unix_layout_security.py -q
       - name: Test release safety policies

--- a/scripts/install/install-aio-remote.sh
+++ b/scripts/install/install-aio-remote.sh
@@ -380,7 +380,9 @@ if [ -z "$entry" ] || [ -z "$candidate" ]; then
   root_fetch "$release/$asset" "$stage/entry"
   [ "$(checksum "$stage/entry")" = "$expected" ] || fail "official binary checksum mismatch"
   chmod 0700 "$stage/entry"
-  [ -n "$entry" ] || entry="$stage/entry"
+  # Run the verified release's installer so an older installed version cannot
+  # prevent its own upgrade before the candidate is published.
+  entry="$stage/entry"
   [ -n "$candidate" ] || candidate="$stage/entry"
 fi
 # BEGIN REQUEST JSON

--- a/scripts/install/install-aio.sh
+++ b/scripts/install/install-aio.sh
@@ -127,7 +127,9 @@ if [ -z "$entry" ] || [ -z "$candidate" ]; then
   root_fetch "$release/$asset" "$stage/entry"
   [ "$(checksum "$stage/entry")" = "$expected" ] || fail "official binary checksum mismatch"
   chmod 0700 "$stage/entry"
-  [ -n "$entry" ] || entry="$stage/entry"
+  # Run the verified release's installer so an older installed version cannot
+  # prevent its own upgrade before the candidate is published.
+  entry="$stage/entry"
   [ -n "$candidate" ] || candidate="$stage/entry"
 fi
 # BEGIN REQUEST JSON

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -263,7 +263,9 @@ if [ -z "$entry" ] || [ -z "$candidate" ]; then
   root_fetch "$release/$asset" "$stage/entry"
   [ "$(checksum "$stage/entry")" = "$expected" ] || fail "official binary checksum mismatch"
   chmod 0700 "$stage/entry"
-  [ -n "$entry" ] || entry="$stage/entry"
+  # Run the verified release's installer so an older installed version cannot
+  # prevent its own upgrade before the candidate is published.
+  entry="$stage/entry"
   [ -n "$candidate" ] || candidate="$stage/entry"
 fi
 # BEGIN REQUEST JSON

--- a/scripts/install/root-apply.sh.in
+++ b/scripts/install/root-apply.sh.in
@@ -74,7 +74,9 @@ if [ -z "$entry" ] || [ -z "$candidate" ]; then
   root_fetch "$release/$asset" "$stage/entry"
   [ "$(checksum "$stage/entry")" = "$expected" ] || fail "official binary checksum mismatch"
   chmod 0700 "$stage/entry"
-  [ -n "$entry" ] || entry="$stage/entry"
+  # Run the verified release's installer so an older installed version cannot
+  # prevent its own upgrade before the candidate is published.
+  entry="$stage/entry"
   [ -n "$candidate" ] || candidate="$stage/entry"
 fi
 # BEGIN REQUEST JSON

--- a/scripts/install/test_root_apply_entry.py
+++ b/scripts/install/test_root_apply_entry.py
@@ -1,0 +1,73 @@
+"""Exercise bootstrap entry selection without root, network, or service IO."""
+import hashlib
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+INSTALL = Path(__file__).parent
+
+
+@unittest.skipUnless(
+    os.name == "posix" and shutil.which("sh") and (shutil.which("sha256sum") or shutil.which("shasum")),
+    "requires native POSIX shell and a SHA256 tool",
+)
+class RootApplyEntryTests(unittest.TestCase):
+    def run_selection(self, installed=True, offline=False, valid_checksum=True):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            old = root / "old"
+            old.write_text("#!/bin/sh\n[ \"$3\" = --help ] && exit 0\nprintf 'old-entry\\n'\n")
+            old.chmod(0o700)
+            new = root / "official"
+            new.write_text("#!/bin/sh\nprintf 'new-entry\\n'\n")
+            digest = hashlib.sha256(new.read_bytes()).hexdigest() if valid_checksum else "0" * 64
+            (root / "manifest").write_text(f"{digest}  mihari-linux-amd64\n")
+            (root / "stage").mkdir()
+            source = (INSTALL / "root-apply.sh.in").read_text()
+            start = source.index("entry=/usr/local/lib/mihari/mihari\n")
+            end = source.index("# BEGIN REQUEST JSON", start)
+            selection = source[start:end].replace("entry=/usr/local/lib/mihari/mihari", "entry=" + shlex.quote(str(old)), 1)
+            script = "set -eu\n" + "\n".join([
+                "stage=" + shlex.quote(str(root / "stage")),
+                "official=" + shlex.quote(str(new)),
+                "manifest=" + shlex.quote(str(root / "manifest")),
+                "candidate=" + shlex.quote(str(root / "offline") if offline else ""),
+                "os=linux; arch=amd64; tag=v0.9.3-dev.2",
+                "trusted_entry() { return " + ("0" if installed else "1") + "; }",
+                'fail() { printf "%s\\n" "$1" >&2; exit 1; }',
+                'checksum() { if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1"; else shasum -a 256 "$1"; fi | cut -d" " -f1; }',
+                'root_fetch() { case "$1" in */SHA256SUMS.txt) cp "$manifest" "$2";; *) cp "$official" "$2";; esac; }',
+                selection,
+                '"$entry" service apply',
+            ])
+            return subprocess.run(["sh", "-c", script], capture_output=True, text=True, timeout=10)
+
+    def test_online_upgrade_executes_verified_new_entry(self):
+        result = self.run_selection()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "new-entry\n")
+
+    def test_first_install_executes_verified_entry(self):
+        result = self.run_selection(installed=False)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "new-entry\n")
+
+    def test_offline_install_keeps_trusted_installed_entry(self):
+        result = self.run_selection(offline=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "old-entry\n")
+
+    def test_bad_checksum_never_executes_an_apply_entry(self):
+        result = self.run_selection(valid_checksum=False)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("official binary checksum mismatch", result.stderr)
+        self.assertEqual(result.stdout, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更内容

已安装版本可能因服务状态识别错误而无法执行升级。在线安装脚本虽然下载并校验了新版官方 binary，却仍优先调用旧版 `service apply`，因此会在发布候选前重现旧版错误，新版始终无法安装。

下载分支现在使用刚完成 SHA256 校验的 root staging binary 执行安装事务。候选字节不作为未经验证的 root 入口；已有可信安装且提供离线候选时仍走原离线路径。由单一模板同步生成三个独立安装脚本。

补充实际执行 shell 入口选择的回归测试（无 root、网络或服务操作），覆盖在线升级、首次安装、离线旧入口保留和 checksum 失败拒绝执行。CI 新增 bootstrap 和完整生成桥接一致性测试。

这是 #212 的恢复路径补充：dev.1 的 TUI 会因旧服务查询逻辑失败而无法自更新，用户可通过更新后的在线安装脚本调用已发布 dev.2 完成安装。本 PR 不声称旧 TUI 自身已被远程修复，也未实际迁移用户数据或重装系统服务。

## 类型

- [x] fix: Bug 修复

## 验证

- 回归测试先复现 `old-entry` 而非 `new-entry`；修复后 4 项通过。
- `python3 -m unittest discover -s scripts/install -p test_root_apply_entry.py -v` 通过。
- 完整 root bridge 漂移/再生成测试通过。
- `python3 scripts/install/generate_root_apply.py --check` 通过。
- 三个生成脚本的 `sh -n` 通过，`git diff --check` 通过。
- 正式 dev.2 Linux binary 已按发布 SHA256 清单校验；本机只读 `self version` 返回 `v0.9.3-dev.2`，`service status --json` 返回 `stopped`。已安装路径仍为 dev.1，未改系统安装。

## 检查清单

- [x] `go test -race ./...` 通过（GitHub CI 三平台）
- [x] `go vet ./...` 通过（GitHub CI 三平台）
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] 未修改 `CHANGELOG.md`
- [x] 未更改 CLI/JSON、退出码、校验来源或离线信任边界

## 审查结论与范围限制

Cubic 和 Pullfrog 均未发现需要修改的问题。Pullfrog 记录的非阻塞限制：AIO/离线路径有可信旧安装和非空候选时仍使用旧入口，因此这类旧版本恢复需改用在线安装脚本；扩大离线候选的 root 执行信任不在本 PR 范围内。
