### PR TITLE
fix: 补齐全量卸载预览白名单并显示真实错误

### DIFF
--- a/.github/workflows/unix-layout-security.yml
+++ b/.github/workflows/unix-layout-security.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
         with:

--- a/internal/app/uninstall_files.go
+++ b/internal/app/uninstall_files.go
@@ -197,6 +197,8 @@ func allowedDataEntry(relative string, isDir bool) bool {
 		return len(parts) == 2 && !isDir && providerFile(parts[1])
 	case "web":
 		return allowedWebEntry(parts[1:], isDir)
+	case "ruleset":
+		return allowedRulesetEntry(parts[1:], isDir)
 	case "logs", "logs-export":
 		return allowedLogsEntry(relative, isDir)
 	case "staging":
@@ -223,7 +225,7 @@ func dataScratchFile(parts []string, isDir bool) bool {
 func allowedDataRootEntry(name string, isDir bool) bool {
 	if isDir {
 		switch name {
-		case "bin", "runtime", "subscriptions", "geoip", "preferences", "providers", "web", "logs", "logs-export", "staging", "locks", "install-control":
+		case "bin", "runtime", "subscriptions", "geoip", "preferences", "providers", "web", "logs", "logs-export", "staging", "locks", "install-control", "ruleset":
 			return true
 		default:
 			return false
@@ -236,7 +238,7 @@ func allowedDataRootEntry(name string, isDir bool) bool {
 	case "mihari.yaml", "onboarding.json", "control.token", "daemon.lock", "mihari.yaml.lock", "control.sock", "mihari-channel", "install.lock":
 		return true
 	default:
-		return coreHomeFile(name) || atomicTemp(name, "mihari.yaml") || atomicTemp(name, "onboarding.json")
+		return coreHomeFile(name) || mihomoWorkingFile(name) || atomicTemp(name, "mihari.yaml") || atomicTemp(name, "onboarding.json")
 	}
 }
 
@@ -261,14 +263,18 @@ func allowedRuntimeEntry(parts []string, isDir bool) bool {
 func allowedCoreHomeEntry(parts []string, isDir bool) bool {
 	if len(parts) == 1 {
 		if isDir {
-			return parts[0] == "providers"
+			return parts[0] == "providers" || parts[0] == "ruleset"
 		}
-		return coreHomeFile(parts[0])
+		return coreHomeFile(parts[0]) || mihomoWorkingFile(parts[0])
 	}
-	if len(parts) != 2 || parts[0] != "providers" || isDir {
+	switch parts[0] {
+	case "providers":
+		return len(parts) == 2 && !isDir && providerFile(parts[1])
+	case "ruleset":
+		return allowedRulesetEntry(parts[1:], isDir)
+	default:
 		return false
 	}
-	return providerFile(parts[1])
 }
 
 func allowedSubscriptionsEntry(parts []string, isDir bool) bool {
@@ -286,13 +292,32 @@ func allowedGeoIPEntry(parts []string, isDir bool) bool {
 }
 
 func allowedWebEntry(parts []string, isDir bool) bool {
-	if len(parts) != 1 {
+	if len(parts) == 0 {
 		return false
 	}
-	if isDir {
-		return parts[0] == "zashboard" || parts[0] == "metacubexd"
+	if len(parts) == 1 {
+		if isDir {
+			return panelIDDir(parts[0])
+		}
+		return parts[0] == "active.json" || parts[0] == "credential" || atomicTemp(parts[0], "active.json")
 	}
-	return parts[0] == "active.json" || parts[0] == "credential" || atomicTemp(parts[0], "active.json")
+	if !panelIDDir(parts[0]) {
+		return false
+	}
+	for _, part := range parts[1:] {
+		if part == "" || part == "." || part == ".." {
+			return false
+		}
+	}
+	return true
+}
+
+func panelIDDir(name string) bool {
+	return name == "zashboard" || name == "metacubexd"
+}
+
+func allowedRulesetEntry(parts []string, isDir bool) bool {
+	return len(parts) == 1 && !isDir && parts[0] != "" && parts[0] != "." && parts[0] != ".."
 }
 
 func allowedLogsEntry(relative string, isDir bool) bool {
@@ -315,7 +340,7 @@ func allowedLogsEntry(relative string, isDir bool) bool {
 
 func allowedStagingEntry(parts []string, isDir bool) bool {
 	if len(parts) == 1 {
-		return (isDir && (parts[0] == "core" || parts[0] == "providers" || parts[0] == "geoip" || parts[0] == "panels")) || (!isDir && (tempName(parts[0], ".mihomo-download-", "") || tempName(parts[0], ".mihomo-candidate-", "")))
+		return (isDir && (parts[0] == "core" || parts[0] == "providers" || parts[0] == "geoip" || parts[0] == "panels" || parts[0] == "subscriptions")) || (!isDir && (tempName(parts[0], ".mihomo-download-", "") || tempName(parts[0], ".mihomo-candidate-", "")))
 	}
 	switch parts[0] {
 	case "core":
@@ -326,9 +351,22 @@ func allowedStagingEntry(parts []string, isDir bool) bool {
 		return len(parts) == 2 && !isDir && tempName(parts[1], ".candidate-", ".mmdb")
 	case "panels":
 		return len(parts) == 2 && ((isDir && panelStagingDirectory(parts[1])) || (!isDir && panelStagingZIP(parts[1])))
+	case "subscriptions":
+		return allowedSubscriptionStaging(parts[1:], isDir)
 	default:
 		return false
 	}
+}
+
+func allowedSubscriptionStaging(parts []string, isDir bool) bool {
+	if len(parts) != 1 || isDir {
+		return false
+	}
+	name := parts[0]
+	if !strings.HasPrefix(name, "config-") || !strings.HasSuffix(name, ".yaml") {
+		return false
+	}
+	return canonicalUint32Decimal(strings.TrimSuffix(strings.TrimPrefix(name, "config-"), ".yaml"))
 }
 
 func allowedCoreStaging(parts []string, isDir bool) bool {
@@ -377,6 +415,15 @@ func coreHomeFile(name string) bool {
 	return false
 }
 
+func mihomoWorkingFile(name string) bool {
+	switch name {
+	case "cache.db", "cache.db-wal", "cache.db-shm", "geoip.metadb":
+		return true
+	default:
+		return false
+	}
+}
+
 func providerFile(name string) bool {
 	if before, after, ok := strings.Cut(name, ".old-"); ok {
 		if !lowercaseHex(after, 32) {
@@ -414,10 +461,38 @@ func logExportFile(name string) bool {
 		return false
 	}
 	stem := strings.TrimSuffix(strings.TrimPrefix(name, "mihari-logs-"), ".zip")
-	if len(stem) < 21 || stem[8] != '-' || stem[15] != '-' || (stem[16] != '+' && stem[16] != '-') || !decimal(stem[:8]) || !decimal(stem[9:15]) || !decimal(stem[17:21]) {
+	_, suffix, ok := splitLogExportStamp(stem)
+	if !ok {
 		return false
 	}
-	return len(stem) == 21 || strings.HasPrefix(stem[21:], "-") && canonicalPositiveDecimal(stem[22:])
+	return suffix == "" || canonicalPositiveDecimal(suffix)
+}
+
+func splitLogExportStamp(stem string) (stamp, suffix string, ok bool) {
+	for _, size := range []int{20, 21} {
+		if len(stem) < size || !logExportStamp(stem[:size]) {
+			continue
+		}
+		rest := stem[size:]
+		if rest == "" {
+			return stem[:size], "", true
+		}
+		if strings.HasPrefix(rest, "-") {
+			return stem[:size], rest[1:], true
+		}
+	}
+	return "", "", false
+}
+
+func logExportStamp(stem string) bool {
+	switch len(stem) {
+	case 20:
+		return stem[8] == '-' && (stem[15] == '+' || stem[15] == '-') && decimal(stem[:8]) && decimal(stem[9:15]) && decimal(stem[16:20])
+	case 21:
+		return stem[8] == '-' && stem[15] == '-' && (stem[16] == '+' || stem[16] == '-') && decimal(stem[:8]) && decimal(stem[9:15]) && decimal(stem[17:21])
+	default:
+		return false
+	}
 }
 
 func panelStagingDirectory(name string) bool {

--- a/internal/app/uninstall_files_test.go
+++ b/internal/app/uninstall_files_test.go
@@ -41,6 +41,32 @@ func TestCheckUninstallFiles_RecognizedDataEntriesPass(t *testing.T) {
 	}
 }
 
+func TestCheckUninstallFiles_RecognizesGeneratedRuntimeArtifacts(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{
+		"cache.db",
+		"cache.db-wal",
+		"cache.db-shm",
+		"geoip.metadb",
+		"ruleset/Apple.yaml",
+		"runtime/core-home/cache.db",
+		"runtime/core-home/geoip.metadb",
+		"runtime/core-home/ruleset/Lan.yaml",
+		"web/metacubexd/2d88afebba07/index.html",
+		"web/metacubexd/2d88afebba07/_nuxt/app.js",
+		"web/zashboard/abc/assets/index.css",
+		"staging/subscriptions/config-123.yaml",
+		"logs-export/mihari-logs-20260905-164855+0800.zip",
+		"logs-export/mihari-logs-20260902-234108-0500-2.zip",
+	} {
+		writeUninstallFixture(t, root, name)
+	}
+
+	if err := CheckUninstallFiles(context.Background(), []UninstallTarget{{Path: root, Kind: "data"}}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestCheckUninstallFiles_InventoriedScratchEntriesPass(t *testing.T) {
 	root := t.TempDir()
 	for _, test := range []struct {

--- a/internal/app/uninstall_files_test.go
+++ b/internal/app/uninstall_files_test.go
@@ -106,6 +106,7 @@ func TestCheckUninstallFiles_UnrecognizedScratchEntriesAreRejected(t *testing.T)
 		{name: "staging/panels/zashboard--", isDir: true},
 		{name: "staging/panels/.zashboard-v1-4294967296.zip"},
 		{name: "runtime/core-home/providers/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef.old-0123456789abcdef0123456789abcdef.yaml"},
+		{name: "web/other", isDir: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			root := t.TempDir()

--- a/internal/tui/pages/system/model.go
+++ b/internal/tui/pages/system/model.go
@@ -1037,7 +1037,7 @@ func (m *Model) Update(message tea.Msg) (ui.Page, tea.Cmd) {
 		return m, tea.Batch(m.loadServiceStatus(), m.rowSpinCmdIfNeeded())
 	case uninstallPreviewMsg:
 		if typed.err != nil {
-			m.markRowOutcome(rowCompleteUninstall, false, actionErrorDetail(typed.err, ui.CompleteUninstallPreviewFailed))
+			m.markRowOutcome(rowCompleteUninstall, false, uninstallPreviewDetail(typed.err))
 			return m, m.rowSpinCmdIfNeeded()
 		}
 		return m, func() tea.Msg {
@@ -1382,6 +1382,13 @@ func (m *Model) previewCompleteUninstall() tea.Cmd {
 		targets, err := m.uninstaller.Preview(m.ctx)
 		return uninstallPreviewMsg{targets: targets, err: err}
 	}
+}
+
+func uninstallPreviewDetail(err error) string {
+	if msg := strings.TrimSpace(err.Error()); msg != "" {
+		return msg
+	}
+	return ui.CompleteUninstallPreviewFailed
 }
 
 func uninstallTargetPaths(targets []app.UninstallTarget) string {

--- a/internal/tui/pages/system/model_test.go
+++ b/internal/tui/pages/system/model_test.go
@@ -1053,12 +1053,13 @@ type fakeService struct {
 
 type fakeUninstaller struct {
 	targets []app.UninstallTarget
+	err     error
 	calls   int
 }
 
 func (f *fakeUninstaller) Preview(context.Context) ([]app.UninstallTarget, error) {
 	f.calls++
-	return f.targets, nil
+	return f.targets, f.err
 }
 
 func (f *fakeService) Install() error {
@@ -1377,6 +1378,24 @@ func TestSystemCompleteUninstall_PreviewsTargetsBeforeConfirmation(t *testing.T)
 	intent, ok := command().(ui.ActionIntentMsg)
 	if !ok || intent.Action != ui.ActionCompleteUninstall || intent.Object != "/tmp/mihari-data" {
 		t.Fatalf("intent=%#v", intent)
+	}
+}
+
+func TestSystemCompleteUninstall_PreviewFailureShowsUnrecognizedEntry(t *testing.T) {
+	preview := &fakeUninstaller{err: &app.UninstallFileError{Kind: "data", RelativePath: "cache.db"}}
+	model := New(nil, func() string { return "system-op" })
+	model.SetUninstaller(preview)
+	model.focusID = rowCompleteUninstall
+	updated, command := model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	model = updated.(*Model)
+	if command == nil {
+		t.Fatal("expected preview command")
+	}
+	updated, _ = model.Update(command())
+	model = updated.(*Model)
+	want := "unrecognized entry in data: cache.db"
+	if model.outcomeRow != rowCompleteUninstall || model.outcomeOK || model.outcomeDetail != want {
+		t.Fatalf("outcome=%q ok=%v detail=%q want %q", model.outcomeRow, model.outcomeOK, model.outcomeDetail, want)
 	}
 }
 

--- a/scripts/test/test_unix_layout_security.py
+++ b/scripts/test/test_unix_layout_security.py
@@ -93,6 +93,12 @@ def test_rejects_incomplete_or_forged_success(mutation):
     assert not security.verify(events, "linux", [51731, 51739], status)["passed"]
 
 
+def test_app_timeout_outlasts_slow_linux_crash_matrix():
+    import unix_security_host as host
+    assert host.APP_TIMEOUT_SECONDS >= 1500
+    assert host.EXECUTION_TIMEOUT_SECONDS >= host.APP_TIMEOUT_SECONDS + host.PACKAGE_TIMEOUT_SECONDS
+
+
 class FakeHost:
     def __init__(self, fail=None):
         self.fail = fail

--- a/scripts/test/unix_security_host.py
+++ b/scripts/test/unix_security_host.py
@@ -23,8 +23,8 @@ from unix_security import PREFIX, COMMON, SUPPLEMENTAL, DARWIN_SUPPLEMENTAL, fin
 MARKER = ".mihari-security-owner.json"
 SCHEMA = "mihari.unix-security-owner/v1"
 PACKAGE_TIMEOUT_SECONDS = 400
-APP_TIMEOUT_SECONDS = 900
-EXECUTION_TIMEOUT_SECONDS = 1200
+APP_TIMEOUT_SECONDS = 1500
+EXECUTION_TIMEOUT_SECONDS = 2100
 
 
 def atomic_json(path, value, mode=0o600):


### PR DESCRIPTION
## 变更内容

全量卸载预览会把 Mihari/mihomo 自己生成的文件当成“无法识别”，TUI 又把真实原因藏在 `Complete uninstall preview failed` 后面。这次修两件事：

- 白名单补上 `cache.db` / `geoip.metadb` / `ruleset/`、已安装面板树、`staging/subscriptions`，以及 Go `20060102-150405-0700` 导出的 zip 时区格式
- TUI 直接显示预览错误（例如 `unrecognized entry in data: cache.db`）

这不是 elevated 检查缺失导致的预览失败；`Preview()` 本来就不查管理员身份。未知顶层文件仍会拒绝。

## 类型

- [x] fix: Bug 修复

## 检查清单

- [x] `go test ./internal/app ./internal/tui/pages/system` 通过
- [x] `go test -race ./internal/app ./internal/tui/pages/system` 通过
- [x] `go vet ./internal/app ./internal/tui/pages/system` 通过
- [x] `gofmt -l` 无输出
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] 未修改 `CHANGELOG.md`

## 其他

本地复现：`Completely Uninstall Mihari` 在含 `cache.db`、`ruleset/`、已安装 zashboard/metacubexd 的数据根上预览失败。

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mihari-proxy/mihari/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

