### PR TITLE
fix: 保留订阅配置校验的 API 错误分类

### DIFF
--- a/internal/control/server/subscription_policy_test.go
+++ b/internal/control/server/subscription_policy_test.go
@@ -1,0 +1,26 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mihari-proxy/mihari/internal/control/protocol"
+)
+
+func TestSubscriptionRefresh_UnknownErrorRemainsInternal(t *testing.T) {
+	runtime := &fakeSubscriptionRuntime{fakeRuntime: &fakeRuntime{}, err: errors.New("private implementation failure")}
+	srv := New(Options{Token: "token", Runtime: runtime})
+	recorder := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(recorder, authorizedRequest(http.MethodPost, "/v1/subscriptions/one/refresh", strings.NewReader(`{"operation_id":"unknown-failure"}`)))
+	var envelope protocol.ErrorEnvelope
+	if err := json.Unmarshal(recorder.Body.Bytes(), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	if recorder.Code != http.StatusInternalServerError || envelope.Error.Code != protocol.CodeInternal || envelope.Error.Message != "internal error" {
+		t.Fatalf("unexpected error response: status=%d envelope=%+v", recorder.Code, envelope)
+	}
+}


### PR DESCRIPTION
## 变更内容

订阅刷新或切换触发 RootConfigPolicy 校验失败时，PolicyError 已携带安全字段路径和错误码，但控制服务端无法将其识别为 APIError，因而统一返回 internal / HTTP 500。本次让 PolicyError 暴露其已分类的 API 错误：配置拒绝返回 data_failure / HTTP 422，不支持的核心条件返回 invalid_state / HTTP 409；保留 mihari.error/v1 信封与现有错误码。

新增路由回归测试通过真实策略生成错误，覆盖刷新、切换、错误包装、未知字段及值脱敏，以及未分类错误仍返回 internal。文档说明首次刷新失败时没有有效缓存，因此仍显示 missing。本 PR 不放宽配置策略，也不处理具体订阅的兼容性问题。

## 类型

- [x] fix: Bug 修复

## 验证

- 新增回归测试在修复前以 HTTP 500 失败，修复后通过。
- `go test -race`：subscription、control/server、runtime、cli 包通过。
- `go vet ./internal/subscription ./internal/control/server`、gofmt 与 diff 检查通过。
- 扩大验证的 control/client 日志导出临时目录清理测试失败；在未修改的 9e0c5bf 基线上单独重现同一失败，不属于本次错误映射变更。未声称全仓测试通过。
- 独立代码审查无阻塞问题。

## 检查清单

- [ ] `go test -race ./...` 通过（等待 CI）
- [ ] `go vet ./...` 通过（本地执行相关包，等待 CI）
- [x] 修改的 Go 文件已格式化
- [x] 提交包含 Signed-off-by（DCO）
- [x] 未修改 CHANGELOG.md
- [x] 已说明 API 可观察变化：纠正错误分类和 HTTP 状态，未知实现错误继续脱敏，不新增协议字段或错误码


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mihari-proxy/mihari/pull/215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

