### PR TITLE
fix: 修复首次启动残留导致的迁移失败

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -29,6 +29,8 @@ Linux 服务启动失败后，systemd 可能显示 `activating (auto-restart)`�
 
 如果旧目录只有 `mihari-channel`、空的 `install.lock`、空的 `locks` 目录和 `transactions/<ID>/transaction-id` 中的部分或全部，说明该目录尚未包含业务配置。安装事务可在校验这些启动残留后建立新的数据目录，保留旧目录，并由新 daemon 完成首次初始化。含恢复日志、事务备份、非空 `locks`、未知文件或不匹配标记的目录不会按此路径处理；不要通过删除这些文件强行绕过恢复检查。
 
+上述残留迁移要求旧数据根与目标数据根不同，例如从旧私有目录迁移到系统布局的 `/var/lib/mihari/data`。显式设置或继承 `MIHARI_DATA` 后在同一私有目录重装会保留原数据，不会清理这些残留。含 `transactions/<ID>/unit-bootstrap` 的目录也不属于仅有启动标记的情形，应保留现场继续排查。
+
 守护进程本身可手动在前台运行(OS 服务与 TUI 的 System 页面使用同一入口);正常使用无需手动执行,且前台运行时关闭终端会停止守护进程:
 
 ```console

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -27,7 +27,7 @@ Unix 的 install/reinstall/update/start/stop/uninstall 走统一安装用例，�
 
 Linux 服务启动失败后，systemd 可能显示 `activating (auto-restart)`。如果此时主进程已退出（`MainPID=0`），`mihari service status` 返回 `stopped`，仍允许进入服务停止或重装流程；这不表示 systemd 已取消自动重启。升级旧版本后若日志提示 `existing data requires recovery or migration`，应使用包含此修复的版本执行 `sudo mihari service reinstall`，由安装事务处理旧数据和服务定义，而不是直接修改 unit 的启动参数。重装失败时保留报错和 `journalctl -u mihari` 日志继续排查。
 
-如果旧目录只有 `mihari-channel`、空的 `install.lock` 和 `transactions/<ID>/transaction-id`，说明该目录尚未包含业务配置。安装事务可在校验这些启动残留后建立新的数据目录，保留旧目录，并由新 daemon 完成首次初始化。含恢复日志、事务备份、未知文件或不匹配标记的目录不会按此路径处理；不要通过删除这些文件强行绕过恢复检查。
+如果旧目录只有 `mihari-channel`、空的 `install.lock`、空的 `locks` 目录和 `transactions/<ID>/transaction-id` 中的部分或全部，说明该目录尚未包含业务配置。安装事务可在校验这些启动残留后建立新的数据目录，保留旧目录，并由新 daemon 完成首次初始化。含恢复日志、事务备份、非空 `locks`、未知文件或不匹配标记的目录不会按此路径处理；不要通过删除这些文件强行绕过恢复检查。
 
 守护进程本身可手动在前台运行(OS 服务与 TUI 的 System 页面使用同一入口);正常使用无需手动执行,且前台运行时关闭终端会停止守护进程:
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -27,6 +27,8 @@ Unix 的 install/reinstall/update/start/stop/uninstall 走统一安装用例，�
 
 Linux 服务启动失败后，systemd 可能显示 `activating (auto-restart)`。如果此时主进程已退出（`MainPID=0`），`mihari service status` 返回 `stopped`，仍允许进入服务停止或重装流程；这不表示 systemd 已取消自动重启。升级旧版本后若日志提示 `existing data requires recovery or migration`，应使用包含此修复的版本执行 `sudo mihari service reinstall`，由安装事务处理旧数据和服务定义，而不是直接修改 unit 的启动参数。重装失败时保留报错和 `journalctl -u mihari` 日志继续排查。
 
+如果旧目录只有 `mihari-channel`、空的 `install.lock` 和 `transactions/<ID>/transaction-id`，说明该目录尚未包含业务配置。安装事务可在校验这些启动残留后建立新的数据目录，保留旧目录，并由新 daemon 完成首次初始化。含恢复日志、事务备份、未知文件或不匹配标记的目录不会按此路径处理；不要通过删除这些文件强行绕过恢复检查。
+
 守护进程本身可手动在前台运行(OS 服务与 TUI 的 System 页面使用同一入口);正常使用无需手动执行,且前台运行时关闭终端会停止守护进程:
 
 ```console

--- a/internal/app/foreground_bootstrap.go
+++ b/internal/app/foreground_bootstrap.go
@@ -96,10 +96,6 @@ func (b ForegroundBootstrap) Start(ctx context.Context) (resultErr error) {
 		return installBusy("legacy source requires migration")
 	}
 	id := x.newTransactionID()
-	marker, err := x.Store.CreateTransactionMarker(ctx, id)
-	if err != nil {
-		return err
-	}
 	layout := InstallLayoutSystem
 	if x.Private {
 		layout = InstallLayoutPrivate
@@ -109,6 +105,12 @@ func (b ForegroundBootstrap) Start(ctx context.Context) (resultErr error) {
 		if err := b.InitializeJournal(ctx, id); err != nil {
 			return err
 		}
+	}
+	// Inspect existing data before creating transaction metadata: private
+	// layouts share the data directory with the journal store.
+	marker, err := x.Store.CreateTransactionMarker(ctx, id)
+	if err != nil {
+		return err
 	}
 	saveJournal := func() error {
 		art := x.preparedArtifacts(request)

--- a/internal/app/foreground_bootstrap_test.go
+++ b/internal/app/foreground_bootstrap_test.go
@@ -121,3 +121,65 @@ func TestUnixBootstrap_PersistsRecoveryBeforePreparingData(t *testing.T) {
 		t.Fatal("data preparation began without a durable recovery journal")
 	}
 }
+
+func TestUnixBootstrap_RejectsExistingDataWithoutLeavingMarker(t *testing.T) {
+	h := newInstallHarness(t, InstallDataCreate)
+	h.tx.Service, h.tx.Effects = nil, nil
+	want := errors.New("existing data requires recovery or migration")
+	b := ForegroundBootstrap{Root: true, Transaction: h.tx,
+		DiscoverSource:    func(context.Context) (bool, error) { return false, nil },
+		InitializeJournal: func(context.Context, string) error { return want },
+		CreateData:        func(context.Context) error { t.Fatal("created data after rejection"); return nil },
+		Run:               func(context.Context, string) error { t.Fatal("started after rejection"); return nil },
+	}
+	for range 2 {
+		if err := b.Start(context.Background()); !errors.Is(err, want) {
+			t.Fatalf("bootstrap error = %v", err)
+		}
+		marker, err := h.tx.Store.files.inspect(context.Background(), transactionMarkerPath(testTxnID))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if marker.Present {
+			t.Fatal("rejected bootstrap left a transaction marker")
+		}
+	}
+}
+
+func TestUnixBootstrap_InitializesBeforeCreatingPrivateMetadata(t *testing.T) {
+	h := newInstallHarness(t, InstallDataCreate)
+	h.tx.Private = true
+	h.tx.Service, h.tx.Effects = nil, nil
+	ran := false
+	b := ForegroundBootstrap{Root: true, Transaction: h.tx,
+		DiscoverSource: func(context.Context) (bool, error) { return false, nil },
+		InitializeJournal: func(ctx context.Context, id string) error {
+			marker, err := h.tx.Store.files.inspect(ctx, transactionMarkerPath(id))
+			if err != nil {
+				return err
+			}
+			if marker.Present {
+				return errors.New("existing data requires recovery or migration")
+			}
+			return nil
+		},
+		PrepareJournal: func(ctx context.Context, id string) error {
+			journal, err := h.tx.Store.Load(ctx)
+			if err != nil {
+				return err
+			}
+			if journal.TransactionID != id {
+				t.Fatal("journal lost bootstrap identity")
+			}
+			return nil
+		},
+		CreateData: func(context.Context) error { return nil },
+		Run:        func(context.Context, string) error { ran = true; return nil },
+	}
+	if err := b.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !ran {
+		t.Fatal("private bootstrap did not reach daemon")
+	}
+}

--- a/internal/app/install_artifact.go
+++ b/internal/app/install_artifact.go
@@ -49,6 +49,7 @@ type preparedMigration struct {
 	activeID                string
 	coreHash                string
 	obs                     map[string]sourceObservation
+	bootstrapOnly           bool
 	afterStop               func()
 	cleanupOnce             sync.Once
 	cleanupFn               func()

--- a/internal/app/install_bootstrap_source.go
+++ b/internal/app/install_bootstrap_source.go
@@ -1,0 +1,115 @@
+package app
+
+import (
+	"context"
+	"strings"
+)
+
+// observeBootstrapSource recognizes only the metadata left before the first
+// recovery journal or business file was published. A nil observation means the
+// ordinary business migration rules must apply. Nothing is removed or copied.
+func observeBootstrapSource(ctx context.Context, source migrationCapability) (map[string]sourceObservation, error) {
+	top, err := source.List(ctx, ".")
+	if err != nil {
+		return nil, err
+	}
+	if len(top) == 0 {
+		return nil, nil
+	}
+	for _, entry := range top {
+		switch entry.Name {
+		case "install.lock", "mihari-channel", "transactions":
+		default:
+			return nil, nil
+		}
+	}
+	obs := map[string]sourceObservation{}
+	record := func(rel string, entry migrationEntry) error {
+		if err := rejectUnsafe(entry, rel); err != nil {
+			return err
+		}
+		if _, exists := obs[rel]; exists {
+			return migrateInvalid("duplicate migration source entry")
+		}
+		if len(obs) >= migrationMaxFiles {
+			return migrateData("migration source exceeds size or file limits")
+		}
+		obs[rel] = rememberObservation(rel, entry.Hash, entry)
+		return nil
+	}
+	read := func(rel string, entry migrationEntry, max int64) ([]byte, error) {
+		if err := record(rel, entry); err != nil {
+			return nil, err
+		}
+		if entry.Dir || entry.Kind != "file" || entry.Size > max {
+			return nil, migrateState("unsupported migration source")
+		}
+		return source.ReadFile(ctx, rel, max)
+	}
+	for _, entry := range top {
+		if entry.Name != "transactions" {
+			raw, err := read(entry.Name, entry, 32)
+			if err != nil {
+				return nil, err
+			}
+			if entry.Name == "install.lock" {
+				if len(raw) != 0 {
+					return nil, migrateState("unsupported migration source")
+				}
+			} else if channel := strings.TrimSuffix(string(raw), "\n"); channel != InstallChannelDev && channel != InstallChannelMain {
+				return nil, migrateState("unsupported migration source")
+			}
+			continue
+		}
+		if err := record(entry.Name, entry); err != nil {
+			return nil, err
+		}
+		if !entry.Dir {
+			return nil, migrateState("unsupported migration source")
+		}
+		transactions, err := source.List(ctx, "transactions")
+		if err != nil {
+			return nil, err
+		}
+		for _, transaction := range transactions {
+			rel := "transactions/" + transaction.Name
+			if err := record(rel, transaction); err != nil {
+				return nil, err
+			}
+			if !transaction.Dir || !validTransactionID(transaction.Name) {
+				return nil, migrateState("unsupported migration source")
+			}
+			entries, err := source.List(ctx, rel)
+			if err != nil {
+				return nil, err
+			}
+			if len(entries) != 1 || entries[0].Name != "transaction-id" {
+				return nil, migrateState("unsupported migration source")
+			}
+			raw, err := read(rel+"/transaction-id", entries[0], 32)
+			if err != nil {
+				return nil, err
+			}
+			if string(raw) != transaction.Name {
+				return nil, migrateState("unsupported migration source")
+			}
+		}
+	}
+	return obs, nil
+}
+
+func (p *preparedMigration) verifySource(ctx context.Context) error {
+	if !p.bootstrapOnly {
+		return verifyStationary(ctx, p.source, p.obs)
+	}
+	current, err := observeBootstrapSource(ctx, p.source)
+	if err != nil || current == nil || len(current) != len(p.obs) {
+		return migrateConflict("migration source changed during copy")
+	}
+	for rel, previous := range p.obs {
+		if now, ok := current[rel]; !ok || now != previous {
+			return migrateConflict("migration source changed during copy")
+		}
+	}
+	return nil
+}

--- a/internal/app/install_bootstrap_source.go
+++ b/internal/app/install_bootstrap_source.go
@@ -18,7 +18,7 @@ func observeBootstrapSource(ctx context.Context, source migrationCapability) (ma
 	}
 	for _, entry := range top {
 		switch entry.Name {
-		case "install.lock", "mihari-channel", "transactions":
+		case "install.lock", "mihari-channel", "transactions", "locks":
 		default:
 			return nil, nil
 		}
@@ -47,6 +47,22 @@ func observeBootstrapSource(ctx context.Context, source migrationCapability) (ma
 		return source.ReadFile(ctx, rel, max)
 	}
 	for _, entry := range top {
+		if entry.Name == "locks" {
+			if err := record(entry.Name, entry); err != nil {
+				return nil, err
+			}
+			if !entry.Dir {
+				return nil, migrateState("unsupported migration source")
+			}
+			entries, err := source.List(ctx, "locks")
+			if err != nil {
+				return nil, err
+			}
+			if len(entries) != 0 {
+				return nil, migrateState("unsupported migration source")
+			}
+			continue
+		}
 		if entry.Name != "transactions" {
 			raw, err := read(entry.Name, entry, 32)
 			if err != nil {

--- a/internal/app/install_bootstrap_source_test.go
+++ b/internal/app/install_bootstrap_source_test.go
@@ -67,12 +67,55 @@ func TestUnixMigration_BootstrapResidueMainChannel(t *testing.T) {
 	}
 }
 
+func TestUnixMigration_BootstrapResidueEmptyLocks(t *testing.T) {
+	fx := bootstrapMigrationFixture(t)
+	if err := os.Mkdir(fx.source.osPath("locks"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := prepareMigration(context.Background(), fx.options())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer prepared.cleanup()
+	if err := prepared.recheckAndPublish(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, fx.source.osPath("locks/install-data-id"), []byte(testTxnID))
+	if err := prepared.recheckAndPublish(context.Background()); err == nil || apiCode(err) != protocol.CodeRevisionConflict {
+		t.Fatalf("new lock state accepted before publication: %v", err)
+	}
+}
+
+func TestUnixMigration_BootstrapResidueBeforeTransactionMarker(t *testing.T) {
+	fx := bootstrapMigrationFixture(t)
+	if err := os.RemoveAll(fx.source.osPath("transactions")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(fx.source.osPath("install.lock")); err != nil {
+		t.Fatal(err)
+	}
+	before := fx.sourceHashes(t)
+	prepared, err := prepareMigration(context.Background(), fx.options())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer prepared.cleanup()
+	if err := prepared.recheckAndPublish(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !mapsEqual(before, fx.sourceHashes(t)) {
+		t.Fatal("source changed")
+	}
+}
+
 func TestUnixMigration_BootstrapResidueRejectsRecoveryState(t *testing.T) {
-	for _, name := range []string{"journal", "backup", "marker-mismatch", "unknown-transaction", "business", "hardlink"} {
+	for _, name := range []string{"journal", "backup", "marker-mismatch", "unknown-transaction", "business", "hardlink", "nonempty-locks"} {
 		t.Run(name, func(t *testing.T) {
 			fx := bootstrapMigrationFixture(t)
 			marker := "transactions/" + strings.Repeat("a", 32) + "/transaction-id"
 			switch name {
+			case "nonempty-locks":
+				mustWrite(t, fx.source.osPath("locks/install-data-id"), []byte(testTxnID))
 			case "journal":
 				mustWrite(t, fx.source.osPath("install-transaction.json"), []byte("pending"))
 			case "backup":

--- a/internal/app/install_bootstrap_source_test.go
+++ b/internal/app/install_bootstrap_source_test.go
@@ -1,0 +1,122 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mihari-proxy/mihari/internal/control/protocol"
+)
+
+func bootstrapMigrationFixture(t *testing.T) *migrationFixture {
+	t.Helper()
+	fx := newMigrationFixture(t)
+	entries, err := os.ReadDir(fx.source.dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if err := os.RemoveAll(filepath.Join(fx.source.dir, entry.Name())); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite(t, fx.source.osPath("mihari-channel"), []byte("dev\n"))
+	mustWrite(t, fx.source.osPath("install.lock"), nil)
+	for _, id := range []string{strings.Repeat("a", 32), strings.Repeat("b", 32)} {
+		mustWrite(t, fx.source.osPath("transactions/"+id+"/transaction-id"), []byte(id))
+	}
+	return fx
+}
+
+func TestUnixMigration_BootstrapResidue(t *testing.T) {
+	fx := bootstrapMigrationFixture(t)
+	before := fx.sourceHashes(t)
+	prepared, err := prepareMigration(context.Background(), fx.options())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer prepared.cleanup()
+	if len(prepared.settings) != 0 || prepared.activeID != "" {
+		t.Fatal("bootstrap residue manufactured business state")
+	}
+	if err := prepared.recheckAndPublish(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"install.lock", "transactions", "mihari-channel"} {
+		if _, err := os.Stat(fx.target.osPath(name)); !os.IsNotExist(err) {
+			t.Fatalf("bootstrap metadata was published: %s (%v)", name, err)
+		}
+	}
+	if !mapsEqual(before, fx.sourceHashes(t)) {
+		t.Fatal("bootstrap source changed")
+	}
+}
+
+func TestUnixMigration_BootstrapResidueMainChannel(t *testing.T) {
+	fx := bootstrapMigrationFixture(t)
+	mustWrite(t, fx.source.osPath("mihari-channel"), []byte(InstallChannelMain+"\n"))
+	prepared, err := prepareMigration(context.Background(), fx.options())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer prepared.cleanup()
+	if err := prepared.recheckAndPublish(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUnixMigration_BootstrapResidueRejectsRecoveryState(t *testing.T) {
+	for _, name := range []string{"journal", "backup", "marker-mismatch", "unknown-transaction", "business", "hardlink"} {
+		t.Run(name, func(t *testing.T) {
+			fx := bootstrapMigrationFixture(t)
+			marker := "transactions/" + strings.Repeat("a", 32) + "/transaction-id"
+			switch name {
+			case "journal":
+				mustWrite(t, fx.source.osPath("install-transaction.json"), []byte("pending"))
+			case "backup":
+				mustWrite(t, fx.source.osPath("transactions/"+strings.Repeat("a", 32)+"/unit-bootstrap"), []byte("recovery"))
+			case "marker-mismatch":
+				mustWrite(t, fx.source.osPath(marker), []byte(strings.Repeat("c", 32)))
+			case "unknown-transaction":
+				mustWrite(t, fx.source.osPath("transactions/unknown/transaction-id"), []byte("unknown"))
+			case "business":
+				mustWrite(t, fx.source.osPath("subscriptions/catalog.yaml"), []byte("preserve"))
+			case "hardlink":
+				fx.source.setFlags(marker, nodeFlags{hardlink: true, nlink: 2})
+			}
+			before := fx.sourceHashes(t)
+			if prepared, err := prepareMigration(context.Background(), fx.options()); err == nil {
+				prepared.cleanup()
+				t.Fatal("unsafe bootstrap source accepted")
+			}
+			if !mapsEqual(before, fx.sourceHashes(t)) {
+				t.Fatal("rejected source changed")
+			}
+		})
+	}
+}
+
+func TestUnixMigration_BootstrapResidueRechecksBeforePublication(t *testing.T) {
+	for _, phase := range []string{"after-copy", "after-stop"} {
+		t.Run(phase, func(t *testing.T) {
+			fx := bootstrapMigrationFixture(t)
+			opts := fx.options()
+			mutate := func() { mustWrite(t, fx.source.osPath("mihari.yaml"), fx.settingsYAML) }
+			if phase == "after-copy" {
+				opts.AfterCopy = mutate
+			} else {
+				opts.AfterStop = mutate
+			}
+			prepared, err := prepareMigration(context.Background(), opts)
+			if err == nil {
+				defer prepared.cleanup()
+				err = prepared.recheckAndPublish(context.Background())
+			}
+			if err == nil || apiCode(err) != protocol.CodeRevisionConflict {
+				t.Fatalf("changed bootstrap source: %v", err)
+			}
+		})
+	}
+}

--- a/internal/app/install_migration.go
+++ b/internal/app/install_migration.go
@@ -137,6 +137,17 @@ func prepareMigration(ctx context.Context, opts migrationOptions) (*preparedMigr
 		return fail(err)
 	}
 	seenTop := map[string]bool{}
+	bootstrap, err := observeBootstrapSource(ctx, opts.Source)
+	if err != nil {
+		return fail(err)
+	}
+	if bootstrap != nil {
+		// An installation that never reached business initialization has no
+		// settings to migrate. The new daemon initializes its normal defaults.
+		prepared.bootstrapOnly = true
+		obs = bootstrap
+		top = nil
+	}
 	for _, entry := range top {
 		if err := rejectUnsafe(entry, entry.Name); err != nil {
 			return fail(err)
@@ -197,12 +208,15 @@ func prepareMigration(ctx context.Context, opts migrationOptions) (*preparedMigr
 	if opts.AfterCopy != nil {
 		opts.AfterCopy()
 	}
-	if err := verifyStationary(ctx, opts.Source, obs); err != nil {
+	prepared.obs = obs
+	if err := prepared.verifySource(ctx); err != nil {
 		return fail(err)
 	}
 
-	if err := validateStagedBusiness(ctx, opts, prepared, goos, arch); err != nil {
-		return fail(err)
+	if !prepared.bootstrapOnly {
+		if err := validateStagedBusiness(ctx, opts, prepared, goos, arch); err != nil {
+			return fail(err)
+		}
 	}
 	if err := verifyInstallBinary(ctx, opts, prepared); err != nil {
 		return fail(err)
@@ -956,7 +970,7 @@ func (p *preparedMigration) recheckAndPublish(ctx context.Context) error {
 	if p.afterStop != nil {
 		p.afterStop()
 	}
-	if err := verifyStationary(ctx, p.source, p.obs); err != nil {
+	if err := p.verifySource(ctx); err != nil {
 		return err
 	}
 	if p.target == nil || p.staging == nil {

--- a/internal/app/install_migration_unix_test.go
+++ b/internal/app/install_migration_unix_test.go
@@ -77,3 +77,31 @@ func migrationTrustedTempDir(t *testing.T) string {
 	}
 	return root
 }
+
+func TestUnixMigration_BootstrapResidueReadOnlySource(t *testing.T) {
+	fx := bootstrapMigrationFixture(t)
+	ctx := context.Background()
+	source, err := openReadOnlyMigrationRoot(ctx, fx.source.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := source.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	opts := fx.options()
+	opts.Source = source
+	prepared, err := prepareMigration(ctx, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer prepared.cleanup()
+	if err := prepared.recheckAndPublish(ctx); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, fx.source.osPath("transactions/"+testTxnID+"/transaction-id"), []byte(testTxnID))
+	if err := prepared.recheckAndPublish(ctx); err == nil || apiCode(err) != protocol.CodeRevisionConflict {
+		t.Fatalf("new transaction accepted after source observation: %v", err)
+	}
+}

--- a/internal/app/install_native_boundary_unix_test.go
+++ b/internal/app/install_native_boundary_unix_test.go
@@ -372,6 +372,50 @@ func TestNativeInstallBoundary_AbsentPathMigrationStagesBothBinaries(t *testing.
 		}
 	}
 }
+
+func TestNativeInstallBoundary_BootstrapResidueMigration(t *testing.T) {
+	ctx, s, _, _ := nativeBoundarySession(t)
+	fx := bootstrapMigrationFixture(t)
+	before := fx.sourceHashes(t)
+	source, err := openReadOnlyMigrationRoot(ctx, fx.source.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := source.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	req := fx.request()
+	req.Layout, req.Data, req.InstallRoot = InstallLayoutPrivate, s.layout.Data.Root, s.layout.InstallRoot
+	req.PathBinary = filepath.Join(filepath.Dir(s.layout.InstallRoot), "mihari-path")
+	inputs := &nativeReleaseInputs{source: source, binary: fx.binary, trust: fx.trust, resources: map[string][]byte{}}
+	nativeBoundaryApply(t, ctx, s, req, service.Definition{Status: service.StatusNotInstalled}, inputs)
+	if s.tx.prepared != nil {
+		t.Cleanup(func() {
+			if err := s.tx.prepared.staging.Close(); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+	for _, path := range []string{req.PathBinary, filepath.Join(s.layout.InstallRoot, "mihari")} {
+		raw, err := os.ReadFile(path)
+		if err != nil || string(raw) != string(fx.binary) {
+			t.Fatalf("candidate not published: %s (%v)", path, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(s.layout.Data.Root, "locks", "install-data-id")); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"mihari.yaml", "transactions"} {
+		if _, err := os.Stat(filepath.Join(s.layout.Data.Root, name)); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("bootstrap source published unexpected %s: %v", name, err)
+		}
+	}
+	if !mapsEqual(before, fx.sourceHashes(t)) {
+		t.Fatal("bootstrap source changed during native migration")
+	}
+}
 func TestNativeInstallBoundary_ServiceIdentityRecovery(t *testing.T) {
 	ctx, s, manager, target := nativeBoundarySession(t)
 	oldFile := target.Files[0]

--- a/scripts/test/unix_security.py
+++ b/scripts/test/unix_security.py
@@ -22,6 +22,7 @@ SUPPLEMENTAL = {
         "TestNativeBinaryStageCleanup_CrashAndIdentityMismatch",
         "TestNativeInstallBoundary_LifecycleRetainsDataAuthority",
         "TestNativeInstallBoundary_AbsentPathMigrationStagesBothBinaries",
+        "TestNativeInstallBoundary_BootstrapResidueMigration",
         "TestNativeInstallBoundary_ServiceIdentityRecovery",
         "TestNativeInstallBoundary_SourceRecoveryRetriesAfterRestore",
         "TestNativeInstallBoundary_UninstallAlreadyMaskedUnit",


### PR DESCRIPTION
## 变更内容

旧版本在 root 私有数据目录首次启动时，先创建 `transactions/<ID>/transaction-id`，随后又把这个目录当成既有数据而拒绝初始化。每次自动重启都会留下一个没有恢复日志的事务标记。在线安装器即使已经使用新版本入口，仍会因为这些残留报 `unsupported migration source`，旧二进制因此没有被替换。

本次将首次启动的数据检查移到事务标记创建之前，保留恢复备份、durable journal、数据 staging 的既有顺序。迁移器仅对完全由合法 channel、空 install.lock 和匹配 transaction-id 构成的目录按尚未初始化处理：不复制残留、不生成业务配置、不删除来源，由新 daemon 执行普通首次初始化。含业务文件、恢复 journal、事务备份、未知项或异常标记的目录仍拒绝此路径。复制后及数据发布前重新检查完整残留集合及身份，来源变化时中止提交。

## 类型

- [x] fix: Bug 修复

## 验证

- 已先复现启动拒绝遗留 marker、metadata-only 来源迁移失败，再验证修复通过。
- 相关 app/service/platform/cli 包测试及 race 通过；全仓 `go vet ./...` 通过。
- Linux amd64、Windows amd64、macOS arm64 的 `CGO_ENABLED=0` 编译通过。
- 实际只读来源访问层覆盖成功迁移及新增 marker 冲突；负例覆盖恢复 journal、备份、业务数据、未知 ID、错误 marker 和硬链接。
- 新增 nativeBoundary 事务测试并加入隔离 native CI 必测名单，验证 TrustedRoot staging、WAL、数据与两个二进制发布、来源保留。该 root fixture 本地未运行，等待 CI；服务管理器与 validation child 仍为 fixture，并非真实 daemon 启动证明。
- 本机 `go test ./internal/integration` 的两个 UnixSnapshotContract 测试因导出临时目录残留失败；在同样权限的未修改 dev（9e0c5bf）副本上重跑相同测试，得到相同失败。本次未修改该路径。
- 独立代码审查未发现阻断问题。

## 检查清单

- [ ] `go test -race ./...` 通过（等待完整 CI）
- [x] `go vet ./...` 通过
- [x] 修改文件 gofmt 无输出，diff 检查通过
- [x] 提交包含 Signed-off-by
- [x] 未修改 CHANGELOG.md
- [x] 未修改公开 CLI/JSON 契约、持久化格式、依赖或跨平台支持范围

本机验证使用隔离目录；未修改当前系统 service 或用户 root 数据。

## 经用户授权的本机实测

已在原 Ubuntu VM 使用 root 备份旧二进制、unit、旧数据和系统安装状态，然后通过正常 service apply 事务安装本 PR 的本地构建 `v0.9.3-dev.3+local.c57750a`。仅在安装期间通过既有 root-owned offline authority 信任该构建的固定 SHA-256，随后移除临时 authority。

- 安装返回 changed=true、source_retained=true；CLI、managed binary 和实际 daemon 版本一致。
- 旧 `/root/.mihari` 与安装前备份递归比较一致。
- 本机 root 与普通用户查询 health=ok、service=running；TUI 可进入 Connected / Service running 的首次配置页，未提交设置或连接订阅。
- systemctl restart 和 mihari service restart 均成功。
- 首次安装提交及 CLI service restart 提交后各发生一次 `install activation changed`，systemd 在 100ms 后重试成功；直接 systemctl restart 无此重试。该阶段检查竞态来自现有启动门禁，作为独立观察记录；不宣称安装瞬间零重试或已验证首次配置后的真实核心运行。

## 第一轮 review 处理（80d7129）

- 兼容首次初始化允许的空 locks 目录；非空 locks 拒绝，并在发布前检查新增 lock 状态。新增测试已先失败再通过，app race 与 vet 通过。
- 保留合法元数据子集支持：初始化可能在创建 install.lock/transaction marker 之前失败，只有 channel 文件且没有任何业务或恢复状态也应能迁移。新增 channel-only 测试验证来源不变；要求所有标记齐全反而会阻塞这一更早失败的场景。
- 首轮原生迁移新测试在 Linux/macOS 均通过；Linux 另外三项既有安全测试失败，已重跑同一提交作对照，尚未认定为环境问题或已修复。
