### PR TITLE
fix: 修复 Unix 订阅更新与回滚的配置重载

### DIFF
--- a/docs/unix-layout.md
+++ b/docs/unix-layout.md
@@ -24,6 +24,8 @@ D 保存 settings、订阅、运行配置、GeoIP、面板、provider、核心�
 
 Unix root 仍只接受 v1.19.30 的四个 Unix OS/arch 内置核心 hash，继续核验 provenance receipt 与执行文件身份，不执行旧用户树 binary。移除 YAML 策略不扩大可信核心版本范围。Mihari 不再保证所有传给 root 核心的字段都经注册表审计；关键覆盖不限制所有额外 listener 或文件访问。
 
+可信核心以 `D/runtime/core-home` 为工作目录，启动配置固定为 `D/runtime/config.yaml`。更新和回滚在重新核验已发布配置的身份后，通过空路径 reload 重载启动时绑定的配置。mihomo 的显式 reload 路径受工作目录安全检查约束，不能直接传入位于该目录之外的配置路径；此流程不扩大 `SAFE_PATHS`，也不关闭路径检查。
+
 升级时先恢复旧 provider/resource WAL，再从活动订阅的原缓存生成配置。旧哈希命名 provider、Geo 资源和有效配置不会被主动删除；原缓存缺失或无效时返回可诊断错误并保留原数据，不从生成配置猜测 URL 或联网补回源数据。核心 receipt 中的历史 policy_id 字符串继续兼容，它不代表仍启用 YAML 策略。
 
 Unix 安装、迁移、服务生命周期与已安装服务自更新统一经过 app installer 的停机事务。锁顺序为 B install → 私有服务 P install → data → endpoint；永久锁文件不 unlink。daemon/Manager 仍是运行业务的唯一写入者，窄例外仅包括 root installer 在停机事务中迁移业务文件及维护安装资源，以及固定应用通道 metadata 的受锁保护维护。TUI 可经 logging 写自己的固定日志序列，不能直接写 settings、订阅或 token。

--- a/internal/core/subscription_reload_test.go
+++ b/internal/core/subscription_reload_test.go
@@ -1,0 +1,69 @@
+package core_test
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/mihari-proxy/mihari/internal/control/protocol"
+	runtimeapi "github.com/mihari-proxy/mihari/internal/runtime"
+	"github.com/mihari-proxy/mihari/internal/subscription"
+)
+
+type changingSubscriptionFetcher struct{ content []byte }
+
+func (f *changingSubscriptionFetcher) Fetch(context.Context, subscription.FetchRequest) (subscription.FetchResult, error) {
+	return subscription.FetchResult{Content: append([]byte(nil), f.content...)}, nil
+}
+
+func TestRootManager_SubscriptionReloadOutsideCoreHome(t *testing.T) {
+	for _, reject := range []bool{false, true} {
+		name := "refresh"
+		if reject {
+			name = "rejected refresh restores previous config and permits retry"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			fetcher := &changingSubscriptionFetcher{content: []byte("proxies: []\nrules: ['MATCH,DIRECT']\n")}
+			m, f, controller, _ := seamManager(t, func(o *runtimeapi.Options) {
+				var err error
+				o.Subscriptions, err = subscription.Open(subscription.ServiceOptions{
+					CatalogPath: filepath.Join(t.TempDir(), "catalog.yaml"), CacheDir: t.TempDir(), Downloader: fetcher,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+			})
+			profile, err := m.AddSubscription(ctx, runtimeapi.Operation{ID: "add", Source: "test"}, runtimeapi.AddSubscriptionInput{Name: "test", URL: "https://subscription.invalid/config"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !profile.Cached || profile.Generation != 1 {
+				t.Fatalf("first fetch did not commit: cached=%v generation=%d", profile.Cached, profile.Generation)
+			}
+			before := f.Content()
+			fetcher.content = []byte("proxies: []\nrules: ['MATCH,REJECT']\n")
+			if reject {
+				controller.failReloads = controller.reloads + 1
+			}
+			updated, err := m.RefreshSubscription(ctx, runtimeapi.Operation{ID: "refresh", Source: "test"}, profile.ID)
+			if reject {
+				assertCode(t, err, protocol.CodeUpstreamFailure)
+				if !bytes.Equal(before, f.Content()) || m.Subscriptions().Profiles[0].Generation != profile.Generation || controller.reloads != 3 {
+					t.Fatal("rejected refresh changed the committed config or cache generation")
+				}
+				updated, err = m.RefreshSubscription(ctx, runtimeapi.Operation{ID: "retry", Source: "test"}, profile.ID)
+			}
+			if err != nil {
+				t.Fatal("refresh requires an unexpected daemon restart", err)
+			}
+			if !updated.Cached || updated.Generation != profile.Generation+1 {
+				t.Fatal("refresh did not publish the next cache generation")
+			}
+			if bytes.Equal(before, f.Content()) || !bytes.Contains(f.Content(), []byte("MATCH,REJECT")) {
+				t.Fatal("successful refresh did not install the changed configuration")
+			}
+		})
+	}
+}

--- a/internal/core/subscription_reload_test.go
+++ b/internal/core/subscription_reload_test.go
@@ -13,10 +13,13 @@ import (
 
 type changingSubscriptionFetcher struct{ content []byte }
 
+// Fetch returns a copy of the subscription document selected by the test.
 func (f *changingSubscriptionFetcher) Fetch(context.Context, subscription.FetchRequest) (subscription.FetchResult, error) {
 	return subscription.FetchResult{Content: append([]byte(nil), f.content...)}, nil
 }
 
+// TestRootManager_SubscriptionReloadOutsideCoreHome verifies startup-bound reload,
+// restoration of rejected configuration changes, and a subsequent refresh.
 func TestRootManager_SubscriptionReloadOutsideCoreHome(t *testing.T) {
 	for _, reject := range []bool{false, true} {
 		name := "refresh"

--- a/internal/core/trusted_integration_test.go
+++ b/internal/core/trusted_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/mihari-proxy/mihari/internal/config"
 	"github.com/mihari-proxy/mihari/internal/control/protocol"
@@ -48,15 +49,17 @@ func (c *seamController) PatchConfigs(_ context.Context, p map[string]any) error
 	c.tun = p["tun"].(map[string]any)
 	return nil
 }
+
+// Reload models mihomo's startup configuration selection and safe-path check.
 func (c *seamController) Reload(ctx context.Context, path string, _ bool) error {
 	// Match mihomo v1.19.30: an explicit reload path must be under -d;
 	// an empty path selects the configuration already bound by -f at startup.
 	command, release, err := c.fixture.Trusted.RunCommand(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("prepare trusted reload command: %w", err)
 	}
 	if err := release(); err != nil {
-		return err
+		return fmt.Errorf("release trusted reload command: %w", err)
 	}
 	if path != "" {
 		relative, err := filepath.Rel(command.Home, path)

--- a/internal/core/trusted_integration_test.go
+++ b/internal/core/trusted_integration_test.go
@@ -48,7 +48,22 @@ func (c *seamController) PatchConfigs(_ context.Context, p map[string]any) error
 	c.tun = p["tun"].(map[string]any)
 	return nil
 }
-func (c *seamController) Reload(_ context.Context, _ string, _ bool) error {
+func (c *seamController) Reload(ctx context.Context, path string, _ bool) error {
+	// Match mihomo v1.19.30: an explicit reload path must be under -d;
+	// an empty path selects the configuration already bound by -f at startup.
+	command, release, err := c.fixture.Trusted.RunCommand(ctx)
+	if err != nil {
+		return err
+	}
+	if err := release(); err != nil {
+		return err
+	}
+	if path != "" {
+		relative, err := filepath.Rel(command.Home, path)
+		if err != nil || !filepath.IsLocal(relative) {
+			return errors.New("path is not subpath of home directory or SAFE_PATHS")
+		}
+	}
 	c.reloads++
 	if c.reloads <= c.failReloads {
 		return errors.New("reload rejected")

--- a/internal/core/tun_native_integration_test.go
+++ b/internal/core/tun_native_integration_test.go
@@ -19,9 +19,17 @@ type tunFaultController struct {
 	*seamController
 	cancel             context.CancelFunc
 	rejectConfirmation bool
+	reloadRequests     []tunReloadRequest
 }
 
+type tunReloadRequest struct {
+	path  string
+	force bool
+}
+
+// Reload records the request and injects post-reload faults for rollback tests.
 func (c *tunFaultController) Reload(ctx context.Context, path string, force bool) error {
+	c.reloadRequests = append(c.reloadRequests, tunReloadRequest{path: path, force: force})
 	if err := c.seamController.Reload(ctx, path, force); err != nil {
 		return err
 	}
@@ -137,6 +145,8 @@ func TestRootManager_DisablingLastSubscriptionDoesNotInjectLegacyTunFields(t *te
 	}
 }
 
+// TestRootManager_DisableFailureRestoresEnabledTunWithoutDegrading verifies that
+// startup-bound reload restores live TUN state and permits a later mutation.
 func TestRootManager_DisableFailureRestoresEnabledTunWithoutDegrading(t *testing.T) {
 	var controller *tunFaultController
 	var settings config.Settings
@@ -162,6 +172,14 @@ func TestRootManager_DisableFailureRestoresEnabledTunWithoutDegrading(t *testing
 	}
 	if !status.DesiredEnable || status.LiveEnable == nil || !*status.LiveEnable || !bytes.Equal(previous, f.Content()) || controller.patches != 0 {
 		t.Fatal("enabled TUN was not restored")
+	}
+	if len(controller.reloadRequests) != 2 {
+		t.Fatalf("reload requests=%d, want apply and rollback", len(controller.reloadRequests))
+	}
+	for _, request := range controller.reloadRequests {
+		if request != (tunReloadRequest{path: "", force: true}) {
+			t.Fatalf("reload request=%+v, want forced startup-bound reload", request)
+		}
 	}
 	controller.rejectConfirmation = false
 	if _, err = m.DisableTun(context.Background(), runtimeapi.Operation{ID: "disable-after-recovery", Source: "test"}); err != nil {

--- a/internal/mihomo/client_test.go
+++ b/internal/mihomo/client_test.go
@@ -140,6 +140,12 @@ func TestClientRuntimeRequests(t *testing.T) {
 			},
 		},
 		{
+			name: "reload startup config", method: http.MethodPut, path: "/configs", query: url.Values{"force": {"true"}}, body: `{"path":""}`,
+			invoke: func(ctx context.Context, client *Client) error {
+				return client.Reload(ctx, "", true)
+			},
+		},
+		{
 			name: "configs", method: http.MethodGet, path: "/configs", response: `{"mode":"rule","tun":{"enable":true,"stack":"gVisor"}}`,
 			invoke: func(ctx context.Context, client *Client) error {
 				got, err := client.Configs(ctx)

--- a/internal/runtime/subscription.go
+++ b/internal/runtime/subscription.go
@@ -582,9 +582,12 @@ func (m *Manager) commitTrustedRuntimeConfig(ctx context.Context, candidate conf
 		return e
 	}
 	defer func() { _ = cap.Close() }() // Read-only capability: no pending writes; closure cannot change the operation result.
-	path, e := cap.Path(ctx)
+	_, e = cap.Path(ctx)
 	if e == nil {
-		e = reloader.Reload(ctx, path, true)
+		// Trusted startup binds -f to runtime/config.yaml, outside the -d
+		// core-home. An empty reload path selects that same startup config;
+		// an explicit path is rejected by mihomo's safe-path check.
+		e = reloader.Reload(ctx, "", true)
 	}
 	if e == nil {
 		m.settingsMu.Lock()
@@ -597,11 +600,11 @@ func (m *Manager) commitTrustedRuntimeConfig(ctx context.Context, candidate conf
 	var reloadErr error
 	if restoreErr == nil {
 		defer func() { _ = old.Close() }() // Read-only capability: no pending writes; closure cannot change the operation result.
-		oldPath, pathErr := old.Path(rollbackCtx)
+		_, pathErr := old.Path(rollbackCtx)
 		if pathErr != nil {
 			restoreErr = pathErr
 		} else {
-			reloadErr = reloader.Reload(rollbackCtx, oldPath, true)
+			reloadErr = reloader.Reload(rollbackCtx, "", true)
 		}
 	}
 	if restoreErr != nil || reloadErr != nil {

--- a/internal/runtime/subscription.go
+++ b/internal/runtime/subscription.go
@@ -560,6 +560,9 @@ func (c configCandidate) cleanup() {
 		_ = os.Remove(c.path)
 	}
 }
+
+// commitTrustedRuntimeConfig publishes validated bytes and reloads the fixed
+// startup configuration, restoring the previous bytes if reload fails.
 func (m *Manager) commitTrustedRuntimeConfig(ctx context.Context, candidate configCandidate) error {
 	// This internal generation is independent of optional client preconditions
 	// and is captured atomically with settings. Publication owns mutation.

--- a/internal/runtime/tun_trusted.go
+++ b/internal/runtime/tun_trusted.go
@@ -129,14 +129,16 @@ func (m *Manager) rollbackTrustedTun(ctx context.Context, op Operation, candidat
 		configErr = err
 		if err == nil {
 			defer func() { _ = cap.Close() }() // Read-only capability; rollback ownership is already settled.
-			path, err := cap.Path(recovery)
+			_, err := cap.Path(recovery)
 			configErr = err
 			if err == nil {
 				reloader, ok := m.controller.(configReloader)
 				if !ok {
 					configErr = errors.New("mihomo reload is unavailable")
 				} else {
-					configErr = reloader.Reload(recovery, path, true)
+					// Reload the startup-bound config after verifying the restored
+					// capability, just as commitTrustedRuntimeConfig does.
+					configErr = reloader.Reload(recovery, "", true)
 				}
 			}
 		}

--- a/internal/runtime/tun_trusted.go
+++ b/internal/runtime/tun_trusted.go
@@ -119,6 +119,9 @@ func sameActiveSubscription(a, b subscription.Catalog) bool {
 	i, j := a.Index(a.ActiveID), b.Index(b.ActiveID)
 	return i >= 0 && j >= 0 && a.Profiles[i].Generation == b.Profiles[j].Generation && a.Profiles[i].Version == b.Profiles[j].Version
 }
+
+// rollbackTrustedTun restores settings and the startup-bound configuration,
+// degrading mutations only when recovery cannot be confirmed.
 func (m *Manager) rollbackTrustedTun(ctx context.Context, op Operation, candidate settingsCandidate, previous []byte, cause error) error {
 	recovery := context.WithoutCancel(ctx)
 	rollback := settingsCandidate{before: candidate.after, after: candidate.before, changed: candidate.changed}


### PR DESCRIPTION
## 变更内容

Unix 可信核心以 `runtime/core-home` 为工作目录，但启动配置位于 `runtime/config.yaml`。显式传入该路径进行 REST reload 会被 mihomo 的安全路径检查拒绝，导致订阅更新和回滚一起失败，随后所有 mutation 被 `mutation compensation failed; restart required` 阻止。

提交、订阅回滚及 TUN 回滚继续验证配置 capability，随后使用空路径重载启动时固定绑定的配置。保留目录布局、文件身份校验和原子发布，不扩大 `SAFE_PATHS`，不关闭路径检查，不改变本地控制 API、CLI/JSON 契约或 Windows 非可信执行路径。

补充模拟 mihomo 路径检查的测试，覆盖首次订阅拉取、新旧配置内容不同的回滚与重试，以及 TUN 回滚；补充空路径 HTTP 请求测试和 Unix 布局说明。

## 类型

- [ ] feat: 新功能
- [x] fix: Bug 修复
- [ ] refactor: 重构
- [ ] docs: 文档
- [ ] test: 测试
- [ ] chore: 构建/工具

## 检查清单

- [x] `go test -race ./...` 通过
- [x] `go vet ./...` 通过
- [x] `gofmt -l cmd internal` 无输出
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] 未修改 `CHANGELOG.md`
- [x] 契约及跨平台影响已在描述中说明

## 验证

- Go 1.26.5：全仓普通测试、race、vet 通过；修改过的 Go 文件格式检查及 `git diff --check` 通过。
- 普通用户测试在与提交内容一致、祖先目录权限符合要求的临时 checkout 中执行。
- `CGO_ENABLED=0`：Linux、Windows、macOS 的 amd64/arm64 六目标编译通过。
- Ubuntu 本地安装验证：daemon 与 mihomo 正常运行，现有订阅自动刷新成功，配置 desired/observed revision 一致，安装后 daemon 错误日志为 0。
- 本地未运行 Python Unix 安全脚本测试（环境缺少 pytest）；以 CI 的 `unix-layout-security` 结果为准。


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mihari-proxy/mihari/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription refresh reliability, including recovery after a failed configuration reload.
  * Ensured successful updates, rollbacks, and TUN recovery consistently reload the active startup configuration.
  * Added safety checks to prevent configuration reloads from referencing paths outside the trusted runtime directory.
  * Ensured failed updates restore the previously active configuration and allow subsequent retries.

* **Documentation**
  * Clarified the trusted runtime’s working directory, startup configuration behavior, and reload/rollback process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->