### PR TITLE
fix: 提升 prerelease 安装建议可见性

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -311,6 +311,22 @@ jobs:
       - name: Ensure installation guidance in release notes
         run: |
           NOTES="$(gh release view "${VERSION}" --json body -q .body)"
+          cat > /tmp/install_guidance_dev.md <<'TEMPLATE'
+
+          <!-- install-guidance -->
+          ## **Do not manually download all-in-one packages. We recommend using the installation scripts below for a one-click installation.**
+
+          ## **不建议手动下载all in one，推荐使用下方安装脚本一键完成。**
+          <!-- /install-guidance -->
+          TEMPLATE
+          cat > /tmp/install_guidance_legacy_dev.md <<'TEMPLATE'
+          <!-- install-guidance -->
+          > **Installation:** Use the complete installation commands in the [README](https://github.com/mihari-proxy/mihari/tree/dev#quick-start) or these release notes. Do not download and run individual release assets directly.
+          >
+          > **安装建议：** 请使用 [README](https://github.com/mihari-proxy/mihari/blob/dev/README.zh-CN.md) 或本 Release notes 提供的完整安装命令；不建议单独下载并直接运行 Release assets。
+          <!-- /install-guidance -->
+          TEMPLATE
+          GUIDANCE="$(cat /tmp/install_guidance_dev.md)"
           START_MARKER='<!-- install-guidance -->'
           END_MARKER='<!-- /install-guidance -->'
           has_start=0
@@ -322,18 +338,44 @@ jobs:
             exit 1
           fi
           if [ "$has_start" -eq 1 ]; then
+            UPDATED_NOTES="$(printf '%s\n' "$NOTES" | awk \
+              -v legacy_file=/tmp/install_guidance_legacy_dev.md \
+              -v guidance_file=/tmp/install_guidance_dev.md '
+                BEGIN {
+                  while ((getline line < legacy_file) > 0) legacy[++legacy_count] = line
+                  close(legacy_file)
+                  while ((getline line < guidance_file) > 0) guidance[++guidance_count] = line
+                  close(guidance_file)
+                }
+                $0 == legacy[1] {
+                  block[1] = $0
+                  block_count = 1
+                  matches_legacy = 1
+                  for (line_number = 2; line_number <= legacy_count; line_number++) {
+                    if ((getline line) <= 0) {
+                      matches_legacy = 0
+                      break
+                    }
+                    block[++block_count] = line
+                    if (line != legacy[line_number]) matches_legacy = 0
+                  }
+                  if (matches_legacy && block_count == legacy_count) {
+                    for (line_number = 1; line_number <= guidance_count; line_number++) print guidance[line_number]
+                  } else {
+                    for (line_number = 1; line_number <= block_count; line_number++) print block[line_number]
+                  }
+                  next
+                }
+                { print }
+              ')"
+            if [ "$UPDATED_NOTES" != "$NOTES" ]; then
+              gh release edit "${VERSION}" --notes "$UPDATED_NOTES"
+              exit 0
+            fi
             echo "installation guidance already present — skipping"
             exit 0
           fi
-          cat > /tmp/install_guidance_dev.md <<'TEMPLATE'
-
-          <!-- install-guidance -->
-          > **Installation:** Use the complete installation commands in the [README](https://github.com/mihari-proxy/mihari/tree/dev#quick-start) or these release notes. Do not download and run individual release assets directly.
-          >
-          > **安装建议：** 请使用 [README](https://github.com/mihari-proxy/mihari/blob/dev/README.zh-CN.md) 或本 Release notes 提供的完整安装命令；不建议单独下载并直接运行 Release assets。
-          <!-- /install-guidance -->
-          TEMPLATE
-          gh release edit "${VERSION}" --notes "$(printf '%s\n%s\n' "$(cat /tmp/install_guidance_dev.md)" "$NOTES")"
+          gh release edit "${VERSION}" --notes "$(printf '%s\n%s\n' "$GUIDANCE" "$NOTES")"
 
       - name: Final verify prerelease and stable latest
         run: |

--- a/scripts/release/tests/test_release_workflow.py
+++ b/scripts/release/tests/test_release_workflow.py
@@ -62,6 +62,14 @@ def _workflow_step(document, job_name, *, name=None, uses=None):
     return matches[0]
 
 
+def _installation_guidance_block(notes):
+    start_marker = "<!-- install-guidance -->"
+    end_marker = "<!-- /install-guidance -->"
+    start = notes.index(start_marker)
+    end = notes.index(end_marker, start) + len(end_marker)
+    return notes[start:end]
+
+
 def _shell_invocations(run):
     normalized = run.replace("\\\n", " ")
     invocations = []
@@ -1148,6 +1156,15 @@ def test_stable_and_dev_release_notes_upsert_guidance_without_replacing_existing
             "release",
             "https://github.com/mihari-proxy/mihari/blob/main/README.zh-CN.md",
             "https://github.com/mihari-proxy/mihari#quick-start",
+            "<!-- install-guidance -->\n"
+            "> **Installation:** Use the complete installation commands in the "
+            "[README](https://github.com/mihari-proxy/mihari#quick-start) or these "
+            "release notes. Do not download and run individual release assets directly.\n"
+            ">\n"
+            "> **安装建议：** 请使用 [README](https://github.com/mihari-proxy/mihari/"
+            "blob/main/README.zh-CN.md) 或本 Release notes 提供的完整安装命令；不建议单独下载并直接运行 "
+            "Release assets。\n"
+            "<!-- /install-guidance -->",
             "Generated changes\n\n<!-- aio-install -->\nstable commands\n",
         ),
         (
@@ -1155,6 +1172,11 @@ def test_stable_and_dev_release_notes_upsert_guidance_without_replacing_existing
             "publish",
             "https://github.com/mihari-proxy/mihari/blob/dev/README.zh-CN.md",
             "https://github.com/mihari-proxy/mihari/tree/dev#quick-start",
+            "<!-- install-guidance -->\n"
+            "## **Do not manually download all-in-one packages. We recommend using the "
+            "installation scripts below for a one-click installation.**\n\n"
+            "## **不建议手动下载all in one，推荐使用下方安装脚本一键完成。**\n"
+            "<!-- /install-guidance -->",
             "This is a development release.\n\n<!-- github-release-dev -->\n\n"
             "<!-- aio-install-dev -->\ndev commands\n",
         ),
@@ -1179,7 +1201,14 @@ fi
     )
     fake_gh.chmod(0o755)
 
-    for index, (document, job_name, readme_url, english_readme_url, existing_body) in enumerate(cases):
+    for index, (
+        document,
+        job_name,
+        readme_url,
+        english_readme_url,
+        expected_guidance,
+        existing_body,
+    ) in enumerate(cases):
         steps = document["jobs"][job_name]["steps"]
         guidance = _workflow_step(
             document,
@@ -1197,7 +1226,7 @@ fi
 
         notes = tmp_path / f"notes-{index}.md"
         edited = tmp_path / f"edited-{index}.md"
-        notes.write_text(existing_body, encoding="utf-8")
+        notes.write_text(existing_body, encoding="utf-8", newline="\n")
         script = (
             f'export PATH="{_bash_path(fake_bin)}:$PATH"\n'
             f'export FAKE_NOTES="{_bash_path(notes)}"\n'
@@ -1216,12 +1245,15 @@ fi
         assert existing_body.rstrip("\n") in updated
         assert updated.count("<!-- install-guidance -->") == 1
         assert updated.count("<!-- /install-guidance -->") == 1
-        assert readme_url in updated
-        assert english_readme_url in updated
-        assert "Do not download and run individual release assets directly." in updated
-        assert "不建议单独下载并直接运行 Release assets" in updated
+        assert _installation_guidance_block(updated) == expected_guidance
+        if job_name == "release":
+            assert readme_url in updated
+            assert english_readme_url in updated
+        else:
+            assert readme_url not in updated
+            assert english_readme_url not in updated
 
-        notes.write_text(updated, encoding="utf-8")
+        notes.write_text(updated, encoding="utf-8", newline="\n")
         edited.unlink()
         second = subprocess.run(
             [_bash_for_workflow_guard(), "-eu", "-o", "pipefail", "-c", script],
@@ -1232,6 +1264,33 @@ fi
         )
         assert second.returncode == 0, second.stderr
         assert not edited.exists()
+
+        if job_name == "publish":
+            legacy_guidance = (
+                "<!-- install-guidance -->\n"
+                "> **Installation:** Use the complete installation commands in the "
+                "[README](https://github.com/mihari-proxy/mihari/tree/dev#quick-start) "
+                "or these release notes. Do not download and run individual release assets "
+                "directly.\n>\n"
+                "> **安装建议：** 请使用 [README](https://github.com/mihari-proxy/mihari/"
+                "blob/dev/README.zh-CN.md) 或本 Release notes 提供的完整安装命令；不建议单独下载并直接运行 "
+                "Release assets。\n"
+                "<!-- /install-guidance -->"
+            )
+            notes.write_text(
+                f"{existing_body}\n{legacy_guidance}\n", encoding="utf-8", newline="\n"
+            )
+            migrated = subprocess.run(
+                [_bash_for_workflow_guard(), "-eu", "-o", "pipefail", "-c", script],
+                encoding="utf-8",
+                capture_output=True,
+                env={**os.environ, "VERSION": "v1.2.3"},
+                check=False,
+            )
+            assert migrated.returncode == 0, migrated.stderr
+            migrated_notes = edited.read_text(encoding="utf-8")
+            assert _installation_guidance_block(migrated_notes) == expected_guidance
+            assert legacy_guidance not in migrated_notes
 
     stable_release = _workflow_step(stable, "release", name="Publish GitHub release")
     assert "body" not in stable_release["with"]


### PR DESCRIPTION
## 变更内容

- 将 dev prerelease 的安装建议改为醒目的中英文加粗二级标题。
- 已发布版本的重跑会将旧引用块文案迁移为新提示；未知已有提示保持幂等。
- 回归测试验证完整 Markdown 块、旧文案迁移与稳定发布说明不变。

## 类型

- [x] fix: Bug 修复

## 检查清单

- [ ] `go test -race ./...` 通过（环境未安装 Go）
- [ ] `go vet ./...` 通过（环境未安装 Go）
- [ ] `gofmt -l cmd internal` 无输出（环境未安装 Go）
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] 未修改 `CHANGELOG.md`
- [x] 未修改 `internal/control/protocol` 契约、CLI 输出/退出码或跨平台行为

## 其他

- 已用模拟 GitHub CLI 执行真实发布步骤，验证新增、幂等与旧提示迁移。
- 未运行 pytest：环境未安装 pytest。

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mihari-proxy/mihari/pull/224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

