### PR TITLE
feat: TUI/CLI 测速对齐内核 test URL (#210)

### DIFF
--- a/docs/superpowers/plans/2026-09-10-delay-test-url.md
+++ b/docs/superpowers/plans/2026-09-10-delay-test-url.md
@@ -1,0 +1,1252 @@
+# TUI/CLI 测速 URL 对齐 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** TUI/CLI 测速使用内核 `testUrl`（省略时由 daemon 回落），并补齐并发上限与错误分类，修复 #204/#210。
+
+**Architecture:** 控制面只读投影补上 `testUrl`/`test_url`。delay-test 允许省略 URL/超时，由 control server 在调用 mihomo 前解析。TUI/CLI 默认不再写死 gstatic。TUI 继续按叶子 `DelayProxy`，用 5 并发队列，跳过组名。
+
+**Tech Stack:** Go 1.26（`go.mod` toolchain）、标准库 `net/http/httptest`、bubbletea v2、`go test`。不新增依赖。
+
+**Spec:** `docs/superpowers/specs/2026-09-10-delay-test-url-design.md`
+
+**工作目录:** `C:\Users\Kinema\Documents\modular_dev\mihari\.worktrees\feat-210-delay-test-url`
+
+**分支:** `feat/210-delay-test-url`（从 `origin/dev` @ `f619cf4`）
+
+## Global Constraints
+
+- 不读磁盘 YAML；不改 Web 网关 delay 透传；不做 Dashboard/Core 双模式；不在 settings 增加测速 URL。
+- 不升 `/v1` 版本；不加新端点；`RuntimeAPI.DelayGroup/DelayProxy` 与 control client 方法签名不变。
+- 不改控制客户端或 mihomo HTTP client 的 10s `Timeout`；不删 `mihomo.Proxy.History`；不给 `ProxyNode` 加 `test_url`；不改 `CHANGELOG.md`。
+- 默认测速 URL 只存在于 `internal/control/server`：`https://www.gstatic.com/generate_204`。TUI/CLI 源码不得再出现该字符串。
+- 错误 envelope、默认 CLI 文本、TUI、slog 不得输出解析后的测速 URL。
+- 每个 commit 使用 Conventional Commits 中文摘要，并带 DCO `-s`。禁止提交到 `main`/`dev`。
+- 验证只认 worktree 内 `go test` / `gofmt`；worktree 的 codegraph/gopls 可能指向主 checkout，不可信。
+- 测试不访问公网、不读真实用户目录、不用 `time.Sleep` 做同步。
+
+## File Structure
+
+| 文件 | 职责 |
+| --- | --- |
+| `internal/mihomo/types.go` | 适配层解码内核 `testUrl` |
+| `internal/control/protocol/runtime.go` | `/v1` DTO：`ProxyGroup.test_url`、可省略的 `DelayTestRequest` |
+| `internal/control/server/runtime.go` | 映射 `test_url`；delay-test/delay-proxy 回落 |
+| `internal/cli/proxy.go` | 默认省略 `--url`/`--timeout` |
+| `internal/tui/ui/strings.go` | `ProxyDelayInvalid` |
+| `internal/tui/pages/proxies/model.go` | 省略 URL、队列、跳过组名、错误分类 |
+
+不新建包。回落逻辑放在 server 包的小函数里，不放进 `protocol`。
+
+---
+
+### Task 1: mihomo 解码 `testUrl`
+
+**Files:**
+- Modify: `internal/mihomo/types.go`（`Proxy` 结构体）
+- Test: `internal/mihomo/client_test.go`
+
+**Interfaces:**
+- Consumes: 现有 `type Proxy struct`
+- Produces: `Proxy.TestURL string`，JSON 名 `testUrl`
+
+- [ ] **Step 1: Write the failing test**
+
+在 `internal/mihomo/client_test.go` 追加：
+
+```go
+func TestProxyJSONDecodesTestURL(t *testing.T) {
+	var got Proxy
+	if err := json.Unmarshal([]byte(`{"name":"HK","type":"URLTest","testUrl":"https://cp.cloudflare.com/generate_204"}`), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "HK" || got.Type != "URLTest" || got.TestURL != "https://cp.cloudflare.com/generate_204" {
+		t.Fatalf("got=%#v", got)
+	}
+	var empty Proxy
+	if err := json.Unmarshal([]byte(`{"name":"HK","type":"Selector"}`), &empty); err != nil {
+		t.Fatal(err)
+	}
+	if empty.TestURL != "" {
+		t.Fatalf("TestURL=%q", empty.TestURL)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```powershell
+cd C:\Users\Kinema\Documents\modular_dev\mihari\.worktrees\feat-210-delay-test-url
+go test ./internal/mihomo -run TestProxyJSONDecodesTestURL -count=1
+```
+
+Expected: FAIL，`got.TestURL` 未定义或始终为空。
+
+- [ ] **Step 3: Write minimal implementation**
+
+`internal/mihomo/types.go` 的 `Proxy` 增加：
+
+```go
+TestURL string `json:"testUrl,omitempty"`
+```
+
+放在 `XUDP` 字段之后。不要改 `History`。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+同 Step 2。Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add internal/mihomo/types.go internal/mihomo/client_test.go
+git commit -s -m "feat(mihomo): 解码内核 testUrl"
+```
+
+---
+
+### Task 2: `/v1` DTO 增加 `test_url` 并允许省略 delay 请求字段
+
+**Files:**
+- Modify: `internal/control/protocol/runtime.go`（`ProxyGroup`、`DelayTestRequest`）
+- Test: `internal/control/protocol/runtime_test.go`
+
+**Interfaces:**
+- Consumes: Task 1 的内核字段名（本任务只改 protocol）
+- Produces: `ProxyGroup.TestURL string` `json:"test_url,omitempty"`；`DelayTestRequest` 的 `url`/`timeout_ms` 带 `omitempty`
+
+- [ ] **Step 1: Write the failing test**
+
+在 `internal/control/protocol/runtime_test.go` 追加：
+
+```go
+func TestProxyGroupTestURLRoundTripAndOmitEmpty(t *testing.T) {
+	raw, err := json.Marshal(ProxyGroup{Name: "HK", Type: "URLTest", TestURL: "https://cp.cloudflare.com/generate_204"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `"test_url":"https://cp.cloudflare.com/generate_204"`) {
+		t.Fatalf("raw=%s", raw)
+	}
+	var got ProxyGroup
+	if err := json.Unmarshal(raw, &got); err != nil || got.TestURL != "https://cp.cloudflare.com/generate_204" {
+		t.Fatalf("got=%#v err=%v", got, err)
+	}
+	empty, err := json.Marshal(ProxyGroup{Name: "GLOBAL", Type: "Selector"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(empty), "test_url") {
+		t.Fatalf("empty=%s", empty)
+	}
+	var old ProxyGroup
+	if err := json.Unmarshal([]byte(`{"name":"GLOBAL","type":"Selector"}`), &old); err != nil || old.TestURL != "" {
+		t.Fatalf("old=%#v err=%v", old, err)
+	}
+}
+
+func TestDelayTestRequestOmitsZeroValues(t *testing.T) {
+	raw, err := json.Marshal(DelayTestRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != `{}` {
+		t.Fatalf("raw=%s", raw)
+	}
+	explicit, err := json.Marshal(DelayTestRequest{URL: "https://example.com/ping", TimeoutMilliseconds: 3500})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(explicit) != `{"url":"https://example.com/ping","timeout_ms":3500}` {
+		t.Fatalf("explicit=%s", explicit)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```powershell
+go test ./internal/control/protocol -run "TestProxyGroupTestURLRoundTripAndOmitEmpty|TestDelayTestRequestOmitsZeroValues" -count=1
+```
+
+Expected: FAIL（`TestURL` 未定义，和/或空 `DelayTestRequest` JSON 含 `"url":""`）。
+
+- [ ] **Step 3: Write minimal implementation**
+
+`ProxyGroup` 增加：
+
+```go
+TestURL string `json:"test_url,omitempty"`
+```
+
+`DelayTestRequest` 改为：
+
+```go
+type DelayTestRequest struct {
+	URL                 string `json:"url,omitempty"`
+	TimeoutMilliseconds int    `json:"timeout_ms,omitempty"`
+}
+```
+
+不要给 `ProxyNode` 加字段。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+同 Step 2。Expected: PASS。再跑：
+
+```powershell
+go test ./internal/control/protocol -count=1
+```
+
+Expected: 全绿（含既有 `TestRuntimeDTOsUseStableSchema`）。
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add internal/control/protocol/runtime.go internal/control/protocol/runtime_test.go
+git commit -s -m "feat(protocol): 下发 test_url 并允许省略 delay 请求字段"
+```
+
+---
+
+### Task 3: `GET /v1/proxies` 映射组 `test_url`
+
+**Files:**
+- Modify: `internal/control/server/runtime.go`（`orderedProxyGroups` / `toGroup`）
+- Test: `internal/control/server/runtime_test.go`
+
+**Interfaces:**
+- Consumes: `mihomo.Proxy.TestURL`；`protocol.ProxyGroup.TestURL`
+- Produces: `GET /v1/proxies` 组对象带 `test_url`
+
+- [ ] **Step 1: Write the failing test**
+
+在 `internal/control/server/runtime_test.go` 追加：
+
+```go
+func TestProxiesMapsGroupTestURL(t *testing.T) {
+	fake := &fakeRuntime{proxies: mihomo.Proxies{Proxies: map[string]mihomo.Proxy{
+		"GLOBAL": {Name: "GLOBAL", Type: "Selector", Now: "HK", All: []string{"HK", "leaf"}},
+		"HK":     {Name: "HK", Type: "URLTest", Now: "leaf", All: []string{"leaf"}, TestURL: "https://cp.cloudflare.com/generate_204"},
+		"leaf":   {Name: "leaf", Type: "VLESS"},
+	}}}
+	server := New(Options{Token: "token", Store: state.NewStore(state.Snapshot{}), Runtime: fake})
+	response := httptest.NewRecorder()
+	server.Handler().ServeHTTP(response, authorizedRequest(http.MethodGet, "/v1/proxies", nil))
+	if response.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	var got protocol.ProxyGroups
+	if err := json.Unmarshal(response.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Groups) < 1 {
+		t.Fatalf("groups=%#v", got.Groups)
+	}
+	var hk protocol.ProxyGroup
+	for _, group := range got.Groups {
+		if group.Name == "HK" {
+			hk = group
+		}
+	}
+	if hk.TestURL != "https://cp.cloudflare.com/generate_204" {
+		t.Fatalf("HK=%#v", hk)
+	}
+	if strings.Contains(response.Body.String(), `"test_url":"https://cp.cloudflare.com/generate_204"`) == false {
+		t.Fatalf("body=%s", response.Body.String())
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```powershell
+go test ./internal/control/server -run TestProxiesMapsGroupTestURL -count=1
+```
+
+Expected: FAIL，`HK.TestURL` 为空。
+
+- [ ] **Step 3: Write minimal implementation**
+
+`toGroup` 构造 `protocol.ProxyGroup` 时抄入 `proxy.TestURL`：
+
+```go
+return protocol.ProxyGroup{
+	Name: proxy.Name, Type: proxy.Type, Now: proxy.Now,
+	All: append([]string(nil), proxy.All...), Nodes: nodes,
+	TestURL: proxy.TestURL,
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+同 Step 2。Expected: PASS。再跑 `TestProxiesMapsNodeProtocolMetadata` 与 `TestProxiesPreservesGLOBALAllOrder`。
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add internal/control/server/runtime.go internal/control/server/runtime_test.go
+git commit -s -m "feat(control): GET /v1/proxies 下发组 test_url"
+```
+
+---
+
+### Task 4: delay-test / delay-proxy daemon 回落
+
+**Files:**
+- Modify: `internal/control/server/runtime.go`（`delayTest`、`delayProxy`、新增回落函数与常量）
+- Modify: `internal/control/server/runtime_test.go`（`fakeRuntime` 记录 URL/timeout，增加 `proxiesErr`）
+- Test: `internal/control/server/runtime_test.go`
+
+**Interfaces:**
+- Consumes: `DelayTestRequest` 零值合法；`runtime.Proxies`；`orderedProxyGroups`
+- Produces: server 在调用 `DelayGroup`/`DelayProxy` 前解析出非空 URL 与 `(0,60000]` 超时
+
+常量（仅 server 包）：
+
+```go
+const (
+	defaultDelayTestURL   = "https://www.gstatic.com/generate_204"
+	defaultDelayTimeoutMS = 5000
+	maxDelayTimeoutMS     = 60_000
+)
+```
+
+回落顺序见 spec §6.2。显式非空 URL **不**调用 `Proxies()`。
+
+- [ ] **Step 1: Extend fakeRuntime and write failing tests**
+
+`fakeRuntime` 增加字段（`delayedProxy` 已存在，`DelayProxy` 继续写它）：
+
+```go
+proxiesErr     error
+delayedGroup   string
+delayedURL     string
+delayedTimeout int
+```
+
+`Proxies` / `DelayGroup` / `DelayProxy` 改为：
+
+```go
+func (f *fakeRuntime) Proxies(context.Context) (mihomo.Proxies, error) {
+	if f.proxiesErr != nil {
+		return mihomo.Proxies{}, f.proxiesErr
+	}
+	return f.proxies, nil
+}
+
+func (f *fakeRuntime) DelayGroup(_ context.Context, group, testURL string, timeoutMilliseconds int) (mihomo.Delays, error) {
+	f.delayedGroup, f.delayedURL, f.delayedTimeout = group, testURL, timeoutMilliseconds
+	return mihomo.Delays{"DIRECT": 1}, nil
+}
+
+func (f *fakeRuntime) DelayProxy(_ context.Context, name, testURL string, timeoutMilliseconds int) (uint16, error) {
+	f.delayedProxy, f.delayedURL, f.delayedTimeout = name, testURL, timeoutMilliseconds
+	return f.proxyDelay, nil
+}
+```
+
+追加测试（可放在同一文件）：
+
+```go
+func TestDelayTestFallsBackToKernelAndDefaultURL(t *testing.T) {
+	cloud := "https://cp.cloudflare.com/generate_204"
+	other := "https://www.gstatic.com/generate_204"
+	proxies := mihomo.Proxies{Proxies: map[string]mihomo.Proxy{
+		"GLOBAL": {Name: "GLOBAL", Type: "Selector", All: []string{"HK", "TW", "leaf"}},
+		"HK":     {Name: "HK", Type: "URLTest", All: []string{"leaf"}, TestURL: cloud},
+		"TW":     {Name: "TW", Type: "URLTest", All: []string{"leaf"}, TestURL: "https://example.com/tw"},
+		"leaf":   {Name: "leaf", Type: "VLESS"},
+		"plain":  {Name: "plain", Type: "Selector", All: []string{"orphan"}, TestURL: ""},
+		"orphan": {Name: "orphan", Type: "Direct"},
+	}}
+
+	t.Run("explicit url wins", func(t *testing.T) {
+		fake := &fakeRuntime{proxies: proxies}
+		postDelay(t, fake, "/v1/proxy-groups/HK/delay-test", `{"url":"https://example.com/ping","timeout_ms":3500}`)
+		if fake.delayedGroup != "HK" || fake.delayedURL != "https://example.com/ping" || fake.delayedTimeout != 3500 {
+			t.Fatalf("fake=%#v", fake)
+		}
+	})
+	t.Run("empty uses group testUrl", func(t *testing.T) {
+		fake := &fakeRuntime{proxies: proxies}
+		postDelay(t, fake, "/v1/proxy-groups/HK/delay-test", `{}`)
+		if fake.delayedURL != cloud || fake.delayedTimeout != 5000 {
+			t.Fatalf("fake=%#v", fake)
+		}
+	})
+	t.Run("leaf uses first parent in GLOBAL.All", func(t *testing.T) {
+		fake := &fakeRuntime{proxies: proxies}
+		postDelay(t, fake, "/v1/proxies/leaf/delay-test", `{}`)
+		if fake.delayedProxy != "leaf" || fake.delayedURL != cloud {
+			t.Fatalf("fake=%#v", fake)
+		}
+	})
+	t.Run("no kernel url uses default", func(t *testing.T) {
+		fake := &fakeRuntime{proxies: proxies}
+		postDelay(t, fake, "/v1/proxies/orphan/delay-test", `{}`)
+		if fake.delayedURL != other {
+			t.Fatalf("url=%q", fake.delayedURL)
+		}
+	})
+	t.Run("timeout bounds", func(t *testing.T) {
+		fake := &fakeRuntime{proxies: proxies}
+		rec := postDelayRaw(t, fake, "/v1/proxy-groups/HK/delay-test", `{"timeout_ms":70000}`)
+		if rec.Code != http.StatusBadRequest || !strings.Contains(rec.Body.String(), "invalid_argument") {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+		if strings.Contains(rec.Body.String(), cloud) {
+			t.Fatalf("leaked url: %s", rec.Body.String())
+		}
+		rec = postDelayRaw(t, fake, "/v1/proxy-groups/HK/delay-test", `{"timeout_ms":-1}`)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("neg status=%d", rec.Code)
+		}
+	})
+	t.Run("proxies failure does not default", func(t *testing.T) {
+		fake := &fakeRuntime{proxiesErr: protocol.APIError{Code: protocol.CodeUpstreamFailure, Message: "mihomo controller is unavailable"}}
+		rec := postDelayRaw(t, fake, "/v1/proxy-groups/HK/delay-test", `{}`)
+		if rec.Code != http.StatusBadGateway {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+		if fake.delayedURL != "" {
+			t.Fatalf("should not call DelayGroup, url=%q", fake.delayedURL)
+		}
+	})
+	t.Run("explicit url skips Proxies", func(t *testing.T) {
+		fake := &fakeRuntime{proxiesErr: protocol.APIError{Code: protocol.CodeUpstreamFailure, Message: "mihomo controller is unavailable"}}
+		postDelay(t, fake, "/v1/proxy-groups/HK/delay-test", `{"url":"https://example.com/ping","timeout_ms":3500}`)
+		if fake.delayedURL != "https://example.com/ping" || fake.delayedTimeout != 3500 {
+			t.Fatalf("fake=%#v", fake)
+		}
+	})
+}
+
+func postDelay(t *testing.T, fake *fakeRuntime, path, body string) {
+	t.Helper()
+	rec := postDelayRaw(t, fake, path, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func postDelayRaw(t *testing.T, fake *fakeRuntime, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	server := New(Options{Token: "token", Store: state.NewStore(state.Snapshot{}), Runtime: fake})
+	rec := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rec, authorizedRequest(http.MethodPost, path, bytes.NewBufferString(body)))
+	return rec
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```powershell
+go test ./internal/control/server -run TestDelayTestFallsBackToKernelAndDefaultURL -count=1
+```
+
+Expected: FAIL（空 URL 仍 400 `invalid_argument`，或 timeout 0 被拒）。
+
+- [ ] **Step 3: Write minimal implementation**
+
+在 `internal/control/server/runtime.go` 增加常量与：
+
+```go
+func resolveDelayTimeout(ms int) (int, error) {
+	if ms < 0 || ms > maxDelayTimeoutMS {
+		return 0, errInvalidDelayTimeout
+	}
+	if ms == 0 {
+		return defaultDelayTimeoutMS, nil
+	}
+	return ms, nil
+}
+
+func (s *Server) resolveDelayURL(ctx context.Context, name, requested string) (string, error) {
+	if requested != "" {
+		return requested, nil
+	}
+	upstream, err := s.runtime.Proxies(ctx)
+	if err != nil {
+		return "", err
+	}
+	if proxy, ok := upstream.Proxies[name]; ok && proxy.TestURL != "" {
+		return proxy.TestURL, nil
+	}
+	for _, group := range orderedProxyGroups(upstream.Proxies) {
+		if group.TestURL == "" {
+			continue
+		}
+		for _, member := range group.All {
+			if member == name {
+				return group.TestURL, nil
+			}
+		}
+	}
+	return defaultDelayTestURL, nil
+}
+```
+
+`errInvalidDelayTimeout` 用包内 `errors.New("delay test timeout is invalid")`，handler 转成 `writeInvalidArgument`，文案保持稳定、不含 URL。
+
+`delayTest` / `delayProxy` 改为：先 `resolveDelayTimeout`，再 `resolveDelayURL`，再调用 runtime。超时非法 → 400；`Proxies()` 失败 → `writeControlError`。错误路径不要把 URL 写入 envelope `details`。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+同 Step 2。Expected: PASS。再跑：
+
+```powershell
+go test ./internal/control/server -run "TestProxyDelayEndpointTestsOneNode|TestInstallAndQueryEndpoints|TestDelayTestFallsBackToKernelAndDefaultURL" -count=1
+```
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add internal/control/server/runtime.go internal/control/server/runtime_test.go
+git commit -s -m "feat(control): delay-test 省略 URL 时回落到内核 testUrl"
+```
+
+---
+
+### Task 5: CLI 默认省略测速 URL 与超时
+
+**Files:**
+- Modify: `internal/cli/proxy.go`
+- Modify: `internal/cli/runtime_test.go`（`fakeRuntimeClient.DelayTest` 记录请求）
+- Test: `internal/cli/runtime_test.go`
+
+**Interfaces:**
+- Consumes: `protocol.DelayTestRequest` omitempty 零值
+- Produces: 默认 `mihari proxy test GROUP` 发送空 URL 与 timeout 0
+
+- [ ] **Step 1: Write the failing test**
+
+`fakeRuntimeClient` 增加：
+
+```go
+delayGroup   string
+delayRequest protocol.DelayTestRequest
+```
+
+`DelayTest` 改为：
+
+```go
+func (c *fakeRuntimeClient) DelayTest(_ context.Context, group string, request protocol.DelayTestRequest) (protocol.DelayResult, error) {
+	c.delayGroup = group
+	c.delayRequest = request
+	return protocol.DelayResult{Schema: "mihari/v1", Delays: map[string]uint16{"DIRECT": 1}}, nil
+}
+```
+
+追加：
+
+```go
+func TestProxyTestOmitsURLByDefaultAndAllowsOverride(t *testing.T) {
+	client := &fakeRuntimeClient{}
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	exit := Execute(context.Background(), []string{"proxy", "test", "HK"}, stdout, stderr, Dependencies{RuntimeClient: client})
+	if exit != ExitOK || stderr.Len() != 0 {
+		t.Fatalf("exit=%d stderr=%q", exit, stderr.String())
+	}
+	if client.delayGroup != "HK" || client.delayRequest.URL != "" || client.delayRequest.TimeoutMilliseconds != 0 {
+		t.Fatalf("request=%#v group=%q", client.delayRequest, client.delayGroup)
+	}
+
+	client = &fakeRuntimeClient{}
+	exit = Execute(context.Background(), []string{"proxy", "test", "HK", "--url", "https://example.com/ping", "--timeout", "3500"}, stdout, stderr, Dependencies{RuntimeClient: client})
+	if exit != ExitOK || client.delayRequest.URL != "https://example.com/ping" || client.delayRequest.TimeoutMilliseconds != 3500 {
+		t.Fatalf("override=%#v exit=%d", client.delayRequest, exit)
+	}
+
+	client = &fakeRuntimeClient{}
+	exit = Execute(context.Background(), []string{"proxy", "test", "HK", "--timeout=-1"}, stdout, stderr, Dependencies{RuntimeClient: client})
+	if exit != ExitUsage || client.delayGroup != "" {
+		t.Fatalf("neg timeout exit=%d group=%q", exit, client.delayGroup)
+	}
+	client = &fakeRuntimeClient{}
+	exit = Execute(context.Background(), []string{"proxy", "test", "HK", "--timeout", "70000"}, stdout, stderr, Dependencies{RuntimeClient: client})
+	if exit != ExitUsage || client.delayGroup != "" {
+		t.Fatalf("high timeout exit=%d", exit)
+	}
+}
+
+func TestProxyGroupsTextOmitsTestURL(t *testing.T) {
+	client := &fakeRuntimeClient{groups: protocol.ProxyGroups{Schema: "mihari/v1", Groups: []protocol.ProxyGroup{{
+		Name: "HK", Type: "URLTest", Now: "leaf", TestURL: "https://cp.cloudflare.com/generate_204",
+	}}}}
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	exit := Execute(context.Background(), []string{"proxy", "groups"}, stdout, stderr, Dependencies{RuntimeClient: client})
+	if exit != ExitOK || strings.Contains(stdout.String(), "http") || strings.Contains(stdout.String(), "test_url") {
+		t.Fatalf("stdout=%q exit=%d", stdout.String(), exit)
+	}
+}
+```
+
+确认 `ExitUsage` 已在 cli 包导出（现有 `TestConnectionsCloseAllRequiresConfirmation` 使用它）。
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```powershell
+go test ./internal/cli -run "TestProxyTestOmitsURLByDefaultAndAllowsOverride|TestProxyGroupsTextOmitsTestURL" -count=1
+```
+
+Expected: FAIL，默认请求仍带 gstatic 和 5000。
+
+- [ ] **Step 3: Write minimal implementation**
+
+`internal/cli/proxy.go`：
+
+```go
+testURL := ""
+timeout := 0
+```
+
+`RunE` 在调用 `DelayTest` 前：
+
+```go
+if timeout < 0 || timeout > 60_000 {
+	return invalidArgument("delay test timeout is invalid")
+}
+```
+
+`--url` / `--timeout` flag 默认即上述零值。帮助文本可写 “empty uses daemon fallback”，不要写 gstatic。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+同 Step 2，以及 `go test ./internal/cli -count=1`。Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add internal/cli/proxy.go internal/cli/runtime_test.go
+git commit -s -m "feat(cli): proxy test 默认走 daemon 测速回落"
+```
+
+---
+
+### Task 6: TUI 测速错误分类
+
+**Files:**
+- Modify: `internal/tui/ui/strings.go`（`TimeoutLabel` 旁增加 `ProxyDelayInvalid = "Invalid"`）
+- Modify: `internal/tui/pages/proxies/model.go`（`DelayKind`、`classifyDelayError`、`delayResultMsg`、`delayStyle`、`renderDelay`）
+- Test: `internal/tui/pages/proxies/model_test.go`
+
+**Interfaces:**
+- Consumes: `protocol.APIError`；`diagnostics.Wrap`；`context.DeadlineExceeded`；`net.Error`
+- Produces: `DelayFailed`、`DelayInvalid`；`classifyDelayError(error) DelayKind`
+
+分类顺序（唯一，禁止 `"timeout"` 子串匹配）：
+
+1. `APIError.Code == invalid_argument` → `DelayInvalid`
+2. `errors.Is(DeadlineExceeded)` 或 `net.Error.Timeout()==true`（含 wrap）→ `DelayTimeout`
+3. 其余 → `DelayFailed`（含裸 `upstream_failure`）
+
+`context.Canceled` 不是 Timeout。
+
+- [ ] **Step 1: Write the failing tests**
+
+`strings.go` 的测试会在实现常量后通过；先改 `TestModel_DelayTimeoutPath` 并追加分类测试。
+
+把 `TestModel_DelayTimeoutPath` 改成 `delayErr: context.DeadlineExceeded`，并用 `applyProxyCmd(t, model, model.testNode("n1"))` 代替 `model.Update(cmd())`（`testNode` 现在/之后都会返回 Batch，直接 `Update(cmd())` 会丢掉 `delayResultMsg`）。追加 Failed/Invalid 视图测试，同样走 `applyProxyCmd`：
+
+```go
+func TestModel_DelayErrorKindsRender(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"failed", protocol.APIError{Code: protocol.CodeUpstreamFailure, Message: "mihomo request failed"}, ui.FailedLabel},
+		{"invalid", protocol.APIError{Code: protocol.CodeInvalidArgument, Message: "delay test URL and timeout are invalid"}, ui.ProxyDelayInvalid},
+		{"wrapped timeout", diagnostics.Wrap(protocol.APIError{Code: protocol.CodeDataFailure, Message: "local control operation failed"}, context.DeadlineExceeded), ui.TimeoutLabel},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &fakeClient{delayErr: tc.err}
+			model := New(client, func() string { return "op" })
+			model.SetGroups(protocol.ProxyGroups{Groups: []protocol.ProxyGroup{{
+				Name: "G", Nodes: []protocol.ProxyNode{{Name: "n1", Type: "ss"}},
+			}}})
+			model.expanded["G"] = true
+			model.focus = FocusID{Group: "G", Node: "n1"}
+			applyProxyCmd(t, model, model.testNode("n1"))
+			view := model.View()
+			if !strings.Contains(view, tc.want) {
+				t.Fatalf("view missing %q:\n%s", tc.want, view)
+			}
+			if !themeDelayBadContains(model.theme, view, tc.want) {
+				t.Fatalf("%q should use DelayBad:\n%s", tc.want, view)
+			}
+		})
+	}
+}
+```
+
+再追加：
+
+```go
+func TestClassifyDelayError(t *testing.T) {
+	timeoutNet := timeoutNetError{}
+	cases := []struct {
+		name string
+		err  error
+		kind DelayKind
+	}{
+		{"deadline", context.DeadlineExceeded, DelayTimeout},
+		{"wrapped data_failure deadline", diagnostics.Wrap(protocol.APIError{Code: protocol.CodeDataFailure, Message: "local control operation failed"}, context.DeadlineExceeded), DelayTimeout},
+		{"net timeout", timeoutNet, DelayTimeout},
+		{"invalid", protocol.APIError{Code: protocol.CodeInvalidArgument, Message: "delay test URL and timeout are invalid"}, DelayInvalid},
+		{"upstream", protocol.APIError{Code: protocol.CodeUpstreamFailure, Message: "mihomo request failed"}, DelayFailed},
+		{"canceled", context.Canceled, DelayFailed},
+		{"plain", errors.New("timeout"), DelayFailed},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyDelayError(tc.err); got != tc.kind {
+				t.Fatalf("kind=%v want %v", got, tc.kind)
+			}
+		})
+	}
+}
+
+type timeoutNetError struct{}
+
+func (timeoutNetError) Error() string   { return "i/o timeout" }
+func (timeoutNetError) Timeout() bool   { return true }
+func (timeoutNetError) Temporary() bool { return true }
+```
+
+`TestDelayStyle_BandsAndTimeout` 增加 `DelayFailed` / `DelayInvalid` → `"bad"`。Task 6 所有测速结果测试必须用 `applyProxyCmd`，禁止 `Update(cmd())`。
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```powershell
+go test ./internal/tui/pages/proxies -run "TestClassifyDelayError|TestModel_DelayTimeoutPath|TestModel_DelayErrorKindsRender|TestDelayStyle_BandsAndTimeout" -count=1
+```
+
+Expected: FAIL（`classifyDelayError` 未定义，和/或任意错误仍是 Timeout）。
+
+- [ ] **Step 3: Write minimal implementation**
+
+`DelayKind` 增加 `DelayFailed`、`DelayInvalid`。
+
+```go
+func classifyDelayError(err error) DelayKind {
+	var api protocol.APIError
+	if errors.As(err, &api) && api.Code == protocol.CodeInvalidArgument {
+		return DelayInvalid
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return DelayTimeout
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return DelayTimeout
+	}
+	return DelayFailed
+}
+```
+
+`delayResultMsg` 必须显式分叉：`typed.err == nil` → `DelayValue`（带 `Milliseconds`）。**不要**对 nil 调 `classifyDelayError`（其默认分支是 `DelayFailed`，会把既有 `"28 ms"` 测成 Failed）。非 nil 才 `Kind: classifyDelayError(typed.err)`。
+
+`delayStyle`：`DelayTimeout`、`DelayFailed`、`DelayInvalid` 都用 `theme.DelayBad`。
+
+`renderDelay`：
+
+```go
+case DelayTimeout:
+	return style.Render(ui.TimeoutLabel)
+case DelayFailed:
+	return style.Render(ui.FailedLabel)
+case DelayInvalid:
+	return style.Render(ui.ProxyDelayInvalid)
+```
+
+`strings.go`：`ProxyDelayInvalid = "Invalid"`，放在 `TimeoutLabel` 旁。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```powershell
+go test ./internal/tui/pages/proxies -count=1
+```
+
+Expected: PASS（含既有选择失败与 spinner）。
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add internal/tui/ui/strings.go internal/tui/pages/proxies/model.go internal/tui/pages/proxies/model_test.go
+git commit -s -m "feat(tui): 区分测速 Timeout、Failed 与 Invalid"
+```
+
+---
+
+### Task 7: TUI 省略 URL、跳过组名、5 并发队列
+
+**Files:**
+- Modify: `internal/tui/pages/proxies/model.go`（删除 `delayTestURL`/`delayTimeout`；`queue`/`inFlight`/`delayTestGen`；`fillSlots`；`testAll`；`t`）
+- Modify: `internal/tui/pages/proxies/model_test.go`（`fakeClient` 记录 `DelayTestRequest`；阻塞门闩测并发）
+- Test: `internal/tui/pages/proxies/model_test.go`
+
+**Interfaces:**
+- Consumes: Task 6 的 `classifyDelayError`；`DelayTestRequest{}`
+- Produces: `delayTestConcurrency = 5`；`fillSlots() tea.Cmd`；`startDelay(name string) tea.Cmd`
+
+行为（spec §7）：
+
+- 真正发请求时才 `context.WithTimeout(10s)` 并设 `DelayTesting`。
+- `Ctrl+T`：`delayTestGen++`，`queue` 换成 unique 叶子（跳过 `m.groups` 的 Name），立刻 `fillSlots`。
+- `fillSlots` 循环到 `len(inFlight)==5` 或没有可启动名字；跳过已在飞的名字，继续填后面的。
+- `testAll` / `testFocused` / `delayResultMsg` 返回的 `tea.Batch` 必须是**一层扁平** Batch：worker `tea.Cmd` 与可选 spinner 并列。禁止 `tea.Batch(tea.Batch(workers...), spinner)`，否则测试一旦 `cmd()` 就会把叶子 worker 跑掉。
+- `delayResultMsg` 删 inFlight、写 delays，然后**总是** `fillSlots`。
+- `t`：不可测叶子 / 已在飞 → no-op；否则插到 queue 队头再 `fillSlots`，不替换整表、不 bump generation。
+- 不测组名；测 `DIRECT`。
+
+- [ ] **Step 1: Write the failing tests**
+
+扩展 `fakeClient`：
+
+```go
+type fakeClient struct {
+	selectedGroup string
+	selectedNode  string
+	operationID   string
+	selectErr     error
+	delay         uint16
+	delayErr      error
+	delayCalls    map[string]int
+	lastDelayReq  protocol.DelayTestRequest
+	started       chan string
+	release       chan struct{}
+	mu            sync.Mutex
+	inProgress    int
+	maxInProgress int
+}
+
+func (c *fakeClient) DelayProxy(_ context.Context, name string, req protocol.DelayTestRequest) (protocol.DelayResult, error) {
+	c.mu.Lock()
+	if c.delayCalls == nil {
+		c.delayCalls = make(map[string]int)
+	}
+	c.delayCalls[name]++
+	c.lastDelayReq = req
+	c.inProgress++
+	if c.inProgress > c.maxInProgress {
+		c.maxInProgress = c.inProgress
+	}
+	started := c.started
+	release := c.release
+	c.mu.Unlock()
+	if started != nil {
+		started <- name
+	}
+	if release != nil {
+		<-release
+	}
+	c.mu.Lock()
+	c.inProgress--
+	c.mu.Unlock()
+	if c.delayErr != nil {
+		return protocol.DelayResult{}, c.delayErr
+	}
+	return protocol.DelayResult{Schema: "mihari/v1", Delays: map[string]uint16{name: c.delay}}, nil
+}
+```
+
+无 `started`/`release` 时行为与现在同步 fake 相同（测试须保证这两个 channel 为 nil）。
+
+测试：
+
+```go
+func TestModel_DelayRequestOmitsURL(t *testing.T) {
+	client := &fakeClient{delay: 10}
+	model := New(client, func() string { return "op" })
+	model.SetGroups(protocol.ProxyGroups{Groups: []protocol.ProxyGroup{{
+		Name: "G", Nodes: []protocol.ProxyNode{{Name: "n1"}},
+	}}})
+	model.focus = FocusID{Group: "G", Node: "n1"}
+	applyProxyCmd(t, model, updateProxyKey(t, model, tea.KeyPressMsg{Code: 't', Text: "t"}))
+	if client.lastDelayReq.URL != "" || client.lastDelayReq.TimeoutMilliseconds != 0 {
+		t.Fatalf("req=%#v", client.lastDelayReq)
+	}
+}
+
+func TestModel_ControlTSkipsGroupNamesKeepsDIRECT(t *testing.T) {
+	client := &fakeClient{delay: 10}
+	model := New(client, func() string { return "op" })
+	model.SetGroups(protocol.ProxyGroups{Groups: []protocol.ProxyGroup{
+		{Name: "HK", Type: "URLTest", Nodes: []protocol.ProxyNode{{Name: "leaf"}, {Name: "TW"}, {Name: "DIRECT"}}},
+		{Name: "TW", Type: "Selector", Nodes: []protocol.ProxyNode{{Name: "leaf"}}},
+	}})
+	_, cmd := model.Update(tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl})
+	applyProxyCmd(t, model, cmd)
+	if client.delayCalls["TW"] != 0 || client.delayCalls["HK"] != 0 {
+		t.Fatalf("calls=%v", client.delayCalls)
+	}
+	if client.delayCalls["leaf"] != 1 || client.delayCalls["DIRECT"] != 1 {
+		t.Fatalf("calls=%v", client.delayCalls)
+	}
+}
+
+func leafCmds(t *testing.T, cmd tea.Cmd) []tea.Cmd {
+	t.Helper()
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("want flat BatchMsg, got %T", msg)
+	}
+	var leaves []tea.Cmd
+	for _, child := range batch {
+		leaves = append(leaves, child)
+	}
+	return leaves
+}
+
+func TestModel_ControlTCapsInFlightAtFive(t *testing.T) {
+	started := make(chan string, 16)
+	release := make(chan struct{})
+	client := &fakeClient{delay: 1, started: started, release: release}
+	model := New(client, func() string { return "op" })
+	nodes := make([]protocol.ProxyNode, 7)
+	for i := range nodes {
+		nodes[i] = protocol.ProxyNode{Name: string(rune('a' + i))}
+	}
+	model.SetGroups(protocol.ProxyGroups{Groups: []protocol.ProxyGroup{{Name: "G", Nodes: nodes}}})
+	_, cmd := model.Update(tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl})
+	leaves := leafCmds(t, cmd)
+	var wg sync.WaitGroup
+	for _, worker := range leaves {
+		worker := worker
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = worker()
+		}()
+	}
+	for i := 0; i < 5; i++ {
+		select {
+		case <-started:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for start")
+		}
+	}
+	client.mu.Lock()
+	max := client.maxInProgress
+	calls := len(client.delayCalls)
+	client.mu.Unlock()
+	if max > 5 || calls != 5 {
+		t.Fatalf("max=%d calls=%d", max, calls)
+	}
+	select {
+	case <-started:
+		t.Fatal("started a 6th before release")
+	default:
+	}
+	close(release)
+	wg.Wait()
+}
+
+func TestModel_QueuedNameIsNotTesting(t *testing.T) {
+	model := New(&fakeClient{delay: 1}, func() string { return "op" })
+	nodes := make([]protocol.ProxyNode, 6)
+	for i := range nodes {
+		nodes[i] = protocol.ProxyNode{Name: string(rune('a' + i))}
+	}
+	model.SetGroups(protocol.ProxyGroups{Groups: []protocol.ProxyGroup{{Name: "G", Nodes: nodes}}})
+	model.Update(tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl})
+	testingCount := 0
+	for _, st := range model.delays {
+		if st.Kind == DelayTesting {
+			testingCount++
+		}
+	}
+	if testingCount != 5 {
+		t.Fatalf("testing=%d delays=%v", testingCount, model.delays)
+	}
+	if model.delays[string(rune('a'+5))].Kind == DelayTesting {
+		t.Fatal("queued 6th node must not be Testing")
+	}
+}
+
+func TestModel_TDoesNotReplaceQueueOrDoubleInFlight(t *testing.T) {
+	started := make(chan string, 8)
+	release := make(chan struct{})
+	client := &fakeClient{delay: 1, started: started, release: release}
+	model := New(client, func() string { return "op" })
+	model.SetGroups(protocol.ProxyGroups{Groups: []protocol.ProxyGroup{{
+		Name: "G", Nodes: []protocol.ProxyNode{{Name: "n1"}, {Name: "n2"}},
+	}}})
+	model.focus = FocusID{Group: "G", Node: "n1"}
+	_, cmd := model.Update(tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl})
+	var wg sync.WaitGroup
+	for _, worker := range leafCmds(t, cmd) {
+		worker := worker
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = worker()
+		}()
+	}
+	<-started
+	<-started
+	_, again := model.Update(tea.KeyPressMsg{Code: 't', Text: "t"})
+	if again != nil {
+		if msg := again(); msg != nil {
+			if _, ok := msg.(tea.BatchMsg); ok {
+				t.Fatal("t must not start a second in-flight DelayProxy for n1")
+			}
+		}
+	}
+	client.mu.Lock()
+	n1 := client.delayCalls["n1"]
+	client.mu.Unlock()
+	if n1 != 1 {
+		t.Fatalf("parallel n1 calls=%d", n1)
+	}
+	close(release)
+	wg.Wait()
+}
+
+func TestModel_TDoesNotReplaceUnstartedQueue(t *testing.T) {
+	model := New(&fakeClient{delay: 1}, func() string { return "op" })
+	nodes := make([]protocol.ProxyNode, 7)
+	for i := range nodes {
+		nodes[i] = protocol.ProxyNode{Name: string(rune('a' + i))}
+	}
+	model.SetGroups(protocol.ProxyGroups{Groups: []protocol.ProxyGroup{{Name: "G", Nodes: nodes}}})
+	model.Update(tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl})
+	if len(model.queue) != 2 {
+		t.Fatalf("queue=%d want 2", len(model.queue))
+	}
+	before := append([]string(nil), model.queue...)
+	model.focus = FocusID{Group: "G", Node: string(rune('a'))}
+	model.Update(tea.KeyPressMsg{Code: 't', Text: "t"})
+	if len(model.queue) != 2 || model.queue[0] != before[0] || model.queue[1] != before[1] {
+		t.Fatalf("t replaced Ctrl+T queue: before=%v after=%v", before, model.queue)
+	}
+}
+
+func TestModel_SecondControlTReplacesUnstartedQueue(t *testing.T) {
+	model := New(&fakeClient{delay: 1}, func() string { return "op" })
+	nodes := make([]protocol.ProxyNode, 7)
+	for i := range nodes {
+		nodes[i] = protocol.ProxyNode{Name: string(rune('a' + i))}
+	}
+	model.SetGroups(protocol.ProxyGroups{Groups: []protocol.ProxyGroup{{Name: "G", Nodes: nodes}}})
+	model.Update(tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl})
+	if len(model.inFlight) != 5 || len(model.queue) != 2 {
+		t.Fatalf("after first inFlight=%d queue=%d", len(model.inFlight), len(model.queue))
+	}
+	firstQueue := append([]string(nil), model.queue...)
+	model.Update(tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl})
+	if len(model.inFlight) != 5 {
+		t.Fatalf("second Ctrl+T must not start over cap, inFlight=%d", len(model.inFlight))
+	}
+	if len(model.queue) != 7 {
+		t.Fatalf("second Ctrl+T must replace queue with all leaves, queue=%d first=%v now=%v", len(model.queue), firstQueue, model.queue)
+	}
+}
+```
+
+`leafCmds` 只展开**一层** `tea.BatchMsg`，把子 `tea.Cmd` 原样交给 goroutine。worker 只调用 `worker()` 取结果，**禁止**在 worker goroutine 里 `model.Update`（`Model` 无锁，会 concurrent map write）。断言并发上限只看 fake 的 `maxInProgress` / `delayCalls`。`TestModel_QueuedNameIsNotTesting` 与 `TestModel_SecondControlTReplacesUnstartedQueue` 只看 `Update` 之后的 `queue`/`delays`/`inFlight`，不必跑 worker。保留并更新 `TestModel_ControlTTestsEveryUniqueNodeOnce`：共享叶子仍只测一次，且请求 URL 为空。
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```powershell
+go test ./internal/tui/pages/proxies -run "TestModel_DelayRequestOmitsURL|TestModel_ControlTSkipsGroupNamesKeepsDIRECT|TestModel_ControlTCapsInFlightAtFive|TestModel_QueuedNameIsNotTesting|TestModel_TDoesNotReplaceQueueOrDoubleInFlight|TestModel_TDoesNotReplaceUnstartedQueue|TestModel_SecondControlTReplacesUnstartedQueue|TestModel_ControlTTestsEveryUniqueNodeOnce|TestModel_DelayTimeoutPath|TestModel_DelayErrorKindsRender" -count=1
+```
+
+Expected: FAIL（仍写死 gstatic，或一次 Batch 打出全部节点，或组名被测）。
+
+- [ ] **Step 3: Write minimal implementation**
+
+删除 `delayTestURL`、`delayTimeout`。
+
+`Model` 增加 `queue []string`、`inFlight map[string]uint64`、`delayTestGen uint64`。`New` 初始化 `inFlight`。
+
+```go
+const delayTestConcurrency = 5
+
+func (m *Model) groupNameSet() map[string]struct{} {
+	names := make(map[string]struct{}, len(m.groups))
+	for _, group := range m.groups {
+		names[group.Name] = struct{}{}
+	}
+	return names
+}
+
+func (m *Model) delayTestLeaves() []string {
+	skip := m.groupNameSet()
+	seen := make(map[string]struct{})
+	var leaves []string
+	for _, group := range m.groups {
+		for _, node := range group.Nodes {
+			if _, isGroup := skip[node.Name]; isGroup {
+				continue
+			}
+			if _, dup := seen[node.Name]; dup {
+				continue
+			}
+			seen[node.Name] = struct{}{}
+			leaves = append(leaves, node.Name)
+		}
+	}
+	return leaves
+}
+
+func (m *Model) startDelay(name string) tea.Cmd {
+	gen := m.delayTestGen
+	if m.inFlight == nil {
+		m.inFlight = make(map[string]uint64)
+	}
+	m.inFlight[name] = gen
+	m.delays[name] = DelayState{Kind: DelayTesting}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		result, err := m.client.DelayProxy(ctx, name, protocol.DelayTestRequest{})
+		delay := uint16(0)
+		if err == nil {
+			delay = result.Delays[name]
+		}
+		return delayResultMsg{node: name, delay: delay, err: err, gen: gen}
+	}
+}
+
+func (m *Model) fillSlots() []tea.Cmd {
+	var cmds []tea.Cmd
+	for len(m.inFlight) < delayTestConcurrency {
+		name, ok := m.popNextQueuedName()
+		if !ok {
+			break
+		}
+		cmds = append(cmds, m.startDelay(name))
+	}
+	return cmds
+}
+
+func (m *Model) delayCmds() tea.Cmd {
+	cmds := m.fillSlots()
+	if spin := m.delaySpinCmdIfNeeded(); spin != nil {
+		cmds = append(cmds, spin)
+	}
+	return tea.Batch(cmds...)
+}
+
+func (m *Model) popNextQueuedName() (string, bool) {
+	for i, name := range m.queue {
+		if _, flying := m.inFlight[name]; flying {
+			continue
+		}
+		m.queue = append(m.queue[:i], m.queue[i+1:]...)
+		return name, true
+	}
+	return "", false
+}
+
+func (m *Model) enqueueFront(name string) {
+	next := make([]string, 0, len(m.queue)+1)
+	next = append(next, name)
+	for _, existing := range m.queue {
+		if existing != name {
+			next = append(next, existing)
+		}
+	}
+	m.queue = next
+}
+
+func (m *Model) testAll() tea.Cmd {
+	m.delayTestGen++
+	m.queue = m.delayTestLeaves()
+	return m.delayCmds()
+}
+
+func (m *Model) testNode(node string) tea.Cmd {
+	if node == "" {
+		return nil
+	}
+	if _, isGroup := m.groupNameSet()[node]; isGroup {
+		return nil
+	}
+	if _, flying := m.inFlight[node]; flying {
+		return nil
+	}
+	m.enqueueFront(node)
+	return m.delayCmds()
+}
+
+func (m *Model) testFocused() tea.Cmd {
+	return m.testNode(m.focus.Node)
+}
+```
+
+`Update`：`ctrl+t` → `testAll`；节点上 `t` → `testFocused`。`delayResultMsg` 删除 `inFlight` 后分类/写 delays，再 `return m, m.delayCmds()`。`delayCmds` 保证扁平 Batch。
+
+保留 `testNode` 薄封装（走 `enqueueFront`+`fillSlots`）。Task 6 的 `TestModel_DelayTimeoutPath` / `TestModel_DelayErrorKindsRender` 必须已经用 `applyProxyCmd`；若仍是 `Update(cmd())`，本任务一并改掉，否则 Batch 会被丢掉、节点卡在 Testing。不要恢复旧的立刻 `DelayProxy` + 写死 URL 实现。
+
+`delayResultMsg` 可加 `gen uint64` 字段供测试；补槽不要求 `msg.gen == delayTestGen`。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```powershell
+go test ./internal/tui/pages/proxies -count=1
+```
+
+Expected: PASS。若并发测试偶发失败，用 channel 门闩修测试，不要加 `Sleep`，不要放宽到 >5。
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add internal/tui/pages/proxies/model.go internal/tui/pages/proxies/model_test.go
+git commit -s -m "feat(tui): 测速走 daemon 回落并限制并发"
+```
+
+---
+
+### Task 8: 包级回归与 gstatic 不再出现在 TUI/CLI
+
+**Files:**
+- Test only（必要时修 Task 5–7 漏网）
+
+- [ ] **Step 1: Grep production sources and run package tests**
+
+在 worktree 确认 `internal/tui` 与 `internal/cli` 不再含 `gstatic.com`。允许 `internal/control/server` 含默认常量。
+
+```powershell
+cd C:\Users\Kinema\Documents\modular_dev\mihari\.worktrees\feat-210-delay-test-url
+$hits = Get-ChildItem -Recurse -File -Include *.go internal\tui,internal\cli | Select-String -Pattern "gstatic.com" -SimpleMatch
+if ($hits) { $hits | ForEach-Object { "$($_.Path):$($_.LineNumber):$($_.Line)" }; throw "gstatic.com must not appear in TUI/CLI sources" }
+go test ./internal/mihomo ./internal/control/protocol ./internal/control/server ./internal/cli ./internal/tui/pages/proxies ./internal/tui/ui -count=1
+gofmt -l internal/mihomo/types.go internal/control/protocol/runtime.go internal/control/server/runtime.go internal/cli/proxy.go internal/tui/pages/proxies/model.go internal/tui/ui/strings.go
+```
+
+TUI/CLI 必须无 `gstatic.com` 匹配。`internal/control/server` 可以有 `defaultDelayTestURL`。
+
+Expected: 测试通过；`gofmt -l` 无输出。
+
+- [ ] **Step 2: Commit only if grep/tests forced extra fixes**
+
+无额外 diff 则跳过 commit。
+
+---
+
+## Spec coverage
+
+| Spec | Task |
+| --- | --- |
+| §5.1 `mihomo.Proxy.TestURL` | 1 |
+| §5.2 `ProxyGroup.test_url` omitempty；不加 ProxyNode 字段 | 2、3 |
+| §5.3 省略 url/timeout；`{}` 合法；timeout 边界 | 2、4 |
+| §6 daemon 回落顺序、默认 gstatic、显式 URL 不查 Proxies、Proxies 失败不默认 | 4 |
+| §6.3 错误不含 URL | 4 |
+| §8 CLI 默认省略、覆盖、文本 groups 不打印 URL | 5 |
+| §7.4 错误分类与 wrap | 6 |
+| §7.1–7.3 省略 URL、跳过组名、测 DIRECT、队列、5 并发、`t` 不替换队列 | 7 |
+| 非目标（Web 网关、YAML、CHANGELOG、HTTP Timeout、History） | 全局约束，无任务 |
+
+## Placeholder scan
+
+无 TBD/TODO；任务含完整测试代码与命令。

--- a/docs/superpowers/specs/2026-09-10-delay-test-url-design.md
+++ b/docs/superpowers/specs/2026-09-10-delay-test-url-design.md
@@ -1,0 +1,352 @@
+# TUI/CLI 测速对齐内核 test URL
+
+日期：2026-09-10
+状态：已定稿，待用户确认后写实施计划
+目标 issue：[#210](https://github.com/mihari-proxy/mihari/issues/210)（根因来自 [#204](https://github.com/mihari-proxy/mihari/issues/204)）
+目标分支：`feat/210-delay-test-url`
+工作目录：`.worktrees/feat-210-delay-test-url`
+基线：`origin/dev` @ `f619cf4`
+
+## 1. 背景
+
+用户在 TUI Proxies 页 `Ctrl+T` / `t` 测速全部 Timeout，同一套 mihomo 与同一批节点在 zashboard 正常。根因不是 TUN 或节点坏了，而是 Mihari 测速没用内核已经加载的测试 URL。
+
+用户 YAML（#204）里 url-test 组与 provider health-check 都是 `https://cp.cloudflare.com/generate_204`。mihomo 启动后这份值出现在 `GET /proxies` 的 `testUrl` 上。zashboard 读的是这条内核 API，不读磁盘 YAML。
+
+Mihari 走另一条投影：
+
+1. daemon 同样请求 mihomo `GET /proxies`，JSON 含 `testUrl`。
+2. `internal/mihomo/types.go` 的 `Proxy` 没有该字段，`json.Unmarshal` 静默丢掉。
+3. `/v1/proxies` 的 `protocol.ProxyGroup` 也没有 `test_url`。
+4. TUI（`internal/tui/pages/proxies/model.go`）与 CLI（`internal/cli/proxy.go`）写死 `https://www.gstatic.com/generate_204` + 5000ms。
+5. `DelayTestRequest.url` 必填，空 URL 直接 `invalid_argument`，daemon 不会回落到内核。
+
+这与「Generate 只覆盖极少托管字段、保留订阅其余配置」不冲突：YAML 里的 `url:` 仍在，内核也在用。丢掉发生在控制面**读路径**的窄 DTO 投影，不是写配置时删除。
+
+现有 TUI 还会把失败放大成「全部 Timeout」：
+
+- 任意错误一律显示 `Timeout`（#80 已登记为非目标，留给本次）。
+- `Ctrl+T` 对所有组 `Nodes` 里出现过的名字一次 `tea.Batch` 打出，无并发上限，含嵌套组名与 `DIRECT`。每个命令立刻启动 10s context；排队中的请求会先耗尽自己的 deadline。
+- 控制客户端与 daemon 的 mihomo HTTP client 默认都是 10s，单次业务超时是 5s。无上限并发时，URL 即使改对了仍可能集体撞上传输超时。
+
+CLI `mihari proxy test GROUP` 走组接口 `POST /v1/proxy-groups/{name}/delay-test`，默认同样是 gstatic。Web 网关对 zashboard 的 `GET /proxies|group/.../delay` 已透传内核 URL，本次不改。
+
+## 2. 目标
+
+TUI/CLI 连通性测试对齐 zashboard 实际使用的内核 `testUrl`，且只走 daemon + 版本化本地协议。
+
+- `/v1/proxies` 下发组的 `test_url`。
+- delay-test 允许省略 URL 与超时；daemon 按内核值回落，再没有才用明确的 Mihari 默认。
+- TUI 不再写死 gstatic；`Ctrl+T` 限流；不把组名当叶子测；Timeout / 上游失败 / 无效参数分开显示。
+- CLI 默认与 TUI 共用 daemon 回落；`--url` / `--timeout` 仍可覆盖。
+- 协议加字段，不升 `/v1` 版本。旧客户端继续传 URL 时行为不变。
+
+## 3. 非目标
+
+- TUI/CLI/daemon 读取磁盘上的订阅 YAML 或 runtime 配置文件来取测速 URL。
+- 改变 Web 网关对 zashboard delay 的透传（`ActionMutateDelayTest` / reverse proxy）。
+- zashboard 那种 Dashboard URL / Core URL 双模式开关。
+- 在 Mihari settings 再增加独立测速 URL。
+- 把 TUI `Ctrl+T` 改成整组 `DelayGroup`；本次仍按叶子 `DelayProxy`。
+- 修改控制客户端或 mihomo HTTP client 的 10s `Timeout`。
+- 从 `mihomo.Proxy` 删除未使用的 `History` 字段。
+- 给 `ProxyNode` 增加 `test_url`。
+- 修改 `CHANGELOG.md`。
+- 真实订阅、真实 mihomo、系统服务或 testenv 验证。
+
+## 4. 方案比较
+
+### 4.1 采用：daemon 拥有回落，DTO 只读下发 `test_url`
+
+TUI/CLI 默认省略 URL。daemon 在调用 mihomo delay 之前解析出具体 URL。`GET /v1/proxies` 仍带组 `test_url`，便于 JSON 检查与显式覆盖，但不作为 TUI 的唯一来源。
+
+客户端不能再各自维护一份与内核不一致的默认值。叶子自身往往没有 `testUrl`，回落必须能走到所在组。
+
+### 4.2 不采用：只改 TUI/CLI 常量到 Cloudflare
+
+治标。用户 YAML 仍可能是别的 URL；CLI 与 TUI 继续分叉；控制面仍强制客户端自带 URL。
+
+### 4.3 不采用：只在 DTO 下发 `test_url`，TUI 自己带上，daemon 仍强制 URL
+
+TUI 能修好当前页，但 CLI 默认、省略 URL 的调用、以及叶子没有 `testUrl` 时仍要客户端猜。回落所有权散在表现层。
+
+### 4.4 不采用：Dashboard / Core 双模式 + settings 测速 URL
+
+超出 #210。内核组上已有 `url:` 才是与 zashboard Core 模式对齐的最小修复。
+
+## 5. 协议
+
+不加新端点，不升 `schema`。`DisallowUnknownFields` 继续生效；本次只增加已建模字段。
+
+### 5.1 `mihomo.Proxy`
+
+```go
+type Proxy struct {
+    Name    string            `json:"name"`
+    Type    string            `json:"type"`
+    Now     string            `json:"now,omitempty"`
+    All     []string          `json:"all,omitempty"`
+    History []json.RawMessage `json:"history,omitempty"`
+    UDP     bool              `json:"udp,omitempty"`
+    XUDP    bool              `json:"xudp,omitempty"`
+    TestURL string            `json:"testUrl,omitempty"`
+}
+```
+
+`testUrl` 是 mihomo controller 的既有驼峰字段，适配层保持原名。`History` 原样保留，本次不映射到 `/v1`。
+
+### 5.2 `protocol.ProxyGroup`
+
+```go
+type ProxyGroup struct {
+    Name    string      `json:"name"`
+    Type    string      `json:"type"`
+    Now     string      `json:"now,omitempty"`
+    All     []string    `json:"all,omitempty"`
+    Nodes   []ProxyNode `json:"nodes,omitempty"`
+    TestURL string      `json:"test_url,omitempty"`
+}
+```
+
+`test_url` 来自该组在内核对象上的 `testUrl`。空则 omit。`ProxyNode` 不加此字段；叶子测速 URL 由 daemon 回落解析。
+
+旧 JSON 无 `test_url` 仍能解码。`orderedProxyGroups` 在构造 group DTO 时抄入 `proxy.TestURL`。
+
+### 5.3 `protocol.DelayTestRequest`
+
+```go
+type DelayTestRequest struct {
+    URL                 string `json:"url,omitempty"`
+    TimeoutMilliseconds int    `json:"timeout_ms,omitempty"`
+}
+```
+
+语义：
+
+| 字段 | 省略或零值 | 显式非零 / 非空 |
+| --- | --- | --- |
+| `url` | daemon 回落 | 原样使用，不再查内核 |
+| `timeout_ms` | 5000 | 使用该值 |
+
+校验：
+
+- `timeout_ms < 0` 或 `timeout_ms > 60_000` → `invalid_argument`。
+- `timeout_ms == 0` 合法，表示默认 5000。
+- `url` 为空合法。
+- body 为 `{}` 合法（`decodeControlJSON` 仍要求恰好一个 JSON 对象）。
+- 非空 `url` 不做格式深校验；非法 URL 由 mihomo 失败映射为既有 `upstream_failure` / `invalid_argument`。
+
+旧客户端继续发送 gstatic + 5000 时，daemon 使用客户端值，行为与现在相同。
+
+### 5.4 `DelayResult`
+
+不变：`{"schema":"mihari/v1","delays":{...}}`。单节点失败仍返回错误 envelope，不把 URL 写入 `details`。
+
+## 6. daemon 回落
+
+解析发生在 control server 的 `delayTest` / `delayProxy`，在调用 `RuntimeAPI.DelayGroup` / `DelayProxy` 之前。`Manager` 与 mihomo 适配器仍接收已经解析好的非空 URL 和正超时。mihomo 的 delay query 继续带 `url` 与 `timeout`，不依赖内核「空 url 表示用组配置」的行为。
+
+默认值只存在于 server 包内，不放进 `protocol`，也不再出现在 TUI/CLI 源码：
+
+```go
+const (
+    defaultDelayTestURL    = "https://www.gstatic.com/generate_204"
+    defaultDelayTimeoutMS  = 5000
+    maxDelayTimeoutMS      = 60_000
+)
+```
+
+默认 URL 对齐 zashboard Dashboard 缺省，**不**改成 Cloudflare。用户 Cloudflare 地址来自内核 `testUrl`。
+
+### 6.1 超时
+
+1. `timeout_ms > 0` 且 `<= 60_000` → 用请求值。
+2. `timeout_ms == 0` → `5000`。
+3. 其余 → `invalid_argument`（文案保持稳定，不回显数值以外的动态 URL）。
+
+本次不从内核 JSON 读取 timeout 字段。
+
+### 6.2 URL
+
+请求 `url` 非空：直接使用，不调用 `Proxies()`。
+
+请求 `url` 为空：
+
+1. `runtime.Proxies(ctx)` 取当前内核快照。失败则按既有 `writeControlError` 返回，不改用默认 URL 掩盖内核不可用。
+2. 若 `proxies[name].TestURL` 非空，使用它。`name` 对组接口是 path 里的组名，对节点接口是节点名。
+3. 否则按 `orderedProxyGroups` 的顺序（`GLOBAL.All` 优先，再补漏组）取第一个 `All` 包含该 `name` 且 `TestURL` 非空的组。
+4. 仍没有 → `defaultDelayTestURL`。
+
+组对象自己的 `testUrl` 只在步骤 2 命中。步骤 3 只为叶子（或自身 `TestURL` 为空的名字）找父组，不把「组名等于 name」再搜一遍。
+
+同一叶子出现在多个组且 URL 不同时，采用上述顺序中第一个非空组 URL。不把多个 URL 合成，不报错。
+
+解析结果只用于本次 mihomo 调用，不写 settings、不改 YAML、不缓存跨请求。
+
+### 6.3 调用后
+
+`DelayGroup` / `DelayProxy` 失败路径不变。错误与日志不得包含解析出的 URL、订阅 URL 或 secret。
+
+## 7. TUI
+
+文件：`internal/tui/pages/proxies/model.go` 及同包测试、`internal/tui/ui/strings.go`。
+
+### 7.1 请求
+
+删除 `delayTestURL` 常量。真正发起时发送 `DelayTestRequest{}`（URL 与 timeout 均省略）。单次请求仍用 `context.WithTimeout(..., 10*time.Second)`，但 **context 在该名字进入 `inFlight`、即将调用 `DelayProxy` 时才创建**，不能在入队时启动。
+
+`t` 与 `Ctrl+T` 共用同一套 `queue` / `inFlight` / `delayTestGen` 与启动规则，但 **`t` 不得整表替换 `Ctrl+T` 的 queue**：
+
+- 焦点不是可测叶子（组头或组名卡片）→ 仍 no-op。
+- 该名已在 `inFlight` → no-op，不并行第二次。
+- 否则把该名插到当前 `queue` 队头（若已在队列中则先去掉再插到队头），然后按 §7.3 补槽。不增加 generation，不丢弃其余已排队名字。
+
+### 7.2 谁测、谁跳过
+
+组名集合 = 当前 `m.groups` 里所有 `Name`。
+
+`Ctrl+T` 与 `t`：
+
+- 跳过名字落在组名集合中的节点（嵌套 Selector / URLTest / Fallback / LoadBalance / Relay 等）。
+- 不跳过 `DIRECT`、`REJECT` 以及其它非组叶子。
+- 焦点在组头（`focus.Node == ""`）时 `t` 仍为 no-op（现有行为）。
+- 焦点在组名卡片上按 `t`：no-op，不调用 `DelayProxy`。
+
+去重仍按节点名；跨组共享叶子只测一次。daemon 负责为该叶子选组 URL。
+
+### 7.3 `Ctrl+T` 队列
+
+禁止对全部节点 `tea.Batch` 立刻启动。
+
+- 并发上限：`delayTestConcurrency = 5`。
+- 状态：`queue []string`（尚未启动的名字）、`inFlight map[string]uint64`（名字 → 启动时的 generation）、`delayTestGen uint64`。
+- `DelayTesting` **只在名字进入 `inFlight`、即将发请求时设置**。写入 `queue` 不得把未启动的节点标成 Testing，否则 unique-leaf 集合变化或队列被替换时，被丢掉的名字会卡在 Testing。
+- `Ctrl+T`：`delayTestGen++`，`queue` **整表替换**为当前 unique 叶子（已过滤组名，保持 `m.groups` 遍历顺序），然后立刻调用 `fillSlots`。不取消已在飞的请求，也不把队列里尚未启动的名字标成 Testing。
+- 补槽 `fillSlots`：**循环**直到 `len(inFlight)==5` 或 queue 里没有可启动的名字。每次扫描 `queue`，跳过已在 `inFlight` 的名字（留在原位），启动下一个不在飞的名字（移出 queue、写入 inFlight、设 DelayTesting、发请求）。一次 `Ctrl+T` 必须能打出初始 burst（最多 5 个），不能理解成每个按键只启动一个。不得在队头是 in-flight 名字时停住。同一名字不得并行两次 `DelayProxy`。
+- `delayResultMsg`：从 `inFlight` 删除该名，把结果写入 `delays`（过期 generation 也写入，避免卡片卡在 Testing）。然后**总是**对当前 `queue` 调 `fillSlots`，不要求 `msg.gen == delayTestGen`。过期结果只释放槽位，不得读已经丢掉的旧队列。
+- 因此重复 `Ctrl+T` 会重测尚未启动的叶子；已在飞的叶子返回后若仍在新 `queue` 里，`fillSlots` 再测一次。
+
+spinner 仍用现有 generation-owned `delaySpinCmdIfNeeded`。
+
+### 7.4 错误显示
+
+节点卡片第二行继续显示测速状态，不用页面首行 `lastError` 折叠全部节点（那是选择失败的位置）。
+
+`DelayKind` 增加：
+
+分类顺序（唯一顺序，禁止按 `err.Error()` 子串匹配 `"timeout"`）：
+
+1. `errors.As` 到 `protocol.APIError` 且 `Code == invalid_argument` → `DelayInvalid`。
+2. 否则，若 `errors.Is(err, context.DeadlineExceeded)`，或 `errors.As` 到实现了 `Timeout() bool` 且返回 true 的 `net.Error` → `DelayTimeout`。必须穿过 `diagnostics.Wrap`：控制客户端把 10s HTTP/context 超时包成 `APIError{Code: data_failure}` + cause，`errors.As` 到 APIError 会成功，**不能**因此走 Failed。`context.Canceled` 不是 Timeout。
+3. 其余（含裸 `upstream_failure`、无 timeout cause 的 `data_failure`）→ `DelayFailed`。内核 5s 探测失败若只以 envelope `upstream_failure` 返回、没有 deadline/`net.Error` cause，显示 Failed。
+
+| Kind | 文案 | 颜色 |
+| --- | --- | --- |
+| `DelayTimeout` | `ui.TimeoutLabel`（`Timeout`） | `DelayBad` |
+| `DelayFailed` | `ui.FailedLabel`（`Failed`） | `DelayBad` |
+| `DelayInvalid` | 新常量 `ui.ProxyDelayInvalid = "Invalid"` | `DelayBad` |
+| `DelayValue` | `"%d ms"` | 现有阶梯 |
+
+成功路径不变。不把 `APIError.Message`、`Details` 或 URL 渲染进卡片。`TestModel_DelayTimeoutPath` 不得再用 `errors.New("timeout")`；至少覆盖裸 `context.DeadlineExceeded` 以及 `diagnostics.Wrap(APIError{Code: data_failure}, context.DeadlineExceeded)`。
+
+`delayResultMsg` 不实现 shell `Err() error` 账本契约（#80 只给了选择路径；本次不把每次节点测速记进 Recent operations）。
+
+## 8. CLI
+
+`mihari proxy test GROUP`：
+
+- 默认 `--url` 为空、`--timeout` 为 0，请求体等价于省略字段，走 daemon 回落。
+- `--url` 非空则覆盖。
+- `--timeout` 为正整数则覆盖；0 表示默认。负值由 Cobra/校验变成 `invalid_argument`（与 server 上限 60_000 一致：CLI 在发请求前拒绝 `> 60000` 或 `< 0`，避免把明显非法值打到 daemon；0 放行）。
+- 文本输出仍是 `name\tN ms`。JSON 输出仍是 `DelayResult`。
+- `proxy groups` 文本行仍是 `name\ttype\tnow`，不打印 `test_url`。`--json` 会因 DTO 加字段而带上 `test_url`，这是向后兼容增量。
+
+TUI 与 CLI 源码都不再出现 gstatic 字符串。
+
+## 9. 安全与日志
+
+- `test_url` 是连通性探测地址，不是订阅 URL，允许出现在 `/v1/proxies` JSON 与 CLI `--json`。
+- 错误 envelope、默认 CLI 文本、TUI、slog 不得输出解析后的测速 URL、完整订阅 URL、controller secret。
+- 不把 delay-test 升级为 mutation coordinator 事务；它仍是 runtime 只读探测，现有路由不变。
+
+## 10. 测试计划
+
+按包 Red–Green。不访问公网、不读真实用户目录。
+
+### 10.1 `internal/mihomo`
+
+- 含 `testUrl` 的 `GET /proxies` fixture 能解码到 `Proxy.TestURL`。
+- 无该字段时 `TestURL` 为空。
+
+### 10.2 `internal/control/protocol`
+
+- `ProxyGroup` 有 `test_url` 时 round-trip；空值 omit。
+- 旧 JSON 无 `test_url` 仍能解码。
+- `DelayTestRequest` 空结构序列化不含 `url` / `timeout_ms`。
+- 显式 URL 与 `timeout_ms` 仍按现有字段名编码。
+
+### 10.3 `internal/control/server`
+
+- `GET /v1/proxies`：组 DTO 带上内核 `testUrl` 映射的 `test_url`。
+- delay-test / delay-proxy：
+  - 显式 URL 原样传给 fake runtime，不因内核另有 `testUrl` 而改写。
+  - 省略 URL：组自身 `testUrl` → 该值。
+  - 省略 URL：叶子无 `testUrl`，所在组有 → 组 URL。
+  - 省略 URL：多组包含同一叶子且 URL 不同 → `GLOBAL.All` 顺序中第一个非空组 URL。
+  - 省略 URL：内核也没有 → `https://www.gstatic.com/generate_204`。
+  - 省略 timeout → fake 收到 5000；显式 3500 → 3500；`timeout_ms: 70000` 或负数 → 400 `invalid_argument`。
+  - `{}` body 被接受并走默认回落。
+  - `Proxies()` 失败时 delay-test 返回对应控制错误，不静默改用默认 URL。
+- 错误响应 body 不含测速 URL。
+
+### 10.4 `internal/cli`
+
+- 默认 `proxy test GROUP` 发给 fake 的 `DelayTestRequest` URL 为空、timeout 为 0。
+- `--url` / `--timeout` 覆盖反映在 fake 收到的请求上。
+- 文本 `proxy groups` 不含 URL 字符串。
+
+### 10.5 `internal/tui/pages/proxies`
+
+- `t` / `Ctrl+T` 发给 fake 的请求 URL 为空。
+- `Ctrl+T` 跳过组名，保留 `DIRECT` 与普通叶子；共享叶子只调用一次。
+- 并发：超过 5 个叶子时，在已返回结果之前 in-flight 不超过 5（用阻塞 fake 或计数门闩，不用 `time.Sleep` 作为同步原语）。队头是已在飞名字时仍能启动队列里其它名字。
+- 写入 queue 不会把未启动节点标成 Testing；Testing 只在进入 inFlight 时出现。
+- `t` 不替换 `Ctrl+T` 队列；已在飞的同一名字不会并行第二次。
+- 重复 `Ctrl+T` 替换未启动队列；过期结果只释放 in-flight 槽位并写入 `delays`，随后按新队列补槽；同一名字不会并行两次 `DelayProxy`。
+- 错误分类：裸 `DeadlineExceeded` 与 `diagnostics.Wrap(data_failure, DeadlineExceeded)` → 视图含 `Timeout`；无 timeout cause 的 `upstream_failure` → `Failed`；`invalid_argument` → `Invalid`；均带 `DelayBad` 样式。
+- 既有选择失败、spinner、共享叶子去重测试保持通过。
+
+## 11. 主要改动文件
+
+| 文件 | 变更 |
+| --- | --- |
+| `internal/mihomo/types.go` | `Proxy.TestURL` |
+| `internal/mihomo/client_test.go` | 解码 `testUrl` |
+| `internal/control/protocol/runtime.go` | `ProxyGroup.TestURL`；`DelayTestRequest` omitempty |
+| `internal/control/protocol/runtime_test.go` | 加字段契约 |
+| `internal/control/server/runtime.go` | 映射 `test_url`；delay 回落 |
+| `internal/control/server/runtime_test.go` | 回落与映射 |
+| `internal/cli/proxy.go` | 默认省略 URL/timeout |
+| `internal/cli/runtime_test.go` | 默认请求断言 |
+| `internal/tui/pages/proxies/model.go` | 删除常量、队列、跳过组名、错误分类 |
+| `internal/tui/pages/proxies/model_test.go` | 对应行为 |
+| `internal/tui/ui/strings.go` | `ProxyDelayInvalid` |
+| `docs/superpowers/specs/2026-09-10-delay-test-url-design.md` | 本文 |
+
+控制客户端方法签名不变。`RuntimeAPI.DelayGroup/DelayProxy` 签名不变。
+
+## 12. 风险
+
+- 叶子只存在于没有 `testUrl` 的 Selector 时，仍回落到 gstatic。这与 zashboard Dashboard 缺省一致；#204 那种 url-test 组会在步骤 2/3 命中 Cloudflare。
+- 不提高 HTTP client 10s 超时。单次 5s 探测加上 5 并发应落在 10s 内；若后续证据表明 daemon→mihomo 排队仍超时，另开 issue，不在本次改 Timeout。
+- `GET /v1/proxies` 的 `--json` 会多出 `test_url`。这是加字段，不是破坏性变更。
+- 部分测试若对整段 body 做 `strings.Contains(..., "url")` 可能被 `test_url` 误伤。现有这条禁令在 rule-providers 测试，不在 proxies；若碰到再改断言，不改产品语义。
+
+## 13. 验收
+
+完成本次后：
+
+1. 内核组带 `testUrl` 时，TUI/CLI 省略 URL 的测速使用该地址，而不是 gstatic。
+2. `Ctrl+T` 不再把组名当叶子打出，且同时在飞不超过 5 个测速。
+3. 测速失败不再一律显示 Timeout。
+4. Web 网关、YAML Generate、settings schema、`/v1` 版本号均不变。

--- a/internal/cli/proxy.go
+++ b/internal/cli/proxy.go
@@ -53,11 +53,14 @@ func newProxyCommand(dependencies Dependencies, options *runOptions) *cobra.Comm
 			return printMutation(command.OutOrStdout(), result)
 		},
 	})
-	testURL := "https://www.gstatic.com/generate_204"
-	timeout := 5000
+	testURL := ""
+	timeout := 0
 	testCommand := &cobra.Command{
 		Use: "test GROUP", Short: "Test proxy-group delays", Args: cobra.ExactArgs(1),
 		RunE: func(command *cobra.Command, args []string) error {
+			if timeout < 0 || timeout > 60_000 {
+				return invalidArgument("delay test timeout is invalid")
+			}
 			client, err := runtimeClient(dependencies)
 			if err != nil {
 				return err
@@ -82,8 +85,8 @@ func newProxyCommand(dependencies Dependencies, options *runOptions) *cobra.Comm
 			return nil
 		},
 	}
-	testCommand.Flags().StringVar(&testURL, "url", testURL, "URL used for delay testing")
-	testCommand.Flags().IntVar(&timeout, "timeout", timeout, "timeout in milliseconds")
+	testCommand.Flags().StringVar(&testURL, "url", testURL, "URL used for delay testing; empty uses daemon fallback")
+	testCommand.Flags().IntVar(&timeout, "timeout", timeout, "timeout in milliseconds; empty uses daemon fallback")
 	root.AddCommand(testCommand)
 	return root
 }

--- a/internal/cli/runtime_test.go
+++ b/internal/cli/runtime_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/mihari-proxy/mihari/internal/control/protocol"
@@ -157,6 +158,8 @@ type fakeRuntimeClient struct {
 	closeAllCalls int
 	coreOperation logging.OperationMetadata
 	coreRequest   protocol.MutationRequest
+	delayGroup    string
+	delayRequest  protocol.DelayTestRequest
 }
 
 func (c *fakeRuntimeClient) Core(context.Context) (protocol.CoreStatus, error) { return c.core, nil }
@@ -183,8 +186,50 @@ func (c *fakeRuntimeClient) SelectProxy(_ context.Context, group string, request
 	return protocol.MutationResult{Schema: "mihari/v1", OperationID: request.OperationID}, nil
 }
 
-func (c *fakeRuntimeClient) DelayTest(context.Context, string, protocol.DelayTestRequest) (protocol.DelayResult, error) {
+func (c *fakeRuntimeClient) DelayTest(_ context.Context, group string, request protocol.DelayTestRequest) (protocol.DelayResult, error) {
+	c.delayGroup = group
+	c.delayRequest = request
 	return protocol.DelayResult{Schema: "mihari/v1", Delays: map[string]uint16{"DIRECT": 1}}, nil
+}
+
+func TestProxyTestOmitsURLByDefaultAndAllowsOverride(t *testing.T) {
+	client := &fakeRuntimeClient{}
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	exit := Execute(context.Background(), []string{"proxy", "test", "HK"}, stdout, stderr, Dependencies{RuntimeClient: client})
+	if exit != ExitOK || stderr.Len() != 0 {
+		t.Fatalf("exit=%d stderr=%q", exit, stderr.String())
+	}
+	if client.delayGroup != "HK" || client.delayRequest.URL != "" || client.delayRequest.TimeoutMilliseconds != 0 {
+		t.Fatalf("request=%#v group=%q", client.delayRequest, client.delayGroup)
+	}
+
+	client = &fakeRuntimeClient{}
+	exit = Execute(context.Background(), []string{"proxy", "test", "HK", "--url", "https://example.com/ping", "--timeout", "3500"}, stdout, stderr, Dependencies{RuntimeClient: client})
+	if exit != ExitOK || client.delayRequest.URL != "https://example.com/ping" || client.delayRequest.TimeoutMilliseconds != 3500 {
+		t.Fatalf("override=%#v exit=%d", client.delayRequest, exit)
+	}
+
+	client = &fakeRuntimeClient{}
+	exit = Execute(context.Background(), []string{"proxy", "test", "HK", "--timeout=-1"}, stdout, stderr, Dependencies{RuntimeClient: client})
+	if exit != ExitUsage || client.delayGroup != "" {
+		t.Fatalf("neg timeout exit=%d group=%q", exit, client.delayGroup)
+	}
+	client = &fakeRuntimeClient{}
+	exit = Execute(context.Background(), []string{"proxy", "test", "HK", "--timeout", "70000"}, stdout, stderr, Dependencies{RuntimeClient: client})
+	if exit != ExitUsage || client.delayGroup != "" {
+		t.Fatalf("high timeout exit=%d", exit)
+	}
+}
+
+func TestProxyGroupsTextOmitsTestURL(t *testing.T) {
+	client := &fakeRuntimeClient{groups: protocol.ProxyGroups{Schema: "mihari/v1", Groups: []protocol.ProxyGroup{{
+		Name: "HK", Type: "URLTest", Now: "leaf", TestURL: "https://cp.cloudflare.com/generate_204",
+	}}}}
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	exit := Execute(context.Background(), []string{"proxy", "groups"}, stdout, stderr, Dependencies{RuntimeClient: client})
+	if exit != ExitOK || strings.Contains(stdout.String(), "http") || strings.Contains(stdout.String(), "test_url") {
+		t.Fatalf("stdout=%q exit=%d", stdout.String(), exit)
+	}
 }
 
 func (c *fakeRuntimeClient) Connections(context.Context) (protocol.ConnectionList, error) {

--- a/internal/control/protocol/runtime.go
+++ b/internal/control/protocol/runtime.go
@@ -23,11 +23,12 @@ type CoreStatus struct {
 }
 
 type ProxyGroup struct {
-	Name  string      `json:"name"`
-	Type  string      `json:"type"`
-	Now   string      `json:"now,omitempty"`
-	All   []string    `json:"all,omitempty"`
-	Nodes []ProxyNode `json:"nodes,omitempty"`
+	Name    string      `json:"name"`
+	Type    string      `json:"type"`
+	Now     string      `json:"now,omitempty"`
+	All     []string    `json:"all,omitempty"`
+	Nodes   []ProxyNode `json:"nodes,omitempty"`
+	TestURL string      `json:"test_url,omitempty"`
 }
 
 type ProxyNode struct {
@@ -124,8 +125,8 @@ type ProxySelectionRequest struct {
 }
 
 type DelayTestRequest struct {
-	URL                 string `json:"url"`
-	TimeoutMilliseconds int    `json:"timeout_ms"`
+	URL                 string `json:"url,omitempty"`
+	TimeoutMilliseconds int    `json:"timeout_ms,omitempty"`
 }
 
 type MutationResult struct {

--- a/internal/control/protocol/runtime_test.go
+++ b/internal/control/protocol/runtime_test.go
@@ -227,3 +227,45 @@ func TestMutationRequestDecodesChannelOptionally(t *testing.T) {
 		t.Fatalf("channel=%v want nil", omitted.Channel)
 	}
 }
+
+func TestProxyGroupTestURLRoundTripAndOmitEmpty(t *testing.T) {
+	raw, err := json.Marshal(ProxyGroup{Name: "HK", Type: "URLTest", TestURL: "https://cp.cloudflare.com/generate_204"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `"test_url":"https://cp.cloudflare.com/generate_204"`) {
+		t.Fatalf("raw=%s", raw)
+	}
+	var got ProxyGroup
+	if err := json.Unmarshal(raw, &got); err != nil || got.TestURL != "https://cp.cloudflare.com/generate_204" {
+		t.Fatalf("got=%#v err=%v", got, err)
+	}
+	empty, err := json.Marshal(ProxyGroup{Name: "GLOBAL", Type: "Selector"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(empty), "test_url") {
+		t.Fatalf("empty=%s", empty)
+	}
+	var old ProxyGroup
+	if err := json.Unmarshal([]byte(`{"name":"GLOBAL","type":"Selector"}`), &old); err != nil || old.TestURL != "" {
+		t.Fatalf("old=%#v err=%v", old, err)
+	}
+}
+
+func TestDelayTestRequestOmitsZeroValues(t *testing.T) {
+	raw, err := json.Marshal(DelayTestRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != `{}` {
+		t.Fatalf("raw=%s", raw)
+	}
+	explicit, err := json.Marshal(DelayTestRequest{URL: "https://example.com/ping", TimeoutMilliseconds: 3500})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(explicit) != `{"url":"https://example.com/ping","timeout_ms":3500}` {
+		t.Fatalf("explicit=%s", explicit)
+	}
+}

--- a/internal/control/server/runtime.go
+++ b/internal/control/server/runtime.go
@@ -21,6 +21,14 @@ import (
 
 const maxControlBodySize = 1 << 20
 
+const (
+	defaultDelayTestURL   = "https://www.gstatic.com/generate_204"
+	defaultDelayTimeoutMS = 5000
+	maxDelayTimeoutMS     = 60_000
+)
+
+var errInvalidDelayTimeout = errors.New("delay test timeout is invalid")
+
 type RuntimeAPI interface {
 	Capabilities() []string
 	Snapshot() state.Snapshot
@@ -214,11 +222,18 @@ func (s *Server) delayTest(writer http.ResponseWriter, request *http.Request) {
 	if !decodeControlJSON(writer, request, &body) {
 		return
 	}
-	if body.URL == "" || body.TimeoutMilliseconds <= 0 || body.TimeoutMilliseconds > 60_000 {
-		writeInvalidArgument(writer, "delay test URL and timeout are invalid")
+	timeout, err := resolveDelayTimeout(body.TimeoutMilliseconds)
+	if err != nil {
+		writeInvalidArgument(writer, errInvalidDelayTimeout.Error())
 		return
 	}
-	delays, err := s.runtime.DelayGroup(request.Context(), request.PathValue("name"), body.URL, body.TimeoutMilliseconds)
+	name := request.PathValue("name")
+	testURL, err := s.resolveDelayURL(request.Context(), name, body.URL)
+	if err != nil {
+		s.writeControlError(request.Context(), writer, err)
+		return
+	}
+	delays, err := s.runtime.DelayGroup(request.Context(), name, testURL, timeout)
 	if err != nil {
 		s.writeControlError(request.Context(), writer, err)
 		return
@@ -234,17 +249,57 @@ func (s *Server) delayProxy(writer http.ResponseWriter, request *http.Request) {
 	if !decodeControlJSON(writer, request, &body) {
 		return
 	}
-	if body.URL == "" || body.TimeoutMilliseconds <= 0 || body.TimeoutMilliseconds > 60_000 {
-		writeInvalidArgument(writer, "delay test URL and timeout are invalid")
+	timeout, err := resolveDelayTimeout(body.TimeoutMilliseconds)
+	if err != nil {
+		writeInvalidArgument(writer, errInvalidDelayTimeout.Error())
 		return
 	}
 	name := request.PathValue("name")
-	delay, err := s.runtime.DelayProxy(request.Context(), name, body.URL, body.TimeoutMilliseconds)
+	testURL, err := s.resolveDelayURL(request.Context(), name, body.URL)
+	if err != nil {
+		s.writeControlError(request.Context(), writer, err)
+		return
+	}
+	delay, err := s.runtime.DelayProxy(request.Context(), name, testURL, timeout)
 	if err != nil {
 		s.writeControlError(request.Context(), writer, err)
 		return
 	}
 	writeJSON(writer, http.StatusOK, protocol.DelayResult{Schema: "mihari/v1", Delays: map[string]uint16{name: delay}})
+}
+
+func resolveDelayTimeout(ms int) (int, error) {
+	if ms < 0 || ms > maxDelayTimeoutMS {
+		return 0, errInvalidDelayTimeout
+	}
+	if ms == 0 {
+		return defaultDelayTimeoutMS, nil
+	}
+	return ms, nil
+}
+
+func (s *Server) resolveDelayURL(ctx context.Context, name, requested string) (string, error) {
+	if requested != "" {
+		return requested, nil
+	}
+	upstream, err := s.runtime.Proxies(ctx)
+	if err != nil {
+		return "", err
+	}
+	if proxy, ok := upstream.Proxies[name]; ok && proxy.TestURL != "" {
+		return proxy.TestURL, nil
+	}
+	for _, group := range orderedProxyGroups(upstream.Proxies) {
+		if group.TestURL == "" {
+			continue
+		}
+		for _, member := range group.All {
+			if member == name {
+				return group.TestURL, nil
+			}
+		}
+	}
+	return defaultDelayTestURL, nil
 }
 
 func (s *Server) connections(writer http.ResponseWriter, request *http.Request) {

--- a/internal/control/server/runtime.go
+++ b/internal/control/server/runtime.go
@@ -160,6 +160,7 @@ func orderedProxyGroups(proxies map[string]mihomo.Proxy) []protocol.ProxyGroup {
 		return protocol.ProxyGroup{
 			Name: proxy.Name, Type: proxy.Type, Now: proxy.Now,
 			All: append([]string(nil), proxy.All...), Nodes: nodes,
+			TestURL: proxy.TestURL,
 		}
 	}
 

--- a/internal/control/server/runtime_test.go
+++ b/internal/control/server/runtime_test.go
@@ -199,6 +199,39 @@ func TestProxiesPreservesGLOBALAllOrder(t *testing.T) {
 	}
 }
 
+func TestProxiesMapsGroupTestURL(t *testing.T) {
+	fake := &fakeRuntime{proxies: mihomo.Proxies{Proxies: map[string]mihomo.Proxy{
+		"GLOBAL": {Name: "GLOBAL", Type: "Selector", Now: "HK", All: []string{"HK", "leaf"}},
+		"HK":     {Name: "HK", Type: "URLTest", Now: "leaf", All: []string{"leaf"}, TestURL: "https://cp.cloudflare.com/generate_204"},
+		"leaf":   {Name: "leaf", Type: "VLESS"},
+	}}}
+	server := New(Options{Token: "token", Store: state.NewStore(state.Snapshot{}), Runtime: fake})
+	response := httptest.NewRecorder()
+	server.Handler().ServeHTTP(response, authorizedRequest(http.MethodGet, "/v1/proxies", nil))
+	if response.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	var got protocol.ProxyGroups
+	if err := json.Unmarshal(response.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Groups) < 1 {
+		t.Fatalf("groups=%#v", got.Groups)
+	}
+	var hk protocol.ProxyGroup
+	for _, group := range got.Groups {
+		if group.Name == "HK" {
+			hk = group
+		}
+	}
+	if hk.TestURL != "https://cp.cloudflare.com/generate_204" {
+		t.Fatalf("HK=%#v", hk)
+	}
+	if strings.Contains(response.Body.String(), `"test_url":"https://cp.cloudflare.com/generate_204"`) == false {
+		t.Fatalf("body=%s", response.Body.String())
+	}
+}
+
 func groupNames(groups []protocol.ProxyGroup) []string {
 	names := make([]string, len(groups))
 	for i, g := range groups {

--- a/internal/control/server/runtime_test.go
+++ b/internal/control/server/runtime_test.go
@@ -80,6 +80,95 @@ func TestProxyDelayEndpointTestsOneNode(t *testing.T) {
 	}
 }
 
+func TestDelayTestFallsBackToKernelAndDefaultURL(t *testing.T) {
+	cloud := "https://cp.cloudflare.com/generate_204"
+	other := "https://www.gstatic.com/generate_204"
+	proxies := mihomo.Proxies{Proxies: map[string]mihomo.Proxy{
+		"GLOBAL": {Name: "GLOBAL", Type: "Selector", All: []string{"HK", "TW", "leaf"}},
+		"HK":     {Name: "HK", Type: "URLTest", All: []string{"leaf"}, TestURL: cloud},
+		"TW":     {Name: "TW", Type: "URLTest", All: []string{"leaf"}, TestURL: "https://example.com/tw"},
+		"leaf":   {Name: "leaf", Type: "VLESS"},
+		"plain":  {Name: "plain", Type: "Selector", All: []string{"orphan"}, TestURL: ""},
+		"orphan": {Name: "orphan", Type: "Direct"},
+	}}
+
+	t.Run("explicit url wins", func(t *testing.T) {
+		fake := &fakeRuntime{proxies: proxies}
+		postDelay(t, fake, "/v1/proxy-groups/HK/delay-test", `{"url":"https://example.com/ping","timeout_ms":3500}`)
+		if fake.delayedGroup != "HK" || fake.delayedURL != "https://example.com/ping" || fake.delayedTimeout != 3500 {
+			t.Fatalf("fake=%#v", fake)
+		}
+	})
+	t.Run("empty uses group testUrl", func(t *testing.T) {
+		fake := &fakeRuntime{proxies: proxies}
+		postDelay(t, fake, "/v1/proxy-groups/HK/delay-test", `{}`)
+		if fake.delayedURL != cloud || fake.delayedTimeout != 5000 {
+			t.Fatalf("fake=%#v", fake)
+		}
+	})
+	t.Run("leaf uses first parent in GLOBAL.All", func(t *testing.T) {
+		fake := &fakeRuntime{proxies: proxies}
+		postDelay(t, fake, "/v1/proxies/leaf/delay-test", `{}`)
+		if fake.delayedProxy != "leaf" || fake.delayedURL != cloud {
+			t.Fatalf("fake=%#v", fake)
+		}
+	})
+	t.Run("no kernel url uses default", func(t *testing.T) {
+		fake := &fakeRuntime{proxies: proxies}
+		postDelay(t, fake, "/v1/proxies/orphan/delay-test", `{}`)
+		if fake.delayedURL != other {
+			t.Fatalf("url=%q", fake.delayedURL)
+		}
+	})
+	t.Run("timeout bounds", func(t *testing.T) {
+		fake := &fakeRuntime{proxies: proxies}
+		rec := postDelayRaw(t, fake, "/v1/proxy-groups/HK/delay-test", `{"timeout_ms":70000}`)
+		if rec.Code != http.StatusBadRequest || !strings.Contains(rec.Body.String(), "invalid_argument") {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+		if strings.Contains(rec.Body.String(), cloud) {
+			t.Fatalf("leaked url: %s", rec.Body.String())
+		}
+		rec = postDelayRaw(t, fake, "/v1/proxy-groups/HK/delay-test", `{"timeout_ms":-1}`)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("neg status=%d", rec.Code)
+		}
+	})
+	t.Run("proxies failure does not default", func(t *testing.T) {
+		fake := &fakeRuntime{proxiesErr: protocol.APIError{Code: protocol.CodeUpstreamFailure, Message: "mihomo controller is unavailable"}}
+		rec := postDelayRaw(t, fake, "/v1/proxy-groups/HK/delay-test", `{}`)
+		if rec.Code != http.StatusBadGateway {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+		if fake.delayedURL != "" {
+			t.Fatalf("should not call DelayGroup, url=%q", fake.delayedURL)
+		}
+	})
+	t.Run("explicit url skips Proxies", func(t *testing.T) {
+		fake := &fakeRuntime{proxiesErr: protocol.APIError{Code: protocol.CodeUpstreamFailure, Message: "mihomo controller is unavailable"}}
+		postDelay(t, fake, "/v1/proxy-groups/HK/delay-test", `{"url":"https://example.com/ping","timeout_ms":3500}`)
+		if fake.delayedURL != "https://example.com/ping" || fake.delayedTimeout != 3500 {
+			t.Fatalf("fake=%#v", fake)
+		}
+	})
+}
+
+func postDelay(t *testing.T, fake *fakeRuntime, path, body string) {
+	t.Helper()
+	rec := postDelayRaw(t, fake, path, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func postDelayRaw(t *testing.T, fake *fakeRuntime, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	server := New(Options{Token: "token", Store: state.NewStore(state.Snapshot{}), Runtime: fake})
+	rec := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rec, authorizedRequest(http.MethodPost, path, bytes.NewBufferString(body)))
+	return rec
+}
+
 func TestInstallAndQueryEndpoints(t *testing.T) {
 	fake := &fakeRuntime{
 		installResult: core.InstallResult{Version: "v1.19.0", Updated: true},
@@ -373,12 +462,16 @@ type fakeRuntime struct {
 	selectedName          string
 	installResult         core.InstallResult
 	proxies               mihomo.Proxies
+	proxiesErr            error
 	connections           mihomo.Connections
 	rules                 mihomo.Rules
 	ruleProviders         mihomo.RuleProviders
 	updatedRuleProvider   string
 	streamMessages        []json.RawMessage
 	delayedProxy          string
+	delayedGroup          string
+	delayedURL            string
+	delayedTimeout        int
 	proxyDelay            uint16
 	geoIPStatus           geoip.Status
 	geoIPRecords          []geoip.Record
@@ -410,7 +503,12 @@ func (f *fakeRuntime) Restart(ctx context.Context, operation runtimeapi.Operatio
 	return nil
 }
 
-func (f *fakeRuntime) Proxies(context.Context) (mihomo.Proxies, error) { return f.proxies, nil }
+func (f *fakeRuntime) Proxies(context.Context) (mihomo.Proxies, error) {
+	if f.proxiesErr != nil {
+		return mihomo.Proxies{}, f.proxiesErr
+	}
+	return f.proxies, nil
+}
 
 func (f *fakeRuntime) SelectProxy(_ context.Context, operation runtimeapi.Operation, group, name string) error {
 	f.operation = operation
@@ -419,12 +517,13 @@ func (f *fakeRuntime) SelectProxy(_ context.Context, operation runtimeapi.Operat
 	return nil
 }
 
-func (f *fakeRuntime) DelayGroup(context.Context, string, string, int) (mihomo.Delays, error) {
+func (f *fakeRuntime) DelayGroup(_ context.Context, group, testURL string, timeoutMilliseconds int) (mihomo.Delays, error) {
+	f.delayedGroup, f.delayedURL, f.delayedTimeout = group, testURL, timeoutMilliseconds
 	return mihomo.Delays{"DIRECT": 1}, nil
 }
 
-func (f *fakeRuntime) DelayProxy(_ context.Context, name, _ string, _ int) (uint16, error) {
-	f.delayedProxy = name
+func (f *fakeRuntime) DelayProxy(_ context.Context, name, testURL string, timeoutMilliseconds int) (uint16, error) {
+	f.delayedProxy, f.delayedURL, f.delayedTimeout = name, testURL, timeoutMilliseconds
 	return f.proxyDelay, nil
 }
 

--- a/internal/mihomo/client_test.go
+++ b/internal/mihomo/client_test.go
@@ -257,3 +257,20 @@ func TestClientClassifiesErrorsAndBoundsResponses(t *testing.T) {
 		})
 	}
 }
+
+func TestProxyJSONDecodesTestURL(t *testing.T) {
+	var got Proxy
+	if err := json.Unmarshal([]byte(`{"name":"HK","type":"URLTest","testUrl":"https://cp.cloudflare.com/generate_204"}`), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "HK" || got.Type != "URLTest" || got.TestURL != "https://cp.cloudflare.com/generate_204" {
+		t.Fatalf("got=%#v", got)
+	}
+	var empty Proxy
+	if err := json.Unmarshal([]byte(`{"name":"HK","type":"Selector"}`), &empty); err != nil {
+		t.Fatal(err)
+	}
+	if empty.TestURL != "" {
+		t.Fatalf("TestURL=%q", empty.TestURL)
+	}
+}

--- a/internal/mihomo/types.go
+++ b/internal/mihomo/types.go
@@ -18,6 +18,7 @@ type Proxy struct {
 	History []json.RawMessage `json:"history,omitempty"`
 	UDP     bool              `json:"udp,omitempty"`
 	XUDP    bool              `json:"xudp,omitempty"`
+	TestURL string            `json:"testUrl,omitempty"`
 }
 
 type Proxies struct {

--- a/internal/tui/pages/proxies/model.go
+++ b/internal/tui/pages/proxies/model.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"net"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -33,6 +35,8 @@ const (
 	DelayTesting
 	DelayValue
 	DelayTimeout
+	DelayFailed
+	DelayInvalid
 )
 
 type DelayState struct {
@@ -149,10 +153,10 @@ func (m *Model) Update(message tea.Msg) (ui.Page, tea.Cmd) {
 		}
 		return m, nil
 	case delayResultMsg:
-		if typed.err != nil {
-			m.delays[typed.node] = DelayState{Kind: DelayTimeout}
-		} else {
+		if typed.err == nil {
 			m.delays[typed.node] = DelayState{Kind: DelayValue, Milliseconds: typed.delay}
+		} else {
+			m.delays[typed.node] = DelayState{Kind: classifyDelayError(typed.err)}
 		}
 		return m, m.delaySpinCmdIfNeeded()
 	case startDelaySpinMsg:
@@ -428,13 +432,28 @@ func (m *Model) delaySpinCmdIfNeeded() tea.Cmd {
 	return func() tea.Msg { return startDelaySpinMsg{gen: gen} }
 }
 
+func classifyDelayError(err error) DelayKind {
+	var api protocol.APIError
+	if errors.As(err, &api) && api.Code == protocol.CodeInvalidArgument {
+		return DelayInvalid
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return DelayTimeout
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return DelayTimeout
+	}
+	return DelayFailed
+}
+
 // delayStyle maps latency state onto the theme color ladder.
-// Bands (ms): <100 good, 100–399 mid, ≥400 bad; timeout → DelayBad; untested → Muted; testing → Warning.
+// Bands (ms): <100 good, 100–399 mid, ≥400 bad; timeout/failed/invalid → DelayBad; untested → Muted; testing → Warning.
 func delayStyle(theme ui.Theme, delay DelayState) lipgloss.Style {
 	switch delay.Kind {
 	case DelayTesting:
 		return theme.Warning
-	case DelayTimeout:
+	case DelayTimeout, DelayFailed, DelayInvalid:
 		return theme.DelayBad
 	case DelayValue:
 		switch {
@@ -463,6 +482,10 @@ func renderDelay(theme ui.Theme, delay DelayState, now time.Time) string {
 		return style.Render(fmt.Sprintf("%d ms", delay.Milliseconds))
 	case DelayTimeout:
 		return style.Render(ui.TimeoutLabel)
+	case DelayFailed:
+		return style.Render(ui.FailedLabel)
+	case DelayInvalid:
+		return style.Render(ui.ProxyDelayInvalid)
 	default:
 		return style.Render(ui.MissingValue)
 	}

--- a/internal/tui/pages/proxies/model.go
+++ b/internal/tui/pages/proxies/model.go
@@ -18,9 +18,8 @@ import (
 )
 
 const (
-	proxyBarMaxWidth = 28
-	delayTestURL     = "https://www.gstatic.com/generate_204"
-	delayTimeout     = 5_000
+	proxyBarMaxWidth     = 28
+	delayTestConcurrency = 5
 )
 
 type Client interface {
@@ -51,6 +50,9 @@ type Model struct {
 	expanded       map[string]bool
 	focus          FocusID
 	delays         map[string]DelayState
+	queue          []string
+	inFlight       map[string]uint64
+	delayTestGen   uint64
 	pending        map[FocusID]bool
 	lastError      string
 	contentFocused bool
@@ -79,6 +81,7 @@ type delayResultMsg struct {
 	node  string
 	delay uint16
 	err   error
+	gen   uint64
 }
 
 // delaySpinTickMsg advances braille frames while any node is DelayTesting.
@@ -97,7 +100,7 @@ func New(client Client, newOperationID func() string) *Model {
 	}
 	return &Model{
 		client: client, newOperationID: newOperationID,
-		expanded: make(map[string]bool), delays: make(map[string]DelayState), pending: make(map[FocusID]bool),
+		expanded: make(map[string]bool), delays: make(map[string]DelayState), inFlight: make(map[string]uint64), pending: make(map[FocusID]bool),
 		theme: ui.DefaultTheme(),
 	}
 }
@@ -153,12 +156,13 @@ func (m *Model) Update(message tea.Msg) (ui.Page, tea.Cmd) {
 		}
 		return m, nil
 	case delayResultMsg:
+		delete(m.inFlight, typed.node)
 		if typed.err == nil {
 			m.delays[typed.node] = DelayState{Kind: DelayValue, Milliseconds: typed.delay}
 		} else {
 			m.delays[typed.node] = DelayState{Kind: classifyDelayError(typed.err)}
 		}
-		return m, m.delaySpinCmdIfNeeded()
+		return m, m.delayCmds()
 	case startDelaySpinMsg:
 		if typed.gen != m.delaySpinGen || !m.hasTesting() {
 			if typed.gen == m.delaySpinGen {
@@ -209,7 +213,7 @@ func (m *Model) Update(message tea.Msg) (ui.Page, tea.Cmd) {
 	case "enter":
 		return m, m.selectFocused()
 	case "t":
-		return m, tea.Batch(m.testNode(m.focus.Node), m.delaySpinCmdIfNeeded())
+		return m, m.testFocused()
 	}
 	return m, nil
 }
@@ -380,35 +384,116 @@ func (m *Model) selectFocused() tea.Cmd {
 	}
 }
 
-func (m *Model) testNode(node string) tea.Cmd {
-	if m.client == nil || node == "" {
-		return nil
+func (m *Model) groupNameSet() map[string]struct{} {
+	names := make(map[string]struct{}, len(m.groups))
+	for _, group := range m.groups {
+		names[group.Name] = struct{}{}
 	}
-	m.delays[node] = DelayState{Kind: DelayTesting}
-	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		result, err := m.client.DelayProxy(ctx, node, protocol.DelayTestRequest{URL: delayTestURL, TimeoutMilliseconds: delayTimeout})
-		return delayResultMsg{node: node, delay: result.Delays[node], err: err}
-	}
+	return names
 }
 
-func (m *Model) testAll() tea.Cmd {
+func (m *Model) delayTestLeaves() []string {
+	skip := m.groupNameSet()
 	seen := make(map[string]struct{})
-	commands := make([]tea.Cmd, 0)
+	var leaves []string
 	for _, group := range m.groups {
 		for _, node := range group.Nodes {
-			if _, exists := seen[node.Name]; exists {
+			if _, isGroup := skip[node.Name]; isGroup {
+				continue
+			}
+			if _, dup := seen[node.Name]; dup {
 				continue
 			}
 			seen[node.Name] = struct{}{}
-			commands = append(commands, m.testNode(node.Name))
+			leaves = append(leaves, node.Name)
 		}
 	}
-	if spin := m.delaySpinCmdIfNeeded(); spin != nil {
-		commands = append(commands, spin)
+	return leaves
+}
+
+func (m *Model) startDelay(name string) tea.Cmd {
+	gen := m.delayTestGen
+	if m.inFlight == nil {
+		m.inFlight = make(map[string]uint64)
 	}
-	return tea.Batch(commands...)
+	m.inFlight[name] = gen
+	m.delays[name] = DelayState{Kind: DelayTesting}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		result, err := m.client.DelayProxy(ctx, name, protocol.DelayTestRequest{})
+		delay := uint16(0)
+		if err == nil {
+			delay = result.Delays[name]
+		}
+		return delayResultMsg{node: name, delay: delay, err: err, gen: gen}
+	}
+}
+
+func (m *Model) fillSlots() []tea.Cmd {
+	var cmds []tea.Cmd
+	for len(m.inFlight) < delayTestConcurrency {
+		name, ok := m.popNextQueuedName()
+		if !ok {
+			break
+		}
+		cmds = append(cmds, m.startDelay(name))
+	}
+	return cmds
+}
+
+func (m *Model) delayCmds() tea.Cmd {
+	cmds := m.fillSlots()
+	if spin := m.delaySpinCmdIfNeeded(); spin != nil {
+		cmds = append(cmds, spin)
+	}
+	return tea.Batch(cmds...)
+}
+
+func (m *Model) popNextQueuedName() (string, bool) {
+	for i, name := range m.queue {
+		if _, flying := m.inFlight[name]; flying {
+			continue
+		}
+		m.queue = append(m.queue[:i], m.queue[i+1:]...)
+		return name, true
+	}
+	return "", false
+}
+
+func (m *Model) enqueueFront(name string) {
+	next := make([]string, 0, len(m.queue)+1)
+	next = append(next, name)
+	for _, existing := range m.queue {
+		if existing != name {
+			next = append(next, existing)
+		}
+	}
+	m.queue = next
+}
+
+func (m *Model) testAll() tea.Cmd {
+	m.delayTestGen++
+	m.queue = m.delayTestLeaves()
+	return m.delayCmds()
+}
+
+func (m *Model) testNode(node string) tea.Cmd {
+	if node == "" {
+		return nil
+	}
+	if _, isGroup := m.groupNameSet()[node]; isGroup {
+		return nil
+	}
+	if _, flying := m.inFlight[node]; flying {
+		return nil
+	}
+	m.enqueueFront(node)
+	return m.delayCmds()
+}
+
+func (m *Model) testFocused() tea.Cmd {
+	return m.testNode(m.focus.Node)
 }
 
 func (m *Model) hasTesting() bool {

--- a/internal/tui/pages/proxies/model_test.go
+++ b/internal/tui/pages/proxies/model_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -306,6 +307,201 @@ func TestModel_ControlTTestsEveryUniqueNodeOnce(t *testing.T) {
 	if client.delayCalls["shared"] != 1 || client.delayCalls["only-a"] != 1 || client.delayCalls["only-b"] != 1 {
 		t.Fatalf("calls=%v", client.delayCalls)
 	}
+	if client.lastDelayReq.URL != "" || client.lastDelayReq.TimeoutMilliseconds != 0 {
+		t.Fatalf("req=%#v", client.lastDelayReq)
+	}
+}
+
+func TestModel_DelayRequestOmitsURL(t *testing.T) {
+	client := &fakeClient{delay: 10}
+	model := New(client, func() string { return "op" })
+	model.SetGroups(protocol.ProxyGroups{Groups: []protocol.ProxyGroup{{
+		Name: "G", Nodes: []protocol.ProxyNode{{Name: "n1"}},
+	}}})
+	model.focus = FocusID{Group: "G", Node: "n1"}
+	applyProxyCmd(t, model, updateProxyKey(t, model, tea.KeyPressMsg{Code: 't', Text: "t"}))
+	if client.lastDelayReq.URL != "" || client.lastDelayReq.TimeoutMilliseconds != 0 {
+		t.Fatalf("req=%#v", client.lastDelayReq)
+	}
+}
+
+func TestModel_ControlTSkipsGroupNamesKeepsDIRECT(t *testing.T) {
+	client := &fakeClient{delay: 10}
+	model := New(client, func() string { return "op" })
+	model.SetGroups(protocol.ProxyGroups{Groups: []protocol.ProxyGroup{
+		{Name: "HK", Type: "URLTest", Nodes: []protocol.ProxyNode{{Name: "leaf"}, {Name: "TW"}, {Name: "DIRECT"}}},
+		{Name: "TW", Type: "Selector", Nodes: []protocol.ProxyNode{{Name: "leaf"}}},
+	}})
+	_, cmd := model.Update(tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl})
+	applyProxyCmd(t, model, cmd)
+	if client.delayCalls["TW"] != 0 || client.delayCalls["HK"] != 0 {
+		t.Fatalf("calls=%v", client.delayCalls)
+	}
+	if client.delayCalls["leaf"] != 1 || client.delayCalls["DIRECT"] != 1 {
+		t.Fatalf("calls=%v", client.delayCalls)
+	}
+}
+
+func leafCmds(t *testing.T, cmd tea.Cmd) []tea.Cmd {
+	t.Helper()
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("want flat BatchMsg, got %T", msg)
+	}
+	var leaves []tea.Cmd
+	for _, child := range batch {
+		leaves = append(leaves, child)
+	}
+	return leaves
+}
+
+func TestModel_ControlTCapsInFlightAtFive(t *testing.T) {
+	started := make(chan string, 16)
+	release := make(chan struct{})
+	client := &fakeClient{delay: 1, started: started, release: release}
+	model := New(client, func() string { return "op" })
+	nodes := make([]protocol.ProxyNode, 7)
+	for i := range nodes {
+		nodes[i] = protocol.ProxyNode{Name: string(rune('a' + i))}
+	}
+	model.SetGroups(protocol.ProxyGroups{Groups: []protocol.ProxyGroup{{Name: "G", Nodes: nodes}}})
+	_, cmd := model.Update(tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl})
+	leaves := leafCmds(t, cmd)
+	var wg sync.WaitGroup
+	for _, worker := range leaves {
+		worker := worker
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = worker()
+		}()
+	}
+	for i := 0; i < 5; i++ {
+		select {
+		case <-started:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for start")
+		}
+	}
+	client.mu.Lock()
+	max := client.maxInProgress
+	calls := len(client.delayCalls)
+	client.mu.Unlock()
+	if max > 5 || calls != 5 {
+		t.Fatalf("max=%d calls=%d", max, calls)
+	}
+	select {
+	case <-started:
+		t.Fatal("started a 6th before release")
+	default:
+	}
+	close(release)
+	wg.Wait()
+}
+
+func TestModel_QueuedNameIsNotTesting(t *testing.T) {
+	model := New(&fakeClient{delay: 1}, func() string { return "op" })
+	nodes := make([]protocol.ProxyNode, 6)
+	for i := range nodes {
+		nodes[i] = protocol.ProxyNode{Name: string(rune('a' + i))}
+	}
+	model.SetGroups(protocol.ProxyGroups{Groups: []protocol.ProxyGroup{{Name: "G", Nodes: nodes}}})
+	model.Update(tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl})
+	testingCount := 0
+	for _, st := range model.delays {
+		if st.Kind == DelayTesting {
+			testingCount++
+		}
+	}
+	if testingCount != 5 {
+		t.Fatalf("testing=%d delays=%v", testingCount, model.delays)
+	}
+	if model.delays[string(rune('a'+5))].Kind == DelayTesting {
+		t.Fatal("queued 6th node must not be Testing")
+	}
+}
+
+func TestModel_TDoesNotReplaceQueueOrDoubleInFlight(t *testing.T) {
+	started := make(chan string, 8)
+	release := make(chan struct{})
+	client := &fakeClient{delay: 1, started: started, release: release}
+	model := New(client, func() string { return "op" })
+	model.SetGroups(protocol.ProxyGroups{Groups: []protocol.ProxyGroup{{
+		Name: "G", Nodes: []protocol.ProxyNode{{Name: "n1"}, {Name: "n2"}},
+	}}})
+	model.focus = FocusID{Group: "G", Node: "n1"}
+	_, cmd := model.Update(tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl})
+	var wg sync.WaitGroup
+	for _, worker := range leafCmds(t, cmd) {
+		worker := worker
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = worker()
+		}()
+	}
+	<-started
+	<-started
+	_, again := model.Update(tea.KeyPressMsg{Code: 't', Text: "t"})
+	if again != nil {
+		if msg := again(); msg != nil {
+			if _, ok := msg.(tea.BatchMsg); ok {
+				t.Fatal("t must not start a second in-flight DelayProxy for n1")
+			}
+		}
+	}
+	client.mu.Lock()
+	n1 := client.delayCalls["n1"]
+	client.mu.Unlock()
+	if n1 != 1 {
+		t.Fatalf("parallel n1 calls=%d", n1)
+	}
+	close(release)
+	wg.Wait()
+}
+
+func TestModel_TDoesNotReplaceUnstartedQueue(t *testing.T) {
+	model := New(&fakeClient{delay: 1}, func() string { return "op" })
+	nodes := make([]protocol.ProxyNode, 7)
+	for i := range nodes {
+		nodes[i] = protocol.ProxyNode{Name: string(rune('a' + i))}
+	}
+	model.SetGroups(protocol.ProxyGroups{Groups: []protocol.ProxyGroup{{Name: "G", Nodes: nodes}}})
+	model.Update(tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl})
+	if len(model.queue) != 2 {
+		t.Fatalf("queue=%d want 2", len(model.queue))
+	}
+	before := append([]string(nil), model.queue...)
+	model.focus = FocusID{Group: "G", Node: string(rune('a'))}
+	model.Update(tea.KeyPressMsg{Code: 't', Text: "t"})
+	if len(model.queue) != 2 || model.queue[0] != before[0] || model.queue[1] != before[1] {
+		t.Fatalf("t replaced Ctrl+T queue: before=%v after=%v", before, model.queue)
+	}
+}
+
+func TestModel_SecondControlTReplacesUnstartedQueue(t *testing.T) {
+	model := New(&fakeClient{delay: 1}, func() string { return "op" })
+	nodes := make([]protocol.ProxyNode, 7)
+	for i := range nodes {
+		nodes[i] = protocol.ProxyNode{Name: string(rune('a' + i))}
+	}
+	model.SetGroups(protocol.ProxyGroups{Groups: []protocol.ProxyGroup{{Name: "G", Nodes: nodes}}})
+	model.Update(tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl})
+	if len(model.inFlight) != 5 || len(model.queue) != 2 {
+		t.Fatalf("after first inFlight=%d queue=%d", len(model.inFlight), len(model.queue))
+	}
+	firstQueue := append([]string(nil), model.queue...)
+	model.Update(tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl})
+	if len(model.inFlight) != 5 {
+		t.Fatalf("second Ctrl+T must not start over cap, inFlight=%d", len(model.inFlight))
+	}
+	if len(model.queue) != 7 {
+		t.Fatalf("second Ctrl+T must replace queue with all leaves, queue=%d first=%v now=%v", len(model.queue), firstQueue, model.queue)
+	}
 }
 
 type fakeClient struct {
@@ -316,6 +512,12 @@ type fakeClient struct {
 	delay         uint16
 	delayErr      error
 	delayCalls    map[string]int
+	lastDelayReq  protocol.DelayTestRequest
+	started       chan string
+	release       chan struct{}
+	mu            sync.Mutex
+	inProgress    int
+	maxInProgress int
 }
 
 func (c *fakeClient) SelectProxy(_ context.Context, group string, request protocol.ProxySelectionRequest) (protocol.MutationResult, error) {
@@ -326,11 +528,29 @@ func (c *fakeClient) SelectProxy(_ context.Context, group string, request protoc
 	return protocol.MutationResult{Schema: "mihari/v1", OperationID: request.OperationID}, nil
 }
 
-func (c *fakeClient) DelayProxy(_ context.Context, name string, _ protocol.DelayTestRequest) (protocol.DelayResult, error) {
+func (c *fakeClient) DelayProxy(_ context.Context, name string, req protocol.DelayTestRequest) (protocol.DelayResult, error) {
+	c.mu.Lock()
 	if c.delayCalls == nil {
 		c.delayCalls = make(map[string]int)
 	}
 	c.delayCalls[name]++
+	c.lastDelayReq = req
+	c.inProgress++
+	if c.inProgress > c.maxInProgress {
+		c.maxInProgress = c.inProgress
+	}
+	started := c.started
+	release := c.release
+	c.mu.Unlock()
+	if started != nil {
+		started <- name
+	}
+	if release != nil {
+		<-release
+	}
+	c.mu.Lock()
+	c.inProgress--
+	c.mu.Unlock()
 	if c.delayErr != nil {
 		return protocol.DelayResult{}, c.delayErr
 	}

--- a/internal/tui/pages/proxies/model_test.go
+++ b/internal/tui/pages/proxies/model_test.go
@@ -9,6 +9,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/mihari-proxy/mihari/internal/control/protocol"
+	"github.com/mihari-proxy/mihari/internal/diagnostics"
 	"github.com/mihari-proxy/mihari/internal/tui/ui"
 )
 
@@ -104,6 +105,8 @@ func TestDelayStyle_BandsAndTimeout(t *testing.T) {
 		{"untested", DelayState{Kind: DelayUntested}, "muted"},
 		{"testing", DelayState{Kind: DelayTesting}, "warning"},
 		{"timeout", DelayState{Kind: DelayTimeout}, "bad"},
+		{"failed", DelayState{Kind: DelayFailed}, "bad"},
+		{"invalid", DelayState{Kind: DelayInvalid}, "bad"},
 		{"good_28", DelayState{Kind: DelayValue, Milliseconds: 28}, "good"},
 		{"good_99", DelayState{Kind: DelayValue, Milliseconds: 99}, "good"},
 		{"mid_100", DelayState{Kind: DelayValue, Milliseconds: 100}, "mid"},
@@ -187,19 +190,14 @@ func TestRenderDelay_TestingUsesBrailleSpinner(t *testing.T) {
 }
 
 func TestModel_DelayTimeoutPath(t *testing.T) {
-	client := &fakeClient{delayErr: errors.New("timeout")}
+	client := &fakeClient{delayErr: context.DeadlineExceeded}
 	model := New(client, func() string { return "op" })
 	model.SetGroups(protocol.ProxyGroups{Groups: []protocol.ProxyGroup{{
 		Name: "G", Nodes: []protocol.ProxyNode{{Name: "n1", Type: "ss"}},
 	}}})
 	model.expanded["G"] = true
 	model.focus = FocusID{Group: "G", Node: "n1"}
-	cmd := model.testNode("n1")
-	if cmd == nil {
-		t.Fatal("expected delay command")
-	}
-	updated, _ := model.Update(cmd())
-	model = updated.(*Model)
+	applyProxyCmd(t, model, model.testNode("n1"))
 	if model.delays["n1"].Kind != DelayTimeout {
 		t.Fatalf("delay kind=%v", model.delays["n1"].Kind)
 	}
@@ -213,6 +211,67 @@ func TestModel_DelayTimeoutPath(t *testing.T) {
 		t.Fatalf("Timeout should be styled with DelayBad in view:\n%s", view)
 	}
 }
+
+func TestModel_DelayErrorKindsRender(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"failed", protocol.APIError{Code: protocol.CodeUpstreamFailure, Message: "mihomo request failed"}, ui.FailedLabel},
+		{"invalid", protocol.APIError{Code: protocol.CodeInvalidArgument, Message: "delay test URL and timeout are invalid"}, ui.ProxyDelayInvalid},
+		{"wrapped timeout", diagnostics.Wrap(protocol.APIError{Code: protocol.CodeDataFailure, Message: "local control operation failed"}, context.DeadlineExceeded), ui.TimeoutLabel},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &fakeClient{delayErr: tc.err}
+			model := New(client, func() string { return "op" })
+			model.SetGroups(protocol.ProxyGroups{Groups: []protocol.ProxyGroup{{
+				Name: "G", Nodes: []protocol.ProxyNode{{Name: "n1", Type: "ss"}},
+			}}})
+			model.expanded["G"] = true
+			model.focus = FocusID{Group: "G", Node: "n1"}
+			applyProxyCmd(t, model, model.testNode("n1"))
+			view := model.View()
+			if !strings.Contains(view, tc.want) {
+				t.Fatalf("view missing %q:\n%s", tc.want, view)
+			}
+			if !themeDelayBadContains(model.theme, view, tc.want) {
+				t.Fatalf("%q should use DelayBad:\n%s", tc.want, view)
+			}
+		})
+	}
+}
+
+func TestClassifyDelayError(t *testing.T) {
+	timeoutNet := timeoutNetError{}
+	cases := []struct {
+		name string
+		err  error
+		kind DelayKind
+	}{
+		{"deadline", context.DeadlineExceeded, DelayTimeout},
+		{"wrapped data_failure deadline", diagnostics.Wrap(protocol.APIError{Code: protocol.CodeDataFailure, Message: "local control operation failed"}, context.DeadlineExceeded), DelayTimeout},
+		{"net timeout", timeoutNet, DelayTimeout},
+		{"invalid", protocol.APIError{Code: protocol.CodeInvalidArgument, Message: "delay test URL and timeout are invalid"}, DelayInvalid},
+		{"upstream", protocol.APIError{Code: protocol.CodeUpstreamFailure, Message: "mihomo request failed"}, DelayFailed},
+		{"canceled", context.Canceled, DelayFailed},
+		{"plain", errors.New("timeout"), DelayFailed},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyDelayError(tc.err); got != tc.kind {
+				t.Fatalf("kind=%v want %v", got, tc.kind)
+			}
+		})
+	}
+}
+
+type timeoutNetError struct{}
+
+func (timeoutNetError) Error() string   { return "i/o timeout" }
+func (timeoutNetError) Timeout() bool   { return true }
+func (timeoutNetError) Temporary() bool { return true }
 
 func themeDelayBadContains(theme ui.Theme, view, label string) bool {
 	return strings.Contains(view, theme.DelayBad.Render(label))

--- a/internal/tui/ui/strings.go
+++ b/internal/tui/ui/strings.go
@@ -119,6 +119,7 @@ const (
 	MissingValue             = "—"
 	TestingLabel             = "Testing…"
 	TimeoutLabel             = "Timeout"
+	ProxyDelayInvalid        = "Invalid"
 	ProxySelectFailed        = "Proxy selection failed"
 	ConnectionsActiveLabel   = "Active"
 	ConnectionsClosedLabel   = "Closed"


### PR DESCRIPTION
## 变更内容

TUI/CLI 测速不再写死 gstatic。daemon 在 delay-test 省略 URL 时回落到内核 `testUrl`（再没有才用 Mihari 默认），`GET /v1/proxies` 下发组的 `test_url`。TUI `Ctrl+T` 限制 5 并发、跳过组名、区分 Timeout / Failed / Invalid。修复 #204 的「全 Timeout」根因，完成 #210。

## 类型

- [x] feat: 新功能
- [x] fix: Bug 修复
- [ ] refactor: 重构
- [x] docs: 文档
- [x] test: 测试
- [ ] chore: 构建/工具

## 检查清单

- [ ] `go test -race ./...` 通过（本地未跑 race；`go test ./...` 通过，`cmd/mihari` 有一次无关 flake 后重跑通过）
- [ ] `go vet ./...` 通过（交给 CI）
- [x] `gofmt -l` 相关文件无输出（Windows CRLF 以 CI 为准）
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] 未修改 `CHANGELOG.md`（`chore/release-*` 正式发版收口，或恢复成与 `main` 一致除外）
- [x] 若修改了 `internal/control/protocol` 的契约、CLI 输出/退出码或跨平台行为，已在 PR 描述中说明影响

## 协议影响

加字段，不升 `/v1`：

- `ProxyGroup` 增加 `test_url`（`omitempty`）
- `DelayTestRequest.url` / `timeout_ms` 改为可省略；空 URL 由 daemon 回落；`timeout_ms == 0` 表示默认 5000
- 旧客户端继续传 URL + 正超时，行为不变
- CLI 文本 `proxy groups` 仍不打印 URL；`--json` 会带上 `test_url`

## 相关 Issues

Closes #210
Related #204

## 其他

设计：`docs/superpowers/specs/2026-09-10-delay-test-url-design.md`
计划：`docs/superpowers/plans/2026-09-10-delay-test-url.md`
目标分支：`dev`
Worktree 保留：`.worktrees/feat-210-delay-test-url`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mihari-proxy/mihari/pull/225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

