### PR TITLE
fix: 修复发布页安装通道与使用提示

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -308,6 +308,33 @@ jobs:
               || { echo "::error::unable to upload a missing release asset"; exit 1; }
           done < /tmp/missing-assets
 
+      - name: Ensure installation guidance in release notes
+        run: |
+          NOTES="$(gh release view "${VERSION}" --json body -q .body)"
+          START_MARKER='<!-- install-guidance -->'
+          END_MARKER='<!-- /install-guidance -->'
+          has_start=0
+          has_end=0
+          if printf '%s' "$NOTES" | grep -qF "$START_MARKER"; then has_start=1; fi
+          if printf '%s' "$NOTES" | grep -qF "$END_MARKER"; then has_end=1; fi
+          if [ "$has_start" -ne "$has_end" ]; then
+            echo "::error::installation guidance markers are incomplete"
+            exit 1
+          fi
+          if [ "$has_start" -eq 1 ]; then
+            echo "installation guidance already present — skipping"
+            exit 0
+          fi
+          cat > /tmp/install_guidance_dev.md <<'TEMPLATE'
+
+          <!-- install-guidance -->
+          > **Installation:** Use the complete installation commands in the [README](https://github.com/mihari-proxy/mihari/tree/dev#quick-start) or these release notes. Do not download and run individual release assets directly.
+          >
+          > **安装建议：** 请使用 [README](https://github.com/mihari-proxy/mihari/blob/dev/README.zh-CN.md) 或本 Release notes 提供的完整安装命令；不建议单独下载并直接运行 Release assets。
+          <!-- /install-guidance -->
+          TEMPLATE
+          gh release edit "${VERSION}" --notes "$(printf '%s\n%s\n' "$(cat /tmp/install_guidance_dev.md)" "$NOTES")"
+
       - name: Final verify prerelease and stable latest
         run: |
           verify_final_tag_ref() {
@@ -359,6 +386,8 @@ jobs:
           python scripts/release/github_release_policy.py release \
             --document /tmp/final-release.json --version "${VERSION}" \
             --release-name "${DEV_RELEASE_NAME}" --marker "<!-- github-release-dev -->" --mode final
+          jq -e '(.body | contains("<!-- install-guidance -->")) and (.body | contains("<!-- /install-guidance -->"))' /tmp/final-release.json >/dev/null \
+            || { echo "::error::final release is missing installation guidance"; exit 1; }
           download_and_verify_assets
           verify_final_tag_ref
           gh api "repos/${GITHUB_REPOSITORY}/releases/latest" > /tmp/latest-after.json 2> /tmp/latest-after.err \
@@ -439,19 +468,18 @@ jobs:
           cat > /tmp/aio_append_dev.md <<'TEMPLATE'
 
           <!-- aio-install-dev -->
-          ## 国内 prerelease 安装（AList，免 GitHub；覆盖 index，不改默认稳定入口）
+          ## 国内 prerelease 安装（AList，免 GitHub；显式 dev 通道，不改默认稳定入口）
 
           Linux / macOS：
 
           ```bash
-          curl -fsSL https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.sh | MIHARI_INDEX_URL=https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari-dev/index.txt bash
+          curl -fsSL https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.sh | bash -s -- --channel dev
           ```
 
           Windows (PowerShell)：
 
           ```powershell
-          $env:MIHARI_INDEX_URL='https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari-dev/index.txt'
-          & ([scriptblock]::Create((irm https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.ps1)))
+          & ([scriptblock]::Create((irm https://cloud.xn--30q18ry71c.com/p/public/mihari-release/mihari/install-aio-remote.ps1))) -Channel dev
           ```
           TEMPLATE
           gh release edit "${VERSION}" --notes "$(printf '%s\n%s\n' "$NOTES" "$(cat /tmp/aio_append_dev.md)")"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,6 +329,35 @@ jobs:
           python scripts/release/github_release_policy.py tag-chain \
             --chain /tmp/final-stable-tag-chain.json --expected-sha "${SHA}"
 
+      - name: Ensure installation guidance in release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NOTES="$(gh release view "${VERSION}" --json body -q .body)"
+          START_MARKER='<!-- install-guidance -->'
+          END_MARKER='<!-- /install-guidance -->'
+          has_start=0
+          has_end=0
+          if printf '%s' "$NOTES" | grep -qF "$START_MARKER"; then has_start=1; fi
+          if printf '%s' "$NOTES" | grep -qF "$END_MARKER"; then has_end=1; fi
+          if [ "$has_start" -ne "$has_end" ]; then
+            echo "::error::installation guidance markers are incomplete"
+            exit 1
+          fi
+          if [ "$has_start" -eq 1 ]; then
+            echo "installation guidance already present — skipping"
+            exit 0
+          fi
+          cat > /tmp/install_guidance.md <<'TEMPLATE'
+
+          <!-- install-guidance -->
+          > **Installation:** Use the complete installation commands in the [README](https://github.com/mihari-proxy/mihari#quick-start) or these release notes. Do not download and run individual release assets directly.
+          >
+          > **安装建议：** 请使用 [README](https://github.com/mihari-proxy/mihari/blob/main/README.zh-CN.md) 或本 Release notes 提供的完整安装命令；不建议单独下载并直接运行 Release assets。
+          <!-- /install-guidance -->
+          TEMPLATE
+          gh release edit "${VERSION}" --notes "$(printf '%s\n%s\n' "$(cat /tmp/install_guidance.md)" "$NOTES")"
+
       - uses: actions/setup-python@v7
         if: env.ALIST_CONFIGURED == 'true'
         with:

--- a/scripts/release/tests/test_release_workflow.py
+++ b/scripts/release/tests/test_release_workflow.py
@@ -1119,14 +1119,124 @@ def test_dev_publish_mutates_alist_after_final_github_verify():
     )
 
 
-def test_dev_release_notes_append_index_url_with_stable_root_downloaders():
-    workflow = WORKFLOW.read_text(encoding="utf-8")
-    assert "<!-- aio-install-dev -->" in workflow
-    assert "mihari-dev/index.txt" in workflow
-    assert "mihari-release/mihari/install-aio-remote.sh" in workflow
-    assert "| MIHARI_INDEX_URL=" in workflow
-    assert "$env:MIHARI_INDEX_URL=" in workflow
-    assert "mihari-release/mihari/install-aio-remote.ps1" in workflow
+def test_dev_release_notes_use_explicit_dev_channel_with_stable_root_downloaders():
+    document = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    run = _workflow_step(
+        document,
+        "publish",
+        name="Append prerelease AList install hook to release notes",
+    )["run"]
+
+    assert "<!-- aio-install-dev -->" in run
+    assert (
+        "curl -fsSL https://cloud.xn--30q18ry71c.com/p/public/mihari-release/"
+        "mihari/install-aio-remote.sh | bash -s -- --channel dev"
+    ) in run
+    assert (
+        "& ([scriptblock]::Create((irm https://cloud.xn--30q18ry71c.com/p/public/"
+        "mihari-release/mihari/install-aio-remote.ps1))) -Channel dev"
+    ) in run
+    assert "MIHARI_INDEX_URL" not in run
+
+
+def test_stable_and_dev_release_notes_upsert_guidance_without_replacing_existing_body(tmp_path):
+    stable = yaml.safe_load(STABLE_WORKFLOW.read_text(encoding="utf-8"))
+    dev = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    cases = (
+        (
+            stable,
+            "release",
+            "https://github.com/mihari-proxy/mihari/blob/main/README.zh-CN.md",
+            "https://github.com/mihari-proxy/mihari#quick-start",
+            "Generated changes\n\n<!-- aio-install -->\nstable commands\n",
+        ),
+        (
+            dev,
+            "publish",
+            "https://github.com/mihari-proxy/mihari/blob/dev/README.zh-CN.md",
+            "https://github.com/mihari-proxy/mihari/tree/dev#quick-start",
+            "This is a development release.\n\n<!-- github-release-dev -->\n\n"
+            "<!-- aio-install-dev -->\ndev commands\n",
+        ),
+    )
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_gh = fake_bin / "gh"
+    fake_gh.write_text(
+        """#!/usr/bin/env bash
+set -eu
+if [ "$1" = release ] && [ "$2" = view ]; then
+  cat "$FAKE_NOTES"
+elif [ "$1" = release ] && [ "$2" = edit ] && [ "$4" = --notes ]; then
+  printf '%s' "$5" > "$FAKE_EDITED"
+else
+  exit 97
+fi
+""",
+        encoding="utf-8",
+        newline="\n",
+    )
+    fake_gh.chmod(0o755)
+
+    for index, (document, job_name, readme_url, english_readme_url, existing_body) in enumerate(cases):
+        steps = document["jobs"][job_name]["steps"]
+        guidance = _workflow_step(
+            document,
+            job_name,
+            name="Ensure installation guidance in release notes",
+        )
+        assert "if" not in guidance
+        guidance_index = steps.index(guidance)
+        publication_name = (
+            "Publish GitHub release"
+            if job_name == "release"
+            else "Create prerelease and upload missing assets"
+        )
+        assert steps.index(_workflow_step(document, job_name, name=publication_name)) < guidance_index
+
+        notes = tmp_path / f"notes-{index}.md"
+        edited = tmp_path / f"edited-{index}.md"
+        notes.write_text(existing_body, encoding="utf-8")
+        script = (
+            f'export PATH="{_bash_path(fake_bin)}:$PATH"\n'
+            f'export FAKE_NOTES="{_bash_path(notes)}"\n'
+            f'export FAKE_EDITED="{_bash_path(edited)}"\n'
+            f'{guidance["run"]}'
+        )
+        first = subprocess.run(
+            [_bash_for_workflow_guard(), "-eu", "-o", "pipefail", "-c", script],
+            encoding="utf-8",
+            capture_output=True,
+            env={**os.environ, "VERSION": "v1.2.3"},
+            check=False,
+        )
+        assert first.returncode == 0, first.stderr
+        updated = edited.read_text(encoding="utf-8")
+        assert existing_body.rstrip("\n") in updated
+        assert updated.count("<!-- install-guidance -->") == 1
+        assert updated.count("<!-- /install-guidance -->") == 1
+        assert readme_url in updated
+        assert english_readme_url in updated
+        assert "Do not download and run individual release assets directly." in updated
+        assert "不建议单独下载并直接运行 Release assets" in updated
+
+        notes.write_text(updated, encoding="utf-8")
+        edited.unlink()
+        second = subprocess.run(
+            [_bash_for_workflow_guard(), "-eu", "-o", "pipefail", "-c", script],
+            encoding="utf-8",
+            capture_output=True,
+            env={**os.environ, "VERSION": "v1.2.3"},
+            check=False,
+        )
+        assert second.returncode == 0, second.stderr
+        assert not edited.exists()
+
+    stable_release = _workflow_step(stable, "release", name="Publish GitHub release")
+    assert "body" not in stable_release["with"]
+    final_dev = _workflow_step(dev, "publish", name="Final verify prerelease and stable latest")
+    assert "<!-- install-guidance -->" in final_dev["run"]
 
 
 def test_dev_retract_github_delete_is_idempotent_and_retains_canonical_tag():


### PR DESCRIPTION
## 变更内容

- 修复 dev prerelease 页面中的 AList 安装命令：Unix 显式传入 `--channel dev`，PowerShell 显式传入 `-Channel dev`，不再仅覆盖 index URL。
- stable 与 dev Release 页面幂等插入双语安装提示，推荐使用 README / Release notes 提供的完整安装命令，不建议单独下载并直接运行 Release assets。
- 使用独立 marker 管理提示，重跑时保留已有生成说明和 AList 安装段；dev 最终验收确认提示已经发布。
- 增加回归测试，覆盖已有 Release、正文保留、重复执行、main/dev 链接隔离及跨平台 Bash 执行。

## 类型

- [ ] feat: 新功能
- [x] fix: Bug 修复
- [ ] refactor: 重构
- [ ] docs: 文档
- [x] test: 测试
- [ ] chore: 构建/工具

## 检查清单

- [ ] `go test -race ./...` 通过
- [x] `go vet ./...` 通过
- [x] `gofmt -l cmd internal` 无输出
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] 未修改 `CHANGELOG.md`（`chore/release-*` 正式发版收口，或恢复成与 `main` 一致除外）
- [x] 未修改 `internal/control/protocol` 契约、CLI 输出/退出码或跨平台产品行为

## 其他

验证结果：

- Python CI 相关套件：445 passed, 11 skipped
- `go test ./...`：通过
- `go vet ./...`：通过
- `go test -race -count=1 ./internal/integration`：通过
- 完整 race 首次运行出现一次既有 `TestWebGatewayAuthProxyRejectInstallActivateRollback` shutdown timeout；该用例及整个 integration race 套件随后均通过。本 PR 未修改 Go 代码。
- 独立代码审查：无 Critical / Important 问题


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mihari-proxy/mihari/pull/221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

