### PR TITLE
feat: TUI 全量卸载改为列出文件夹并确认两次

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Mihari 是面向 Windows、Linux 和 macOS 的 mihomo 本地管理器。它使�
 - daemon/Manager 是运行业务状态与 mihomo 生命周期的唯一所有者和写入者。窄例外：Unix root installer 仅在持锁停机事务中迁移业务文件及管理安装资源；固定应用通道 metadata 可经 app 维护用例在 install.lock 下原子更新并拒绝未完成相关事务。不得扩展为任意 CLI/TUI 业务文件写入。
 - CLI、TUI 及其他本地客户端只通过 `internal/control/client` 和版本化本地控制协议访问 daemon，不直接修改 daemon 管理的业务文件。
 - **日志窄例外**：TUI 仅可通过 `internal/logging` 创建其日志目录并追加/轮转固定 `mihari-tui.log*`。Unix 系统模式使用当前 UID 的 U/logs，导出到 U/logs-export；Windows/显式私有 P 保留单根。不得创建机器 B/D/credential 或写 settings、订阅、面板等业务状态。停机 installer 例外仅限上一条已批准范围。
-- **卸载窄例外**：服务已停止且 daemon 不再存活后，已提权的本地全量卸载路径可删除预检通过的受管文件根。不得在 daemon 存活期间由 TUI/CLI 直写业务文件，也不得把该路径扩成 settings、订阅或其他业务状态写入。
+- **卸载窄例外**：服务已停止且 daemon 不再存活后，已提权的本地全量卸载路径可删除预览列出的目标根。`--purge --yes` 仍只删白名单内文件；TUI 两次确认或 `--force` 可整根删除。不得在 daemon 存活期间由 TUI/CLI 直写业务文件，也不得把该路径扩成 settings、订阅或其他业务状态写入。
 - 本地控制 API 使用 Windows named pipe 或 Unix domain socket，不得退化为 TCP 监听。
 - mihomo controller 仅绑定 loopback；浏览器不得获得 controller 地址或 secret。
 - 所有 Web 面板的 REST、WebSocket 与写操作必须经过 Mihari Web gateway 和统一 mutation coordinator；未知写操作默认拒绝。

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ mihari sysproxy enable
 | System proxy / TUN | `mihari sysproxy enable` · `mihari sysproxy enable --force` · `mihari tun enable` · `mihari tun enable --force` |
 | Web panels | `mihari panel list` · `mihari panel open` |
 | Service control | `mihari service status` · `mihari service stop` |
-| Completely uninstall | System page `Completely Uninstall Mihari` · `mihari service uninstall --purge --yes` |
+| Completely uninstall | System page `Completely Uninstall Mihari` · `mihari service uninstall --purge --yes` · `mihari service uninstall --purge --yes --force` |
 | Update mihari | System page `Update Mihari` · `mihari self update` |
 
 See [docs/commands.md](docs/commands.md) for the full command reference, and [docs/architecture.md](docs/architecture.md) for the architecture and security model.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -134,7 +134,7 @@ mihari sysproxy enable
 | 系统代理 / TUN | `mihari sysproxy enable` · `mihari sysproxy enable --force` · `mihari tun enable` · `mihari tun enable --force` |
 | Web 面板 | `mihari panel list` · `mihari panel open` |
 | 服务控制 | `mihari service status` · `mihari service stop` |
-| 全量卸载 | System 页 `Completely Uninstall Mihari` · `mihari service uninstall --purge --yes` |
+| 全量卸载 | System 页 `Completely Uninstall Mihari` · `mihari service uninstall --purge --yes` · `mihari service uninstall --purge --yes --force` |
 | 更新 mihari | System 页 `Update Mihari` · `mihari self update` |
 
 完整命令参考见 [docs/commands.md](docs/commands.md),架构与安全机制见 [docs/architecture.md](docs/architecture.md)。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,7 +86,7 @@ Phase 4 保留几条明确边界：认证前、预解析和只读请求没有统
 
 - TUI 只通过 `internal/control/client` 经原生 IPC 控制面与本地守护进程通信。它从不打开 mihomo 控制器、从不接收控制器密钥。
 - TUI 的日志直接写入例外是经 `internal/logging` 在当前 UID 的 U/logs 追加/轮转固定 `mihari-tui.log*`（Windows/显式私有 P 保留单根）;不得写 `mihari.yaml`、订阅、token、面板或其他业务状态。日志配置变更仍只走 daemon 控制面。
-- System 页面 Logging 下方的 Maintenance 区提供 **Completely Uninstall Mihari**。确认框默认 Cancel；确认后先关闭 TUI 资源，再由已提权的本地卸载路径停止并注销 OS 服务，然后删除预检通过的受管文件。CLI 对应入口是 `mihari service uninstall --purge --yes`。普通 `service uninstall` 仍只注销服务。
+- System 页面 Logging 下方的 Maintenance 区提供 **Completely Uninstall Mihari**。两次确认框都默认 Cancel，并列出将清空的文件夹；确认后先关闭 TUI 资源，再由已提权的本地卸载路径停止并注销 OS 服务，然后删除这些文件夹。CLI `mihari service uninstall --purge --yes` 仍只删除白名单内的受管文件；整根删除需再加 `--force`。普通 `service uninstall` 仍只注销服务。
 - 搜索与表单字段中的括号粘贴和 Ctrl+V 使用纯 Go 实现的 `github.com/atotto/clipboard` 辅助库;Mihari 本身从不把密钥写入剪贴板。
 - 页面:独立的首次运行 Setup 路由、Overview、可展开的 Proxies、带本地 GeoIP 详情的活动/已关闭 Connections、Rules/Providers、有界的结构化 Logs 流、订阅管理表单、分类的 System 页面,以及驱动面板安装/更新/激活/打开/回滚的 Web GUI 页面(在守护进程通告 `web-gui` 能力之后)。
 - Setup 安装核心、可添加初始订阅、准备本地 GeoIP 数据,并请求守护进程持久化校验过的本地端点。
@@ -136,7 +136,7 @@ Unix 默认入口 B 为 Linux `/var/lib/mihari` 或 macOS `/Library/Application 
 
 显式 MIHARI_DATA=P 保留 P 本身的私有布局与0700/0600权限；Windows 路径、named pipe、DACL、服务与本地 ZIP v1 保留。Unix 系统导出为 mihari-logs-export/v2，通过固定机器快照协议组合机器和本用户日志，离线须明确选仅本用户日志。客户端不创建 B/D/C，也不直接读取 D。
 
-业务写入归 daemon/Manager；窄例外为 root installer 的持锁停机迁移/安装事务，app 对固定 channel sidecar 的受锁原子维护，以及服务已停止后的全量卸载删除预检通过的受管文件根。安装锁顺序 B→私有服务 P→data→endpoint，永久锁不 unlink。activation 之前恢复 source，之后只修复 target；旧树和日志保留，未知身份拒绝覆盖。已安装服务启动先校验全局 B 的 matching activation 与 binary hash，取得 data/E 后再校验，不重入 installer 持有的 install lease。未标记 root P 前台只看 P。root P channel 写入持 P 锁时只读相关 B journal，相关未完成事务拒绝；非 root P 不读 B。
+业务写入归 daemon/Manager；窄例外为 root installer 的持锁停机迁移/安装事务，app 对固定 channel sidecar 的受锁原子维护，以及服务已停止后的全量卸载删除预览列出的目标根。安装锁顺序 B→私有服务 P→data→endpoint，永久锁不 unlink。activation 之前恢复 source，之后只修复 target；旧树和日志保留，未知身份拒绝覆盖。已安装服务启动先校验全局 B 的 matching activation 与 binary hash，取得 data/E 后再校验，不重入 installer 持有的 install lease。未标记 root P 前台只看 P。root P channel 写入持 P 锁时只读相关 B journal，相关未完成事务拒绝；非 root P 不读 B。
 
 所有平台由共同的 subscription.Generate 保留非托管配置，仅覆盖 Mihari 管理的关键参数，TUN 只覆盖 enable；配置语义与原生 provider 由 mihomo 处理。root runtime 保留可信核心 provenance，仍只允许 v1.19.30 的四个 Unix hash；不再按完整字段白名单拒绝配置，也不保证限制所有额外 listener 或文件访问。旧 provider/resource WAL 先恢复，再从原订阅缓存生成；缺失原缓存时保留旧数据并报错，历史资源不主动清理。验证子进程先恢复历史事务，再执行认证和校验，不启动真实业务、后台刷新或核心。可信 I 及全部祖先必须满足 owner/ACL/挂载规则，不能自动修复主机祖先；离线信任位置为解析后的 I/install-trust。无服务 self-update 使用编译通道且不访问 B；服务更新走统一安装事务。
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -24,7 +24,7 @@ mihari service uninstall --purge --yes
 
 执行 `service install` + `start` 后,关闭 TUI 或普通控制台**不会**停止 Mihari;只有 `service stop`、卸载或操作系统才能停止它。同样的控制也在 TUI 的 **System** 页面中提供(变更操作需要提权 shell)。
 
-Unix 的 install/reinstall/update/start/stop/uninstall 走统一安装用例，未完成事务须显式恢复；Windows 保持原服务行为。Unix 自动化入口为 `mihari service apply --request /absolute/request.json`（严格版本化 JSON，请求文件 root0600）；operation=recover 用于恢复，不会隐式导入旧树。普通 `service uninstall` 只注销 OS 服务，保留数据与旧日志。`--purge --yes` 与 TUI System 页 Maintenance 中的 **Completely Uninstall Mihari** 使用同一用例：先卸载服务，再删除预检通过的受管文件。未知文件名会停止且不删除。需要已提权 shell，不自动弹出 UAC/sudo。
+Unix 的 install/reinstall/update/start/stop/uninstall 走统一安装用例，未完成事务须显式恢复；Windows 保持原服务行为。Unix 自动化入口为 `mihari service apply --request /absolute/request.json`（严格版本化 JSON，请求文件 root0600）；operation=recover 用于恢复，不会隐式导入旧树。普通 `service uninstall` 只注销 OS 服务，保留数据与旧日志。`--purge --yes` 先卸载服务，再删除白名单内的受管文件；未知文件名会停止且不删除。`--purge --yes --force` 跳过内容检查并删除整个目标文件夹。TUI System 页 **Completely Uninstall Mihari** 列出将清空的文件夹并确认两次，等价于 `--force`。需要已提权 shell，不自动弹出 UAC/sudo。
 
 Linux 服务启动失败后，systemd 可能显示 `activating (auto-restart)`。如果此时主进程已退出（`MainPID=0`），`mihari service status` 返回 `stopped`，仍允许进入服务停止或重装流程；这不表示 systemd 已取消自动重启。升级旧版本后若日志提示 `existing data requires recovery or migration`，应使用包含此修复的版本执行 `sudo mihari service reinstall`，由安装事务处理旧数据和服务定义，而不是直接修改 unit 的启动参数。重装失败时保留报错和 `journalctl -u mihari` 日志继续排查。
 

--- a/docs/superpowers/specs/2026-09-11-uninstall-extra-files-confirm-design.md
+++ b/docs/superpowers/specs/2026-09-11-uninstall-extra-files-confirm-design.md
@@ -1,0 +1,63 @@
+# 彻底卸载：列出文件夹并确认两次
+
+状态：用户已批准简化范围。本文覆盖同日「额外文件摘要」稿。不改 `/v1`。未授权真实卸载。
+
+关联：`2026-09-10-issue-194-uninstall-design.md`。固定根、删除顺序、默认 Cancel、英文文案、不跟随链接删除、不回滚，仍然有效。本文取消 TUI 对目录内容的白名单预检。
+
+## 问题
+
+白名单预检把未建模的生成文件（例如 `bin/core-channel`）和外来文件都变成 TUI Failed。继续扩清单或做「额外文件摘要」都太重。用户要自己看将被清空的文件夹，决定是否整目录删除。
+
+## 范围
+
+做：
+
+- TUI Preview **不扫目录内容**。确认框列出将删除的目标根路径。必须确认两次，两次都默认 Cancel。
+- 两次都确认后，退出 TUI，卸服务，再 `RemoveAll` 这些根（根内额外文件一并删除）。
+- CLI `service uninstall --purge --yes` 仍走白名单失败闭环；补上源码可证明的 `bin/core-channel`。
+- CLI 增加 `--force`：必须同时有 `--purge --yes`，才跳过内容检查并整根删除。TUI 两次确认等价于这个开关。
+- 目标根本身若是符号链接、junction/重解析点、或不是目录，仍立刻失败。不扫根内文件。
+
+不做：
+
+- 额外文件摘要、AcceptUnrecognized、把未知项收集进 Preview
+- 让 `--yes` 单独覆盖外来文件
+- 新 daemon 协议、事务/身份/恢复、改 `CHANGELOG.md`
+
+## TUI
+
+Maintenance 一行不变。Enter 后：
+
+1. Preview 解析固定根（缺的跳过）。根本身非法则该行 Failed，展示真实错误，不开确认框。
+2. 第一张确认框：Object 为将删除的文件夹路径；说明这些文件夹会被整个清空。默认 Cancel。
+3. 第二张确认框：同一组路径；说明不可撤销，服务和这些文件夹会被永久删除。默认 Cancel。Enter/Esc 仍取消。
+4. 两次都主动选 Uninstall 后，退出 alternate screen，现有 cleanup，再 `RunForce`。
+
+按钮仍是 Cancel / Uninstall。其它 System section 不动。
+
+## CLI
+
+- `service uninstall`：只卸服务，不变。
+- `--purge --yes`：检查文件；未识别则失败，不卸服务、不删。需要 `bin/core-channel`。
+- `--force` 没有 `--purge`：非法参数。
+- `--purge --force` 没有 `--yes`：仍是 `--purge requires --yes`。
+- `--purge --yes --force`：跳过内容检查，整根删除。进度和 JSON envelope 与现有 purge 成功路径相同。
+
+## App 契约
+
+`Preview(ctx) ([]UninstallTarget, error)` 只解析根并检查根形态，不调用内容白名单。
+
+`Run(ctx, progress)` 仍在停服务前后做 `CheckUninstallFiles`。
+
+`RunForce(ctx, progress)` 不做内容检查；删除前仍拒绝符号链接/非目录根。顺序不变：data/logs → program → 其余。
+
+## 测试
+
+TDD。临时目录与 fake。
+
+- 识别树含 `bin/core-channel` 时检查通过
+- `Preview` 在根内有未知文件时仍成功并返回这些根
+- `Run` 遇到未知文件不卸服务、不删
+- `RunForce` 删除含未知文件的根；根是 symlink/reparse/非目录时仍失败
+- TUI 第一次确认后出现第二次确认，两次默认 Cancel；取消第二次不 `Run`
+- CLI `--purge --yes` 仍调 `Run`；`--force` 约束；`--purge --yes --force` 调 `RunForce`

--- a/docs/unix-layout.md
+++ b/docs/unix-layout.md
@@ -30,7 +30,7 @@ Unix root 仍只接受 v1.19.30 的四个 Unix OS/arch 内置核心 hash，继�
 
 Unix 安装、迁移、服务生命周期与已安装服务自更新统一经过 app installer 的停机事务。锁顺序为 B install → 私有服务 P install → data → endpoint；永久锁文件不 unlink。daemon/Manager 仍是运行业务的唯一写入者，窄例外仅包括 root installer 在停机事务中迁移业务文件及维护安装资源，以及固定应用通道 metadata 的受锁保护维护。TUI 可经 logging 写自己的固定日志序列，不能直接写 settings、订阅或 token。
 
-迁移来源由可信已有服务定义或显式来源选项决定。没有已有服务时，固定 root-home 旧树存在可阻止错误的新建，但不会自动选择或导入该树。旧树与旧日志保留，不删除用户数据；迁移不会执行旧树 core。候选数据/核心/二进制先校验，持久化 action intent 后才改变安装资源。activation 持久化前可以恢复 source，之后只修复 target；恢复会核对 inode/hash/事务身份，重复恢复必须收敛。`mihari service apply --request <file>` 的 recover 请求是明确恢复入口；普通启动和通道写入不会悄悄恢复未完成事务。`service uninstall` 保留业务数据与恢复所需身份。`service uninstall --purge --yes` 在服务停止后删除预检通过的受管文件根；未知名称停止且不删除。
+迁移来源由可信已有服务定义或显式来源选项决定。没有已有服务时，固定 root-home 旧树存在可阻止错误的新建，但不会自动选择或导入该树。旧树与旧日志保留，不删除用户数据；迁移不会执行旧树 core。候选数据/核心/二进制先校验，持久化 action intent 后才改变安装资源。activation 持久化前可以恢复 source，之后只修复 target；恢复会核对 inode/hash/事务身份，重复恢复必须收敛。`mihari service apply --request <file>` 的 recover 请求是明确恢复入口；普通启动和通道写入不会悄悄恢复未完成事务。`service uninstall` 保留业务数据与恢复所需身份。`service uninstall --purge --yes` 在服务停止后删除白名单内的受管文件根；未知名称停止且不删除。`--purge --yes --force` 跳过内容检查并删除整个目标根。
 
 已安装服务启动必须匹配全局 B 的 activation/complete、选定 P/D/E/C/I 和当前 binary hash，并在取得 data/endpoint lease 后再次校验。普通未标记的 root P 前台只查看自己的 P；不存在安装权限绕过。TUI 更新先取消并等待工作与日志句柄退出，再执行安装事务和重新启动界面。
 

--- a/internal/app/uninstall.go
+++ b/internal/app/uninstall.go
@@ -65,7 +65,8 @@ func newUninstaller(layout platform.ResolvedLayout, opts UninstallerOptions, res
 	return &Uninstaller{layout: layout, opts: opts, controlRoot: controlRoot, controlRootErr: controlRootErr}
 }
 
-// Preview verifies and returns the fixed roots selected for uninstall.
+// Preview returns the fixed roots selected for uninstall. It does not inspect
+// folder contents; callers that must refuse unrecognized files use Run.
 func (u *Uninstaller) Preview(ctx context.Context) ([]UninstallTarget, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -74,17 +75,33 @@ func (u *Uninstaller) Preview(ctx context.Context) ([]UninstallTarget, error) {
 		return nil, fmt.Errorf("resolve Mihari installation control directory: %w", u.controlRootErr)
 	}
 	targets := uninstallTargets(u.layout, u.controlRoot)
-	if err := CheckUninstallFiles(ctx, targets); err != nil {
+	if err := inspectUninstallRoots(ctx, targets); err != nil {
 		return nil, err
 	}
 	return targets, nil
 }
 
-// Run stops and removes the service, then removes only roots verified by Preview.
+// Run stops and removes the service, then removes only roots whose contents
+// match the generated-file allowlist.
 func (u *Uninstaller) Run(ctx context.Context, progress func(string)) error {
+	return u.run(ctx, progress, false)
+}
+
+// RunForce stops and removes the service, then deletes the previewed folders
+// without inspecting unrecognized files inside them.
+func (u *Uninstaller) RunForce(ctx context.Context, progress func(string)) error {
+	return u.run(ctx, progress, true)
+}
+
+func (u *Uninstaller) run(ctx context.Context, progress func(string), force bool) error {
 	targets, err := u.Preview(ctx)
 	if err != nil {
 		return err
+	}
+	if !force {
+		if err := CheckUninstallFiles(ctx, targets); err != nil {
+			return err
+		}
 	}
 	if u.opts.Elevated == nil || !u.opts.Elevated() {
 		return errors.New("administrator privileges are required; re-run this command from an elevated shell")
@@ -97,8 +114,13 @@ func (u *Uninstaller) Run(ctx context.Context, progress func(string)) error {
 	if err := u.waitForDaemonStop(ctx, progress); err != nil {
 		return err
 	}
-	if err := CheckUninstallFiles(ctx, targets); err != nil {
+	if err := inspectUninstallRoots(ctx, targets); err != nil {
 		return err
+	}
+	if !force {
+		if err := CheckUninstallFiles(ctx, targets); err != nil {
+			return err
+		}
 	}
 
 	for phase := 0; phase < 3; phase++ {
@@ -257,8 +279,8 @@ func removeUninstallTarget(target UninstallTarget, remove func(string) error) er
 	if err != nil {
 		return err
 	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return newUninstallFileError(target, ".", "symbolic link")
+	if reason := uninstallRootLinkReason(info); reason != "" {
+		return newUninstallFileError(target, ".", reason)
 	}
 	if !info.IsDir() {
 		return newUninstallFileError(target, ".", "non-directory root")

--- a/internal/app/uninstall_files.go
+++ b/internal/app/uninstall_files.go
@@ -48,15 +48,44 @@ func CheckUninstallFiles(ctx context.Context, targets []UninstallTarget) error {
 		if err != nil {
 			return fmt.Errorf("inspect uninstall %s root: %w", target.Kind, err)
 		}
-		if info.Mode()&os.ModeSymlink != 0 {
-			return newUninstallFileError(target, ".", "symbolic link")
-		}
-		if !info.IsDir() {
-			return newUninstallFileError(target, ".", "non-directory root")
+		if err := refuseInvalidUninstallRoot(target, info); err != nil {
+			return err
 		}
 		if err := checkUninstallDirectory(ctx, target, target.Path, ""); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func inspectUninstallRoots(ctx context.Context, targets []UninstallTarget) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	for _, target := range targets {
+		if !validUninstallTargetKind(target.Kind) {
+			return fmt.Errorf("unknown uninstall target kind %q", target.Kind)
+		}
+		info, err := os.Lstat(target.Path)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("inspect uninstall %s root: %w", target.Kind, err)
+		}
+		if err := refuseInvalidUninstallRoot(target, info); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func refuseInvalidUninstallRoot(target UninstallTarget, info os.FileInfo) error {
+	if reason := uninstallRootLinkReason(info); reason != "" {
+		return newUninstallFileError(target, ".", reason)
+	}
+	if !info.IsDir() {
+		return newUninstallFileError(target, ".", "non-directory root")
 	}
 	return nil
 }
@@ -79,8 +108,8 @@ func checkUninstallDirectory(ctx context.Context, target UninstallTarget, path, 
 		if relative != "" {
 			rel = relative + "/" + entry.Name()
 		}
-		if info.Mode()&os.ModeSymlink != 0 {
-			return newUninstallFileError(target, rel, "symbolic link")
+		if reason := uninstallRootLinkReason(info); reason != "" {
+			return newUninstallFileError(target, rel, reason)
 		}
 		if !allowedUninstallEntry(target.Kind, rel, info.IsDir()) {
 			return newUninstallFileError(target, rel, "")
@@ -247,7 +276,7 @@ func allowedBinEntry(parts []string, isDir bool) bool {
 		return false
 	}
 	name := parts[0]
-	return name == "mihomo" || name == "mihomo.exe" || name == "mihomo.provenance.json" || canonicalPositiveSuffix(name, "mihomo.exe.old-")
+	return name == "mihomo" || name == "mihomo.exe" || name == "mihomo.provenance.json" || name == "core-channel" || canonicalPositiveSuffix(name, "mihomo.exe.old-")
 }
 
 func allowedRuntimeEntry(parts []string, isDir bool) bool {

--- a/internal/app/uninstall_files_test.go
+++ b/internal/app/uninstall_files_test.go
@@ -14,6 +14,7 @@ func TestCheckUninstallFiles_RecognizedDataEntriesPass(t *testing.T) {
 		"mihari.yaml",
 		".mihari.yaml.tmp-4294967295",
 		"bin/mihomo",
+		"bin/core-channel",
 		"runtime/config.yaml",
 		"runtime/.mihari-abcdef123456",
 		"runtime/core-home/Country.mmdb.old-0123456789abcdef0123456789abcdef",

--- a/internal/app/uninstall_link_unix.go
+++ b/internal/app/uninstall_link_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package app
+
+import "os"
+
+func uninstallRootLinkReason(info os.FileInfo) string {
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "symbolic link"
+	}
+	return ""
+}

--- a/internal/app/uninstall_link_windows.go
+++ b/internal/app/uninstall_link_windows.go
@@ -1,0 +1,17 @@
+package app
+
+import (
+	"os"
+	"syscall"
+)
+
+func uninstallRootLinkReason(info os.FileInfo) string {
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "symbolic link"
+	}
+	data, ok := info.Sys().(*syscall.Win32FileAttributeData)
+	if ok && data.FileAttributes&syscall.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+		return "reparse point"
+	}
+	return ""
+}

--- a/internal/app/uninstall_test.go
+++ b/internal/app/uninstall_test.go
@@ -213,6 +213,70 @@ func TestUninstaller_RunReturnsCancellationWhileWaitingForDaemon(t *testing.T) {
 	}
 }
 
+func TestUninstaller_PreviewAllowsUnrecognizedFiles(t *testing.T) {
+	layout, data, program := uninstallTestLayout(t)
+	writeUninstallFixture(t, data, "unknown.txt")
+	writeUninstallFixture(t, program, "mihari")
+	runner := newUninstallTestRunner(t, layout, UninstallerOptions{})
+
+	targets, err := runner.Preview(context.Background())
+	if err != nil {
+		t.Fatalf("Preview error = %v, want success when only folder contents are unrecognized", err)
+	}
+	if len(targets) < 2 || targets[0].Path != data || targets[1].Path != program {
+		t.Fatalf("Preview targets = %#v, want data and program roots", targets)
+	}
+}
+
+func TestUninstaller_RunForceRemovesUnrecognizedFiles(t *testing.T) {
+	layout, data, program := uninstallTestLayout(t)
+	writeUninstallFixture(t, data, "unknown.txt")
+	writeUninstallFixture(t, program, "mihari")
+	service := &uninstallFakeService{status: service.StatusStopped}
+	runner := newUninstallTestRunner(t, layout, UninstallerOptions{
+		Service:     service,
+		Elevated:    func() bool { return true },
+		ProbeDaemon: func(context.Context) (bool, error) { return false, nil },
+	})
+
+	if err := runner.RunForce(context.Background(), nil); err != nil {
+		t.Fatal(err)
+	}
+	if service.uninstallCalls != 1 {
+		t.Fatalf("uninstall calls = %d, want 1", service.uninstallCalls)
+	}
+	if fileExists(data) || fileExists(program) {
+		t.Fatalf("forced roots remain: data=%t program=%t", fileExists(data), fileExists(program))
+	}
+}
+
+func TestUninstaller_RunForceStillRefusesSymlinkRoot(t *testing.T) {
+	layout, data, program := uninstallTestLayout(t)
+	writeUninstallFixture(t, program, "mihari")
+	realData := filepath.Join(t.TempDir(), "real-data")
+	if err := os.MkdirAll(realData, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realData, data); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	service := &uninstallFakeService{status: service.StatusStopped}
+	runner := newUninstallTestRunner(t, layout, UninstallerOptions{
+		Service:     service,
+		Elevated:    func() bool { return true },
+		ProbeDaemon: func(context.Context) (bool, error) { return false, nil },
+	})
+
+	err := runner.RunForce(context.Background(), nil)
+	var checkErr *UninstallFileError
+	if !errors.As(err, &checkErr) || service.uninstallCalls != 0 || !fileExists(realData) {
+		t.Fatalf("RunForce error = %v, uninstall calls = %d; want symlink root refusal without deletion", err, service.uninstallCalls)
+	}
+}
+
 func TestUninstaller_PreviewPrivateLayoutIncludesCapturedWindowsControlTarget(t *testing.T) {
 	layout, data, program := uninstallTestLayout(t)
 	writeUninstallFixture(t, data, "mihari.yaml")

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -23,6 +23,7 @@ type StatusClient interface {
 type Uninstaller interface {
 	Preview(context.Context) ([]app.UninstallTarget, error)
 	Run(context.Context, func(string)) error
+	RunForce(context.Context, func(string)) error
 }
 
 type RuntimeClient interface {

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -49,8 +49,11 @@ func serviceController(dependencies Dependencies) (ServiceController, error) {
 }
 
 func newServiceUninstallCommand(dependencies Dependencies, options *runOptions) *cobra.Command {
-	var purge, yes bool
+	var purge, yes, force bool
 	command := &cobra.Command{Use: "uninstall", Short: "Remove the Mihari OS service", Args: cobra.NoArgs, RunE: func(command *cobra.Command, _ []string) error {
+		if force && !purge {
+			return invalidArgument("--force requires --purge")
+		}
 		if !purge {
 			return runServiceAction(command, "uninstall", dependencies, options, true, func(c ServiceController) error { return c.Uninstall() })
 		}
@@ -74,7 +77,11 @@ func newServiceUninstallCommand(dependencies Dependencies, options *runOptions) 
 				_, _ = fmt.Fprintln(command.ErrOrStderr(), message)
 			}
 		}
-		if err := dependencies.Uninstaller.Run(ctx, progress); err != nil {
+		run := dependencies.Uninstaller.Run
+		if force {
+			run = dependencies.Uninstaller.RunForce
+		}
+		if err := run(ctx, progress); err != nil {
 			reportLocalTaskFailure(ctx, dependencies, "service.uninstall.purge.failed", err)
 			return protocol.APIError{Code: protocol.CodeInvalidState, Message: err.Error()}
 		}
@@ -86,6 +93,7 @@ func newServiceUninstallCommand(dependencies Dependencies, options *runOptions) 
 	}}
 	command.Flags().BoolVar(&purge, "purge", false, "remove the Mihari service and recognized Mihari files")
 	command.Flags().BoolVar(&yes, "yes", false, "confirm complete uninstall")
+	command.Flags().BoolVar(&force, "force", false, "delete entire target folders without checking recognized files (requires --purge --yes)")
 	return command
 }
 

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -22,14 +22,21 @@ type fakeService struct {
 }
 
 type fakePurgeUninstaller struct {
-	calls int
-	err   error
+	calls      int
+	forceCalls int
+	err        error
 }
 
 func (*fakePurgeUninstaller) Preview(context.Context) ([]app.UninstallTarget, error) { return nil, nil }
 
 func (f *fakePurgeUninstaller) Run(_ context.Context, progress func(string)) error {
 	f.calls++
+	progress("Uninstalling Mihari service")
+	return f.err
+}
+
+func (f *fakePurgeUninstaller) RunForce(_ context.Context, progress func(string)) error {
+	f.forceCalls++
 	progress("Uninstalling Mihari service")
 	return f.err
 }
@@ -46,6 +53,12 @@ func (*orderedPurgeUninstaller) Preview(context.Context) ([]app.UninstallTarget,
 func (f *orderedPurgeUninstaller) Run(context.Context, func(string)) error {
 	f.calls++
 	*f.order = append(*f.order, "run")
+	return nil
+}
+
+func (f *orderedPurgeUninstaller) RunForce(context.Context, func(string)) error {
+	f.calls++
+	*f.order = append(*f.order, "run-force")
 	return nil
 }
 
@@ -168,8 +181,8 @@ func TestServiceUninstall_PurgeWithYesRunsOnceAndKeepsJSONSingleEnvelope(t *test
 				args = append(args, "--json")
 			}
 			exit := Execute(context.Background(), args, stdout, stderr, Dependencies{Uninstaller: uninstaller})
-			if exit != ExitOK || uninstaller.calls != 1 {
-				t.Fatalf("exit=%d calls=%d stdout=%q stderr=%q", exit, uninstaller.calls, stdout.String(), stderr.String())
+			if exit != ExitOK || uninstaller.calls != 1 || uninstaller.forceCalls != 0 {
+				t.Fatalf("exit=%d calls=%d forceCalls=%d stdout=%q stderr=%q", exit, uninstaller.calls, uninstaller.forceCalls, stdout.String(), stderr.String())
 			}
 			if jsonOutput {
 				if strings.Count(stdout.String(), "\n") != 1 || !strings.Contains(stdout.String(), `"ok":true`) || stderr.Len() != 0 {
@@ -212,6 +225,37 @@ func TestServiceUninstall_PurgeClosesLocalResourcesBeforeRun(t *testing.T) {
 	})
 	if exit != ExitOK || uninstaller.calls != 1 || len(order) != 2 || order[0] != "close" || order[1] != "run" {
 		t.Fatalf("exit=%d calls=%d order=%v", exit, uninstaller.calls, order)
+	}
+}
+
+func TestServiceUninstall_ForceRequiresPurge(t *testing.T) {
+	stderr := &bytes.Buffer{}
+	exit := Execute(context.Background(), []string{"service", "uninstall", "--force"}, io.Discard, stderr, Dependencies{})
+	if exit != ExitUsage || !strings.Contains(stderr.String(), "--force requires --purge") {
+		t.Fatalf("exit=%d stderr=%q", exit, stderr.String())
+	}
+}
+
+func TestServiceUninstall_PurgeForceRequiresYes(t *testing.T) {
+	stderr := &bytes.Buffer{}
+	exit := Execute(context.Background(), []string{"service", "uninstall", "--purge", "--force"}, io.Discard, stderr, Dependencies{})
+	if exit != ExitUsage || !strings.Contains(stderr.String(), "--purge requires --yes") {
+		t.Fatalf("exit=%d stderr=%q", exit, stderr.String())
+	}
+}
+
+func TestServiceUninstall_PurgeYesForceRunsForceOnce(t *testing.T) {
+	prev := elevate.Check
+	t.Cleanup(func() { elevate.Check = prev })
+	elevate.Check = func() bool { return true }
+	uninstaller := &fakePurgeUninstaller{}
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	exit := Execute(context.Background(), []string{"service", "uninstall", "--purge", "--yes", "--force"}, stdout, stderr, Dependencies{Uninstaller: uninstaller})
+	if exit != ExitOK || uninstaller.calls != 0 || uninstaller.forceCalls != 1 {
+		t.Fatalf("exit=%d calls=%d forceCalls=%d stdout=%q stderr=%q", exit, uninstaller.calls, uninstaller.forceCalls, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Uninstalling Mihari service") || !strings.Contains(stdout.String(), "Mihari has been completely uninstalled") {
+		t.Fatalf("stdout=%q stderr=%q", stdout.String(), stderr.String())
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -494,6 +494,13 @@ func (model Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 				model.preparedUninstall = true
 				return model, tea.Quit
 			}
+			if next, ok := typed.Result.(ui.ActionIntentMsg); ok && next.Action == ui.ActionCompleteUninstall {
+				delete(model.pendingActions, typed.Intent.Key)
+				if len(model.pendingActions) == 0 {
+					model.globalState = ""
+				}
+				return model.handleActionIntent(next)
+			}
 		}
 		model.recordActionOutcome(typed.Intent, typed.Result)
 		var pageCmd tea.Cmd

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -636,7 +636,7 @@ func TestCompleteUninstallConfirmation_FirstConfirmOpensSecondPrompt(t *testing.
 
 func TestCompleteUninstallConfirmation_TwoConfirmsQuitAndPrepareUninstall(t *testing.T) {
 	model := NewModel()
-	updated, command := model.Update(ui.ActionIntentMsg{
+	updated, _ := model.Update(ui.ActionIntentMsg{
 		Action: ui.ActionCompleteUninstall, Key: "system:complete-uninstall",
 		Title: ui.CompleteUninstallTitle, Object: "/tmp/mihari-data", Impact: ui.CompleteUninstallImpact,
 		Execute: func() tea.Msg {
@@ -649,7 +649,7 @@ func TestCompleteUninstallConfirmation_TwoConfirmsQuitAndPrepareUninstall(t *tes
 	})
 	model = updated.(Model)
 	model.modal.selected = 0
-	updated, command = model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	updated, command := model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	model = updated.(Model)
 	updated, command = model.Update(command())
 	model = updated.(Model)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -634,6 +634,49 @@ func TestCompleteUninstallConfirmation_FirstConfirmOpensSecondPrompt(t *testing.
 	}
 }
 
+func TestCompleteUninstallConfirmation_TwoConfirmsQuitAndPrepareUninstall(t *testing.T) {
+	model := NewModel()
+	updated, command := model.Update(ui.ActionIntentMsg{
+		Action: ui.ActionCompleteUninstall, Key: "system:complete-uninstall",
+		Title: ui.CompleteUninstallTitle, Object: "/tmp/mihari-data", Impact: ui.CompleteUninstallImpact,
+		Execute: func() tea.Msg {
+			return ui.ActionIntentMsg{
+				Action: ui.ActionCompleteUninstall, Key: ui.CompleteUninstallConfirmKey,
+				Title: ui.CompleteUninstallConfirmTitle, Object: "/tmp/mihari-data", Impact: ui.CompleteUninstallConfirmImpact,
+				Execute: func() tea.Msg { return ui.CompleteUninstallConfirmedMsg{} },
+			}
+		},
+	})
+	model = updated.(Model)
+	model.modal.selected = 0
+	updated, command = model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	model = updated.(Model)
+	updated, command = model.Update(command())
+	model = updated.(Model)
+	model, _ = applyRootCmd(model, command)
+	if model.preparedUninstall || model.modal == nil || model.modal.selected != 1 {
+		t.Fatalf("after first confirm: prepared=%v modal=%v selected=%d", model.preparedUninstall, model.modal != nil, modalSelected(model))
+	}
+	model.modal.selected = 0
+	updated, command = model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	model = updated.(Model)
+	if command == nil {
+		t.Fatal("second confirm did not start execute")
+	}
+	updated, command = model.Update(command())
+	model = updated.(Model)
+	if command == nil {
+		t.Fatal("second confirm did not execute the complete uninstall action")
+	}
+	model, command = applyRootCmd(model, command)
+	if command == nil || !model.preparedUninstall || model.modal != nil {
+		t.Fatalf("prepared=%v modal=%v command=%v", model.preparedUninstall, model.modal != nil, command != nil)
+	}
+	if command() != tea.Quit() {
+		t.Fatal("two confirms did not quit the TUI")
+	}
+}
+
 func modalSelected(model Model) int {
 	if model.modal == nil {
 		return -1

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -595,6 +595,59 @@ func TestCompleteUninstallConfirmation_QuitsOnceAfterDeliberateConfirm(t *testin
 	}
 }
 
+func TestCompleteUninstallConfirmation_FirstConfirmOpensSecondPrompt(t *testing.T) {
+	model := NewModel()
+	updated, command := model.Update(ui.ActionIntentMsg{
+		Action: ui.ActionCompleteUninstall, Key: "system:complete-uninstall",
+		Title: ui.CompleteUninstallTitle, Object: "/tmp/mihari-data", Impact: ui.CompleteUninstallImpact,
+		Execute: func() tea.Msg {
+			return ui.ActionIntentMsg{
+				Action: ui.ActionCompleteUninstall, Key: ui.CompleteUninstallConfirmKey,
+				Title: ui.CompleteUninstallConfirmTitle, Object: "/tmp/mihari-data", Impact: ui.CompleteUninstallConfirmImpact,
+				Execute: func() tea.Msg { return ui.CompleteUninstallConfirmedMsg{} },
+			}
+		},
+	})
+	model = updated.(Model)
+	if command != nil || model.modal == nil || model.modal.selected != 1 {
+		t.Fatalf("first modal=%v selected=%d command=%v", model.modal != nil, modalSelected(model), command != nil)
+	}
+	model.modal.selected = 0
+	updated, command = model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	model = updated.(Model)
+	if command == nil {
+		t.Fatal("first confirm did not start execute")
+	}
+	updated, command = model.Update(command())
+	model = updated.(Model)
+	if command == nil {
+		t.Fatal("first confirm did not execute the complete uninstall action")
+	}
+	model, command = applyRootCmd(model, command)
+	if model.preparedUninstall || model.modal == nil || model.modal.selected != 1 || model.modal.title != ui.CompleteUninstallConfirmTitle {
+		t.Fatalf("prepared=%v modal title=%q selected=%d command=%v", model.preparedUninstall, modalTitle(model), modalSelected(model), command != nil)
+	}
+	updated, command = model.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	model = updated.(Model)
+	if command != nil || model.modal != nil || model.preparedUninstall {
+		t.Fatalf("cancel second: prepared=%v modal=%v command=%v", model.preparedUninstall, model.modal != nil, command != nil)
+	}
+}
+
+func modalSelected(model Model) int {
+	if model.modal == nil {
+		return -1
+	}
+	return model.modal.selected
+}
+
+func modalTitle(model Model) string {
+	if model.modal == nil {
+		return ""
+	}
+	return model.modal.title
+}
+
 func TestOperationLedgerKeepsNewestFiftyEntries(t *testing.T) {
 	model := NewModel()
 	for index := 0; index < 60; index++ {

--- a/internal/tui/pages/system/model.go
+++ b/internal/tui/pages/system/model.go
@@ -1041,10 +1041,17 @@ func (m *Model) Update(message tea.Msg) (ui.Page, tea.Cmd) {
 			return m, m.rowSpinCmdIfNeeded()
 		}
 		return m, func() tea.Msg {
+			paths := uninstallTargetPaths(typed.targets)
 			return ui.ActionIntentMsg{
 				Action: ui.ActionCompleteUninstall, Page: ui.PageSystem, Key: "system:complete-uninstall",
-				Title: ui.CompleteUninstallTitle, Object: uninstallTargetPaths(typed.targets), Impact: ui.CompleteUninstallImpact, Rollback: ui.CompleteUninstallRollback,
-				Execute: func() tea.Msg { return ui.CompleteUninstallConfirmedMsg{} },
+				Title: ui.CompleteUninstallTitle, Object: paths, Impact: ui.CompleteUninstallImpact, Rollback: ui.CompleteUninstallRollback,
+				Execute: func() tea.Msg {
+					return ui.ActionIntentMsg{
+						Action: ui.ActionCompleteUninstall, Page: ui.PageSystem, Key: ui.CompleteUninstallConfirmKey,
+						Title: ui.CompleteUninstallConfirmTitle, Object: paths, Impact: ui.CompleteUninstallConfirmImpact, Rollback: ui.CompleteUninstallRollback,
+						Execute: func() tea.Msg { return ui.CompleteUninstallConfirmedMsg{} },
+					}
+				},
 			}
 		}
 	case systemProxyActionResultMsg:

--- a/internal/tui/pages/system/model_test.go
+++ b/internal/tui/pages/system/model_test.go
@@ -1062,6 +1062,10 @@ func (f *fakeUninstaller) Preview(context.Context) ([]app.UninstallTarget, error
 	return f.targets, f.err
 }
 
+func (*fakeUninstaller) Run(context.Context, func(string)) error { return nil }
+
+func (*fakeUninstaller) RunForce(context.Context, func(string)) error { return nil }
+
 func (f *fakeService) Install() error {
 	f.installs++
 	return f.controlErr
@@ -1376,8 +1380,15 @@ func TestSystemCompleteUninstall_PreviewsTargetsBeforeConfirmation(t *testing.T)
 		t.Fatalf("command=%v preview calls=%d", command != nil, preview.calls)
 	}
 	intent, ok := command().(ui.ActionIntentMsg)
-	if !ok || intent.Action != ui.ActionCompleteUninstall || intent.Object != "/tmp/mihari-data" {
+	if !ok || intent.Action != ui.ActionCompleteUninstall || intent.Object != "/tmp/mihari-data" || intent.Impact != ui.CompleteUninstallImpact || intent.Key != "system:complete-uninstall" {
 		t.Fatalf("intent=%#v", intent)
+	}
+	second, ok := intent.Execute().(ui.ActionIntentMsg)
+	if !ok || second.Action != ui.ActionCompleteUninstall || second.Object != intent.Object || second.Impact != ui.CompleteUninstallConfirmImpact || second.Key != ui.CompleteUninstallConfirmKey {
+		t.Fatalf("second intent=%#v", second)
+	}
+	if _, ok := second.Execute().(ui.CompleteUninstallConfirmedMsg); !ok {
+		t.Fatalf("second execute=%T", second.Execute())
 	}
 }
 

--- a/internal/tui/pages/system/model_test.go
+++ b/internal/tui/pages/system/model_test.go
@@ -1392,8 +1392,8 @@ func TestSystemCompleteUninstall_PreviewsTargetsBeforeConfirmation(t *testing.T)
 	}
 }
 
-func TestSystemCompleteUninstall_PreviewFailureShowsUnrecognizedEntry(t *testing.T) {
-	preview := &fakeUninstaller{err: &app.UninstallFileError{Kind: "data", RelativePath: "cache.db"}}
+func TestSystemCompleteUninstall_PreviewFailureShowsRootError(t *testing.T) {
+	preview := &fakeUninstaller{err: &app.UninstallFileError{Kind: "data", RelativePath: ".", Reason: "symbolic link"}}
 	model := New(nil, func() string { return "system-op" })
 	model.SetUninstaller(preview)
 	model.focusID = rowCompleteUninstall
@@ -1404,7 +1404,7 @@ func TestSystemCompleteUninstall_PreviewFailureShowsUnrecognizedEntry(t *testing
 	}
 	updated, _ = model.Update(command())
 	model = updated.(*Model)
-	want := "unrecognized entry in data: cache.db"
+	want := "unrecognized symbolic link in data: ."
 	if model.outcomeRow != rowCompleteUninstall || model.outcomeOK || model.outcomeDetail != want {
 		t.Fatalf("outcome=%q ok=%v detail=%q want %q", model.outcomeRow, model.outcomeOK, model.outcomeDetail, want)
 	}

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -44,6 +44,7 @@ type Options struct {
 type Uninstaller interface {
 	Preview(context.Context) ([]app.UninstallTarget, error)
 	Run(context.Context, func(string)) error
+	RunForce(context.Context, func(string)) error
 }
 
 // LocalLoggingHealth reports whether the local TUI file logger is available.

--- a/internal/tui/ui/strings.go
+++ b/internal/tui/ui/strings.go
@@ -404,10 +404,13 @@ const (
 const (
 	CompleteUninstallLabel         = "Completely Uninstall Mihari"
 	CompleteUninstallTitle         = "Completely Uninstall Mihari"
-	CompleteUninstallImpact        = "Removes the Mihari service and recognized Mihari files after confirmation."
+	CompleteUninstallImpact        = "Deletes the listed folders entirely, including any extra files inside."
+	CompleteUninstallConfirmTitle  = "Confirm complete uninstall"
+	CompleteUninstallConfirmImpact = "This cannot be undone. The Mihari service and the listed folders will be permanently removed."
 	CompleteUninstallRollback      = "Reinstall Mihari from a separate copy if you need it again."
 	CompleteUninstallUnavailable   = "Complete uninstall is unavailable"
 	CompleteUninstallPreviewFailed = "Complete uninstall preview failed"
+	CompleteUninstallConfirmKey    = "system:complete-uninstall-confirm"
 )
 
 const (

--- a/internal/tui/uninstall.go
+++ b/internal/tui/uninstall.go
@@ -23,7 +23,7 @@ func finishCompleteUninstallRun(ctx context.Context, final tea.Model, runErr err
 	if uninstaller == nil {
 		return errors.New("complete uninstall is unavailable")
 	}
-	return uninstaller.Run(ctx, func(message string) {
+	return uninstaller.RunForce(ctx, func(message string) {
 		if out != nil {
 			_, _ = fmt.Fprintln(out, message)
 		}

--- a/internal/tui/uninstall_test.go
+++ b/internal/tui/uninstall_test.go
@@ -25,6 +25,13 @@ func (f *uninstallRunFake) Run(_ context.Context, progress func(string)) error {
 	return nil
 }
 
+func (f *uninstallRunFake) RunForce(_ context.Context, progress func(string)) error {
+	f.runCalls++
+	*f.order = append(*f.order, "run")
+	progress("Uninstalling Mihari service")
+	return nil
+}
+
 func TestFinishCompleteUninstallRun_CleansUpBeforeRunningAndPrintsProgress(t *testing.T) {
 	var order []string
 	fake := &uninstallRunFake{order: &order}

--- a/skills/mihari-cli/references/commands.md
+++ b/skills/mihari-cli/references/commands.md
@@ -28,7 +28,7 @@
 
 ### D 级 · 禁止执行（由用户自行操作）
 
-`mihari daemon`（阻塞前台进程）、`mihari service install/uninstall/reinstall/start/stop/restart`（系统服务生命周期，需提权）、`mihari service uninstall --purge --yes`（全量卸载服务与受管文件，需提权）、`mihari self update`（替换 mihari 自身二进制）、`mihari traffic --follow` / `mihari logs --follow`（无限流阻塞 shell）
+`mihari daemon`（阻塞前台进程）、`mihari service install/uninstall/reinstall/start/stop/restart`（系统服务生命周期，需提权）、`mihari service uninstall --purge --yes`（全量卸载服务与受管文件，需提权）、`mihari service uninstall --purge --yes --force`（跳过文件检查并删除整个目标文件夹，需提权）、`mihari self update`（替换 mihari 自身二进制）、`mihari traffic --follow` / `mihari logs --follow`（无限流阻塞 shell）
 
 ## 查询类
 


### PR DESCRIPTION
## 变更内容

彻底卸载不再因为目录里有未识别文件就在 TUI 里 Failed。System 页会列出将清空的文件夹，用户确认两次后整根删除（含额外文件）。

CLI `service uninstall --purge --yes` 仍走白名单失败闭环，并补上 `bin/core-channel`。整根删除必须再加 `--force`。目标根本身若是符号链接、junction/重解析点或非目录，仍然拒绝。

## 类型

- [x] feat: 新功能
- [ ] fix: Bug 修复
- [ ] refactor: 重构
- [ ] docs: 文档
- [ ] test: 测试
- [ ] chore: 构建/工具

## 检查清单

- [x] 受影响包 `go test -race` 通过（`internal/app` `internal/cli` `internal/tui` `internal/tui/pages/system` `internal/integration`）
- [x] `go vet ./...` 通过
- [x] `gofmt -l cmd internal` 无输出
- [x] 提交包含 `Signed-off-by`（DCO 签名）
- [x] 未修改 `CHANGELOG.md`
- [x] CLI 新增 `--force`；`--purge --yes` 契约不变。TUI 两次确认后走 `RunForce`。

## 其他

- Worktree: `.worktrees/feat-uninstall-extra-files-confirm`
- Spec: `docs/superpowers/specs/2026-09-11-uninstall-extra-files-confirm-design.md`
- 未跑全仓 `go test -race ./...`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/mihari-proxy/mihari/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

