### PR TITLE
fix: 让 Program Files 安装能探测到替换版本

### DIFF
--- a/internal/platform/replacement_target_windows.go
+++ b/internal/platform/replacement_target_windows.go
@@ -12,6 +12,9 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// NT SERVICE\TrustedInstaller. C:\ and Program Files are owned by this SID.
+const windowsTrustedInstallerSID = "S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464"
+
 func openReplacementFile(ctx context.Context, path string) (file *os.File, id string, trusted bool, verify func() error, closeParent func() error, err error) {
 	type link struct {
 		path   string
@@ -59,7 +62,7 @@ func openReplacementFile(ctx context.Context, path string) (file *os.File, id st
 			return nil, "", false, nil, nil, e
 		}
 		sd, e := windows.GetSecurityInfo(h, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
-		if e != nil || !replacementWindowsExecutionTrust(sd, elevated, user) {
+		if e != nil || !replacementWindowsExecutionTrust(sd, elevated, user, filepath.Dir(p) == p) {
 			trusted = false
 		}
 	}
@@ -80,7 +83,7 @@ func openReplacementFile(ctx context.Context, path string) (file *os.File, id st
 			actual, e := identityFromHandle(h)
 			if trusted {
 				sd, securityErr := windows.GetSecurityInfo(h, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
-				if securityErr != nil || !replacementWindowsExecutionTrust(sd, elevated, user) {
+				if securityErr != nil || !replacementWindowsExecutionTrust(sd, elevated, user, filepath.Dir(l.path) == l.path) {
 					e = errors.Join(e, ErrIdentityMismatch, securityErr)
 				}
 			}
@@ -119,7 +122,7 @@ func replacementWindowsOpen(path string, file bool) (windows.Handle, error) {
 	return h, nil
 }
 
-func replacementWindowsExecutionTrust(sd *windows.SECURITY_DESCRIPTOR, elevated bool, user *windows.SID) bool {
+func replacementWindowsExecutionTrust(sd *windows.SECURITY_DESCRIPTOR, elevated bool, user *windows.SID, volumeRoot bool) bool {
 	if sd == nil {
 		return false
 	}
@@ -131,8 +134,12 @@ func replacementWindowsExecutionTrust(sd *windows.SECURITY_DESCRIPTOR, elevated 
 	if err != nil {
 		return false
 	}
+	installer, err := windows.StringToSid(windowsTrustedInstallerSID)
+	if err != nil {
+		return false
+	}
 	allowed := func(sid *windows.SID) bool {
-		return sid != nil && (sid.Equals(system) || sid.Equals(admins) || (!elevated && user != nil && sid.Equals(user)))
+		return sid != nil && (sid.Equals(system) || sid.Equals(admins) || sid.Equals(installer) || (!elevated && user != nil && sid.Equals(user)))
 	}
 	owner, _, err := sd.Owner()
 	if err != nil || !allowed(owner) {
@@ -142,7 +149,12 @@ func replacementWindowsExecutionTrust(sd *windows.SECURITY_DESCRIPTOR, elevated 
 	if err != nil || acl == nil {
 		return false
 	}
-	const write = windows.FILE_WRITE_DATA | windows.FILE_APPEND_DATA | windows.FILE_WRITE_EA | windows.FILE_WRITE_ATTRIBUTES | installControlFileDeleteChild | windows.DELETE | windows.WRITE_DAC | windows.WRITE_OWNER | windows.GENERIC_WRITE | windows.GENERIC_ALL
+	write := windows.ACCESS_MASK(windows.FILE_WRITE_DATA | windows.FILE_APPEND_DATA | windows.FILE_WRITE_EA | windows.FILE_WRITE_ATTRIBUTES | installControlFileDeleteChild | windows.DELETE | windows.WRITE_DAC | windows.WRITE_OWNER | windows.GENERIC_WRITE | windows.GENERIC_ALL)
+	if volumeRoot {
+		// Volume roots commonly let Authenticated Users create directories.
+		// That does not allow replacing existing children such as Program Files.
+		write &^= windows.FILE_WRITE_DATA | windows.FILE_APPEND_DATA
+	}
 	for i := uint32(0); i < uint32(acl.AceCount); i++ {
 		var ace *windows.ACCESS_ALLOWED_ACE
 		if err := windows.GetAce(acl, i, &ace); err != nil {

--- a/internal/platform/replacement_target_windows_test.go
+++ b/internal/platform/replacement_target_windows_test.go
@@ -15,20 +15,25 @@ func TestReplacementFile_WindowsExecutionTrust(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, tc := range []struct {
-		name, sddl     string
-		elevated, want bool
+		name, sddl                 string
+		elevated, volumeRoot, want bool
 	}{
-		{"admin controlled", "O:BAG:BAD:(A;;FA;;;SY)(A;;FA;;;BA)(A;;GRGX;;;BU)", true, true},
-		{"unsafe write ACL", "O:BAG:BAD:(A;;FA;;;SY)(A;;FA;;;BA)(A;;GW;;;BU)", true, false},
-		{"user owned elevated", "O:S-1-5-21-1-2-3-1000G:BAD:(A;;FA;;;S-1-5-21-1-2-3-1000)", true, false},
-		{"same user", "O:S-1-5-21-1-2-3-1000G:BAD:(A;;FA;;;S-1-5-21-1-2-3-1000)", false, true},
+		{"admin controlled", "O:BAG:BAD:(A;;FA;;;SY)(A;;FA;;;BA)(A;;GRGX;;;BU)", true, false, true},
+		{"unsafe write ACL", "O:BAG:BAD:(A;;FA;;;SY)(A;;FA;;;BA)(A;;GW;;;BU)", true, false, false},
+		{"user owned elevated", "O:S-1-5-21-1-2-3-1000G:BAD:(A;;FA;;;S-1-5-21-1-2-3-1000)", true, false, false},
+		{"same user", "O:S-1-5-21-1-2-3-1000G:BAD:(A;;FA;;;S-1-5-21-1-2-3-1000)", false, false, true},
+		{"trusted installer owner", "O:" + windowsTrustedInstallerSID + "G:SYD:(A;;FA;;;SY)(A;;FA;;;BA)(A;;FA;;;" + windowsTrustedInstallerSID + ")(A;;GRGX;;;BU)", true, false, true},
+		{"trusted installer owner user write", "O:" + windowsTrustedInstallerSID + "G:SYD:(A;;FA;;;SY)(A;;FA;;;BA)(A;;GW;;;BU)", true, false, false},
+		{"volume root users add subdirectory", "O:" + windowsTrustedInstallerSID + "G:SYD:(A;;FA;;;SY)(A;;FA;;;BA)(A;;0x4;;;AU)(A;;GRGX;;;BU)", true, true, true},
+		{"non-root users add subdirectory", "O:" + windowsTrustedInstallerSID + "G:SYD:(A;;FA;;;SY)(A;;FA;;;BA)(A;;0x4;;;AU)(A;;GRGX;;;BU)", true, false, false},
+		{"volume root users generic write", "O:" + windowsTrustedInstallerSID + "G:SYD:(A;;FA;;;SY)(A;;GW;;;AU)", true, true, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			sd, err := windows.SecurityDescriptorFromString(tc.sddl)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got := replacementWindowsExecutionTrust(sd, tc.elevated, user); got != tc.want {
+			if got := replacementWindowsExecutionTrust(sd, tc.elevated, user, tc.volumeRoot); got != tc.want {
 				t.Fatalf("trust=%v want %v", got, tc.want)
 			}
 		})


### PR DESCRIPTION
## 变更内容

elevated 自更新确认框把官方 `C:\Program Files\Mihari\mihari.exe` 的 service/binary 显示成 Unknown，即使二进制 `self version --json` 实际是 `v0.9.3-dev.7`。

原因是 Windows 执行信任检查从盘符开始走完整路径：

- `C:\` / `C:\Program Files` 所有者是 TrustedInstaller，不在原先的 SYSTEM/Administrators 名单里
- `C:\` 默认给 Authenticated Users 开了 CreateDirectories（`FILE_APPEND_DATA`），被当成危险写权限

探测因此 `MayExecute=false`，跳过版本查询。

本次：

- 把 TrustedInstaller 视为受保护的系统主体
- 卷根上忽略“建文件/建目录”，仍拒绝 GENERIC_WRITE / DELETE / WRITE_DAC 等真正能改现有子项的权限
- 用户可写副本在 elevated 下仍是 unknown

## 类型

- [x] fix: Bug 修复

## 检查清单

- [x] `go test ./internal/platform` 通过
- [x] `go test -race ./internal/platform` 通过
- [x] `go vet ./internal/platform` 通过
- [x] `gofmt -l` 无输出
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] 未修改 `CHANGELOG.md`

## 其他

不读取真实 Program Files；用 SDDL fixture 覆盖 TrustedInstaller 所有者、卷根建目录 ACE、以及非卷根同类 ACE 仍拒绝。

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mihari-proxy/mihari/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

